### PR TITLE
Remove references to hyperledger-labs

### DIFF
--- a/.github/workflows/build-llvm.yml
+++ b/.github/workflows/build-llvm.yml
@@ -49,7 +49,7 @@ jobs:
   linux-arm64:
     name: Linux arm64
     runs-on: linux-arm64
-    if: ${{ github.repository_owner == 'hyperledger-labs' }}
+    if: ${{ github.repository_owner == 'hyperledger' }}
     needs: create
     steps:
     - run: git clone --depth 1 --branch solana-rustc/13.0-2021-08-08 https://github.com/solana-labs/llvm-project.git
@@ -77,7 +77,7 @@ jobs:
     name: Mac Arm
     needs: create
     runs-on: macos-arm
-    if: ${{ github.repository_owner == 'hyperledger-labs' }}
+    if: ${{ github.repository_owner == 'hyperledger' }}
     steps:
     - run: git clone --depth 1 --branch solana-rustc/13.0-2021-08-08 https://github.com/solana-labs/llvm-project.git
 #    - name: Install Ninja

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -2,7 +2,7 @@ name: Build and push ci image
 on: [workflow_dispatch]
 jobs:
   build-push-ci-image:
-    runs-on: macos-arm
+    runs-on: linux-arm64
     steps:
     - name: Checkout sources
       uses: actions/checkout@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
   linux-arm64:
     name: Linux arm64
     runs-on: linux-arm64
-    if: ${{ github.repository_owner == 'hyperledger-labs' }}
+    if: ${{ github.repository_owner == 'hyperledger' }}
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2
@@ -141,7 +141,7 @@ jobs:
   mac-arm:
     name: Mac Arm
     runs-on: macos-arm
-    if: ${{ github.repository_owner == 'hyperledger-labs' }}
+    if: ${{ github.repository_owner == 'hyperledger' }}
     steps:
     - name: Checkout sources
       uses: actions/checkout@v3
@@ -230,8 +230,8 @@ jobs:
     needs: [mac-arm, mac-intel]
     steps:
     - run: |
-        curl -L --output solang-mac-intel https://github.com/hyperledger-labs/solang/releases/download/${GITHUB_REF/refs\/tags\//}/solang-mac-intel
-        curl -L --output solang-mac-arm https://github.com/hyperledger-labs/solang/releases/download/${GITHUB_REF/refs\/tags\//}/solang-mac-arm
+        curl -L --output solang-mac-intel https://github.com/hyperledger/solang/releases/download/${GITHUB_REF/refs\/tags\//}/solang-mac-intel
+        curl -L --output solang-mac-arm https://github.com/hyperledger/solang/releases/download/${GITHUB_REF/refs\/tags\//}/solang-mac-arm
         lipo -create -output solang-mac solang-mac-intel solang-mac-arm
     - name: Upload binary
       uses: svenstaro/upload-release-action@v2
@@ -244,7 +244,7 @@ jobs:
   container:
     name: Container Image
     runs-on: ubuntu-20.04
-    if: ${{ github.repository_owner != 'hyperledger-labs' }}
+    if: ${{ github.repository_owner != 'hyperledger' }}
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2
@@ -258,7 +258,7 @@ jobs:
   container-multiarch:
     name: Multiarch Container Image
     runs-on: linux-arm64
-    if: ${{ github.repository_owner == 'hyperledger-labs' }}
+    if: ${{ github.repository_owner == 'hyperledger' }}
     steps:
     - name: Checkout sources
       uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
   lints:
     name: Lints
     runs-on: ubuntu-20.04
-    container: ghcr.io/hyperledger-labs/solang:ci
+    container: ghcr.io/hyperledger/solang:ci
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -51,7 +51,7 @@ jobs:
   linux-x86-64:
     name: Linux x86-64
     runs-on: ubuntu-20.04
-    container: ghcr.io/hyperledger-labs/solang:ci
+    container: ghcr.io/hyperledger/solang:ci
     steps:
     - name: Checkout sources
       # Make sure "git describe --tags" works for solang --version
@@ -73,8 +73,8 @@ jobs:
   linux-arm:
     name: Linux Arm
     runs-on: linux-arm64
-    if: ${{ github.repository_owner == 'hyperledger-labs' }}
-    container: ghcr.io/hyperledger-labs/solang:ci
+    if: ${{ github.repository_owner == 'hyperledger' }}
+    container: ghcr.io/hyperledger/solang:ci
     steps:
     - name: Checkout sources
       # Make sure "git describe --tags" works for solang --version
@@ -104,7 +104,7 @@ jobs:
         fetch-depth: 0
         submodules: recursive
     - name: Download LLVM
-      run: curl -sSL -o c:\llvm.zip https://github.com/hyperledger-labs/solang/releases/download/v0.1.11/llvm13.0-win.zip
+      run: curl -sSL -o c:\llvm.zip https://github.com/hyperledger/solang/releases/download/v0.1.12/llvm13.0-win.zip
     - name: Extract LLVM
       run: unzip c:\llvm.zip -d c:/
     - name: Add LLVM to Path
@@ -130,7 +130,7 @@ jobs:
   mac-arm:
     name: Mac Arm
     runs-on: macos-arm
-    if: ${{ github.repository_owner == 'hyperledger-labs' }}
+    if: ${{ github.repository_owner == 'hyperledger' }}
     steps:
     - name: Checkout sources
       uses: actions/checkout@v3
@@ -139,7 +139,7 @@ jobs:
         fetch-depth: 0
         submodules: recursive
     - name: Get LLVM
-      run: curl -L --output llvm13.0-mac-arm.tar.xz https://github.com/hyperledger-labs/solang/releases/download/v0.1.12/llvm13.0-mac-arm.tar.xz
+      run: curl -L --output llvm13.0-mac-arm.tar.xz https://github.com/hyperledger/solang/releases/download/v0.1.12/llvm13.0-mac-arm.tar.xz
     - name: Extract LLVM
       run: tar Jxf llvm13.0-mac-arm.tar.xz
     - name: Add LLVM to Path
@@ -164,7 +164,7 @@ jobs:
         fetch-depth: 0
         submodules: recursive
     - name: Get LLVM
-      run: wget -q -O llvm13.0-mac-intel.tar.xz https://github.com/hyperledger-labs/solang/releases/download/v0.1.11/llvm13.0-mac-intel.tar.xz
+      run: wget -q -O llvm13.0-mac-intel.tar.xz https://github.com/hyperledger/solang/releases/download/v0.1.12/llvm13.0-mac-intel.tar.xz
     - name: Extract LLVM
       run: tar Jxf llvm13.0-mac-intel.tar.xz
     - name: Add LLVM to Path
@@ -200,7 +200,7 @@ jobs:
   image-multiarch:
     name: Multiarch Container Image
     runs-on: linux-arm64
-    if: ${{ github.repository_owner == 'hyperledger-labs' }}
+    if: ${{ github.repository_owner == 'hyperledger' }}
     steps:
     - name: Checkout sources
       uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-All notable changes to [Solang](https://github.com/hyperledger-labs/solang/)
+All notable changes to [Solang](https://github.com/hyperledger/solang/)
 will be documented here.
 
 ## v0.1.12 Cairo
@@ -40,7 +40,7 @@ will be documented here.
 - On Solana, the accounts that were passed into the transactions are listed in
   the `tx.accounts` builtin. There is also a builtin struct `AccountInfo`
 - A new common subexpression elimination pass was added, thanks to
-  [LucasSte](https://github.com/hyperledger-labs/solang/pull/550)
+  [LucasSte](https://github.com/hyperledger/solang/pull/550)
 - A graphviz dot file can be generated from the ast, using `--emit ast-dot`
 - Many improvements to the solidity parser, and the parser has been spun out
   in it's own create `solang-parser`.
@@ -71,7 +71,7 @@ will be documented here.
 - On the solang command line, the target must be specified.
 - The Solana instruction now includes a 64 bit value field
 - Many fixes to the parser and resolver, so solidity compatibility is much
-  improved, thanks to [sushi-shi](https://github.com/hyperledger-labs/solang/pulls?q=is%3Apr+author%3Asushi-shi+is%3Aclosed).
+  improved, thanks to [sushi-shi](https://github.com/hyperledger/solang/pulls?q=is%3Apr+author%3Asushi-shi+is%3Aclosed).
 
 ### Removed
 - The Sawtooth Sabre target has been removed.
@@ -93,14 +93,14 @@ will be documented here.
 - The Solana target now compiles all contracts to a single `bundle.so` BPF
   program.
 - Any unused variables, events, or contract variables are now detected and
-  warnings are given, thanks to [LucasSte](https://github.com/hyperledger-labs/solang/pull/429)
+  warnings are given, thanks to [LucasSte](https://github.com/hyperledger/solang/pull/429)
 - The `immutable` attribute on contract storage variables is now supported.
 - The `override` attribute on public contract storage variables is now supported.
 - The `unchecked {}` code block is now parsed and supported. Math overflow still
   is unsupported for types larger than 64 bit.
 - `assembly {}` blocks are now parsed and give a friendly error message.
 - Any variable use before it is given a value is now detected and results in
-  a undefined variable diagnostic, thanks to [LucasSte](https://github.com/hyperledger-labs/solang/pull/468)
+  a undefined variable diagnostic, thanks to [LucasSte](https://github.com/hyperledger/solang/pull/468)
 
 ### Changed
 - Solang now uses LLVM 12.0, based on the [Solana LLVM tree](https://github.com/solana-labs/llvm-project/)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solang"
 version = "0.1.12"
 authors = ["Sean Young <sean@mess.org>"]
-homepage = "https://github.com/hyperledger-labs/solang"
+homepage = "https://github.com/hyperledger/solang"
 documentation = "https://solang.readthedocs.io/"
 license = "Apache-2.0"
 build = "build.rs"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # Ubuntu 18.04 produces a builder image 1.53 GiB and solang image of 84 MiB
 # Debian Buster produces a builder image 2.04 GiB
 
-FROM ghcr.io/hyperledger-labs/solang:ci as builder
+FROM ghcr.io/hyperledger/solang:ci as builder
 
 COPY . src
 WORKDIR /src/stdlib/

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # solang - Solidity Compiler for Solana and Substrate
 
 [![Discord](https://img.shields.io/discord/905194001349627914?logo=Hyperledger&style=plastic)](https://discord.gg/jhn4rkqNsT)
-[![CI](https://github.com/hyperledger-labs/solang/workflows/test/badge.svg)](https://github.com/hyperledger-labs/solang/actions)
+[![CI](https://github.com/hyperledger/solang/workflows/test/badge.svg)](https://github.com/hyperledger/solang/actions)
 [![Documentation Status](https://readthedocs.org/projects/solang/badge/?version=latest)](https://solang.readthedocs.io/en/latest/?badge=latest)
-[![license](https://img.shields.io/github/license/hyperledger-labs/solang.svg)](LICENSE)
-[![LoC](https://tokei.rs/b1/github/hyperledger-labs/solang?category=lines)](https://github.com/hyperledger-labs/solang)
+[![license](https://img.shields.io/github/license/hyperledger/solang.svg)](LICENSE)
+[![LoC](https://tokei.rs/b1/github/hyperledger/solang?category=lines)](https://github.com/hyperledger/solang)
 
 Welcome to Solang, a new Solidity compiler written in rust which uses
 llvm as the compiler backend. Solang can compile Solidity for Solana and
@@ -20,7 +20,7 @@ Solang is under active development right now, and has
 Solang is available as a Brew cask for MacOS, with the following command:
 
 ```
-brew install hyperledger-labs/solang/solang
+brew install hyperledger/solang/solang
 ```
 
 For other operating systems, please check the [installation guide](https://solang.readthedocs.io/en/latest/installing.html).
@@ -58,7 +58,7 @@ solang compile --target solana flipper.sol
 Alternatively if you want to use the solang container, run:
 
 ```
-docker run --rm -it -v $(pwd):/sources ghcr.io/hyperledger-labs/solang compile -v -o /sources --target solana /sources/flipper.sol
+docker run --rm -it -v $(pwd):/sources ghcr.io/hyperledger/solang compile -v -o /sources --target solana /sources/flipper.sol
 ```
 
 A file called `flipper.abi` and `bundle.so`. Now install `@solana/solidity`:
@@ -134,7 +134,7 @@ solang compile --target substrate flipper.sol
 Alternatively if you want to use the solang container, run:
 
 ```
-docker run --rm -it -v $(pwd):/sources ghcr.io/hyperledger-labs/solang -v -o /sources --target substrate /sources/flipper.sol
+docker run --rm -it -v $(pwd):/sources ghcr.io/hyperledger/solang -v -o /sources --target substrate /sources/flipper.sol
 ```
 You will have a file called flipper.contract. You can use this directly in
 the [Contracts UI](https://contracts-ui.substrate.io/),

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -17,4 +17,4 @@
 - Release new version of vscode plugin if needed
 - Mention release in Discord (Solana, Hyperledger) and Hyperledger /dev/weekly
 - Update the version number and the MacOS binaries' sha256 hash in `Casks/solang.rb` under
-  the repository `hyperledger-labs/homebrew-solang`.
+  the repository `hyperledger/homebrew-solang`.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -9,14 +9,14 @@ Target Specific
 
 Solang supports Substrate and Solana. These targets need testing
 via integration tests. New targets like
-`Fabric <https://github.com/hyperledger-labs/fabric-chaincode-wasm>`_ need to be
+`Fabric <https://github.com/hyperledger/fabric-chaincode-wasm>`_ need to be
 added, and tests added.
 
 How to report issues
 --------------------
 
 Please report issues to
-`github issues <https://github.com/hyperledger-labs/solang/issues>`_.
+`github issues <https://github.com/hyperledger/solang/issues>`_.
 
 Debugging issues with LLVM
 --------------------------

--- a/docs/extension.rst
+++ b/docs/extension.rst
@@ -34,23 +34,23 @@ Development
 -----------
 
 The code is spread over two parts. The first part the vscode extension client code,
-`written in TypeScript <https://github.com/hyperledger-labs/solang/tree/main/vscode>`_.
+`written in TypeScript <https://github.com/hyperledger/solang/tree/main/vscode>`_.
 This part deals with syntax highlighting, and calling out to the Solang language server when
 needed. The client needs `npm and node installed <https://docs.npmjs.com/downloading-and-installing-node-js-and-npm>`_.
 The client implementation is present in
-`src/client <https://github.com/hyperledger-labs/solang/tree/main/vscode/src/client>`_.
+`src/client <https://github.com/hyperledger/solang/tree/main/vscode/src/client>`_.
 The extension client code is in
-`src/client/extension.ts <https://github.com/hyperledger-labs/solang/tree/main/vscode/src/client/extension.ts>`_.
+`src/client/extension.ts <https://github.com/hyperledger/solang/tree/main/vscode/src/client/extension.ts>`_.
 
 Secondly, there is the language server which is written in Rust.
 The Solang binary has an option ``--language-server``, which start the
-`built-in language server <https://github.com/hyperledger-labs/solang/blob/main/src/bin/languageserver/mod.rs>`_.
+`built-in language server <https://github.com/hyperledger/solang/blob/main/src/bin/languageserver/mod.rs>`_.
 
 Once you have node and npm installed, you can build the extension like so:
 
 .. code-block:: bash
 
-    git clone https://github.com/hyperledger-labs/solang
+    git clone https://github.com/hyperledger/solang
     cd solang/vscode
     npm install
     npm install -g vsce

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ Welcome to the Solang Solidity Compiler. Using Solang, you can compile smart con
 
 Solang aims for source file compatibility with the Ethereum EVM Solidity compiler,
 version 0.8. Where differences exists, this is noted in the language documentation.
-The source code repository can be found on `github <https://github.com/hyperledger-labs/solang>`_
+The source code repository can be found on `github <https://github.com/hyperledger/solang>`_
 and we have a `channel #solang on Hyperledger Discord <https://discord.gg/jhn4rkqNsT>`_, and
 a `channel #solang-solidity-compiler on Solana Discord <https://discord.gg/TmE2Ek5ZbW>`_.
 

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -19,7 +19,7 @@ To install Solang via Brew, run the following command:
 
 .. code-block:: text
 
-    brew install hyperledger-labs/solang/solang
+    brew install hyperledger/solang/solang
 
 .. _download-binaries:
 
@@ -28,11 +28,11 @@ Option 2: Download release binaries
 
 There are binaries available on github releases:
 
-- `Linux x86-64 <https://github.com/hyperledger-labs/solang/releases/download/v0.1.12/solang-linux-x86-64>`_
-- `Linux arm64 <https://github.com/hyperledger-labs/solang/releases/download/v0.1.12/solang-linux-arm64>`_
-- `Windows x64 <https://github.com/hyperledger-labs/solang/releases/download/v0.1.12/solang.exe>`_
-- `MacOS intel <https://github.com/hyperledger-labs/solang/releases/download/v0.1.12/solang-mac-intel>`_
-- `MacOS arm <https://github.com/hyperledger-labs/solang/releases/download/v0.1.12/solang-mac-arm>`_
+- `Linux x86-64 <https://github.com/hyperledger/solang/releases/download/v0.1.12/solang-linux-x86-64>`_
+- `Linux arm64 <https://github.com/hyperledger/solang/releases/download/v0.1.12/solang-linux-arm64>`_
+- `Windows x64 <https://github.com/hyperledger/solang/releases/download/v0.1.12/solang.exe>`_
+- `MacOS intel <https://github.com/hyperledger/solang/releases/download/v0.1.12/solang-mac-intel>`_
+- `MacOS arm <https://github.com/hyperledger/solang/releases/download/v0.1.12/solang-mac-arm>`_
 
 On MacOS, remember to give execution permission to the file and remove it from quarantine by executing the following commands:
 
@@ -48,16 +48,16 @@ are using an Arm based Linux, the command is the following: ``chmod +x solang-li
 
 .. _download-docker:
 
-Option 3: Use ghcr.io/hyperledger-labs/solang containers
---------------------------------------------------------
+Option 3: Use ghcr.io/hyperledger/solang containers
+---------------------------------------------------
 
 New images are automatically made available on
-`solang containers <https://github.com/hyperledger-labs/solang/pkgs/container/solang>`_.
+`solang containers <https://github.com/hyperledger/solang/pkgs/container/solang>`_.
 There is a release `v0.1.12` tag and a `latest` tag:
 
 .. code-block:: bash
 
-	docker pull ghcr.io/hyperledger-labs/solang:latest
+	docker pull ghcr.io/hyperledger/solang:latest
 
 The Solang binary is stored at ``/usr/bin/solang`` in this image. The `latest` tag
 gets updated each time there is a commit to the main branch of the Solang git repository.
@@ -71,7 +71,7 @@ First clone the git repo using:
 
 .. code-block:: bash
 
-  git clone https://github.com/hyperledger-labs/solang
+  git clone https://github.com/hyperledger/solang
 
 Then you can build the image using:
 
@@ -110,7 +110,7 @@ These patches make it possible to generate code for Solana, and fixes some
 concurrency issues in the lld linker.
 
 You can either download the pre-built libraries from
-`github <https://github.com/hyperledger-labs/solang/releases/tag/v0.1.12>`_
+`github <https://github.com/hyperledger/solang/releases/tag/v0.1.12>`_
 or :ref:`build your own from source <llvm-from-source>`. After that, you need to add the ``bin`` directory to your
 path, so that the build system of Solang can find the correct version of LLVM to use.
 
@@ -118,7 +118,7 @@ Linux
 ~~~~~
 
 A pre-built version of LLVM, specifically configured for Solang, is available at
-`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.12/llvm13.0-linux-x86-64.tar.xz>`_.
+`<https://github.com/hyperledger/solang/releases/download/v0.1.12/llvm13.0-linux-x86-64.tar.xz>`_.
 After downloading, untar the file in a terminal and add it to your path.
 
 .. code-block:: bash
@@ -130,7 +130,7 @@ Windows
 ~~~~~~~
 
 A pre-built version of LLVM, specifically configured for Solang, is available at
-`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.12/llvm13.0-win.zip>`_.
+`<https://github.com/hyperledger/solang/releases/download/v0.1.12/llvm13.0-win.zip>`_.
 
 After unzipping the file, add the bin directory to your path.
 
@@ -142,8 +142,8 @@ Mac
 ~~~
 
 A pre-built version of LLVM for intel macs, is available at
-`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.12/llvm13.0-mac-intel.tar.xz>`_ and for arm macs there is
-`<https://github.com/hyperledger-labs/solang/releases/download/v0.1.12/llvm13.0-mac-arm.tar.xz>`_. After downloading,
+`<https://github.com/hyperledger/solang/releases/download/v0.1.12/llvm13.0-mac-intel.tar.xz>`_ and for arm macs there is
+`<https://github.com/hyperledger/solang/releases/download/v0.1.12/llvm13.0-mac-arm.tar.xz>`_. After downloading,
 untar the file in a terminal and add it to your path like so:
 
 .. code-block:: bash
@@ -196,7 +196,7 @@ Once you have the correct LLVM version in your path, simply run:
 
 .. code-block:: bash
 
-	git clone https://github.com/hyperledger-labs/solang/
+	git clone https://github.com/hyperledger/solang/
 	cd solang
 	cargo build --release
 

--- a/docs/language/managing_values.rst
+++ b/docs/language/managing_values.rst
@@ -10,7 +10,7 @@ Value in Solidity is represented by ``uint128``.
 
     Parity Substrate can be compiled with a different type for ``T::Balance``. If you
     need support for a different type, please raise an
-    `issue <https://github.com/hyperledger-labs/solang/issues>`_.
+    `issue <https://github.com/hyperledger/solang/issues>`_.
 
 Checking your balance
 _____________________

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -155,29 +155,29 @@ Running Solang using container
 ______________________________
 
 First pull the last Solang container from
-`solang containers <https://github.com/hyperledger-labs/solang/pkgs/container/solang>`_:
+`solang containers <https://github.com/hyperledger/solang/pkgs/container/solang>`_:
 
 .. code-block:: bash
 
-    docker pull ghcr.io/hyperledger-labs/solang
+    docker pull ghcr.io/hyperledger/solang
 
 And if you are using podman:
 
 .. code-block:: bash
 
-    podman image pull ghcr.io/hyperledger-labs/solang
+    podman image pull ghcr.io/hyperledger/solang
 
 Now you can run Solang like so:
 
 .. code-block:: bash
 
-	  docker run --rm -it ghcr.io/hyperledger-labs/solang --version
+	  docker run --rm -it ghcr.io/hyperledger/solang --version
 
 Or podman:
 
 .. code-block:: bash
 
-	  podman container run --rm -it ghcr.io/hyperledger-labs/solang --version
+	  podman container run --rm -it ghcr.io/hyperledger/solang --version
 
 If you want to compile some solidity files, the source file needs to be
 available inside the container. You can do this via the -v command line.
@@ -186,10 +186,10 @@ to your solidity files:
 
 .. code-block:: bash
 
-	  docker run --rm -it -v /local/path:/sources ghcr.io/hyperledger-labs/solang compile -o /sources /sources/flipper.sol
+	  docker run --rm -it -v /local/path:/sources ghcr.io/hyperledger/solang compile -o /sources /sources/flipper.sol
 
 On Windows, you need to specify absolute paths:
 
 .. code-block:: text
 
-	 docker run --rm -it -v C:\Users\User:/sources ghcr.io/hyperledger-labs/solang compile -o /sources /sources/flipper.sol
+	 docker run --rm -it -v C:\Users\User:/sources ghcr.io/hyperledger/solang compile -o /sources /sources/flipper.sol

--- a/docs/targets/solana.rst
+++ b/docs/targets/solana.rst
@@ -71,7 +71,7 @@ Now run the following javascript by saving it to `flipper.js` and running it wit
 The contract can be used via the `@solana/solidity <https://www.npmjs.com/package/@solana/solidity>`_  npm package. This
 package has `documentation <https://solana-labs.github.io/solana-solidity.js/>`_ and there
 are `some examples <https://solana-labs.github.io/solana-solidity.js/>`_. There is also
-`solang's integration tests <https://github.com/hyperledger-labs/solang/tree/main/integration/solana>`_.
+`solang's integration tests <https://github.com/hyperledger/solang/tree/main/integration/solana>`_.
 
 .. _value_transfer:
 
@@ -225,10 +225,10 @@ transfering token. This is the Solana equivalent of
 `ERC-20 <https://ethereum.org/en/developers/docs/standards/tokens/erc-20/>`_ and
 `ERC-721 <https://ethereum.org/en/developers/docs/standards/tokens/erc-721/>`_. We have created a library ``SplToken`` to use
 spl-token from Solidity. The file
-`spl_token.sol <https://github.com/hyperledger-labs/solang/blob/main/examples/spl_token.sol>`_  should be copied into
+`spl_token.sol <https://github.com/hyperledger/solang/blob/main/examples/spl_token.sol>`_  should be copied into
 your source tree, and then imported in your solidity files where it is required. The ``SplToken`` library has doc
 comments explaining how it should be used.
 
 There is an example in our integration tests of how this should be used, see
-`token.sol <https://github.com/hyperledger-labs/solang/blob/main/integration/solana/token.sol>`_ and
-`token.spec.ts <https://github.com/hyperledger-labs/solang/blob/main/integration/solana/token.spec.ts>`_.
+`token.sol <https://github.com/hyperledger/solang/blob/main/integration/solana/token.sol>`_ and
+`token.spec.ts <https://github.com/hyperledger/solang/blob/main/integration/solana/token.spec.ts>`_.

--- a/docs/targets/substrate.rst
+++ b/docs/targets/substrate.rst
@@ -15,7 +15,7 @@ The Parity Substrate has the following differences to Ethereum Solidity:
 - An `assert()`, `require()`, or `revert()` executes the wasm unreachable instruction. The reason code is lost
 
 There is an solidity example which can be found in the
-`examples <https://github.com/hyperledger-labs/solang/tree/main/examples>`_
+`examples <https://github.com/hyperledger/solang/tree/main/examples>`_
 directory. Write this to flipper.sol and run:
 
 .. code-block:: bash

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -2,13 +2,13 @@ Solang Test Suite
 =================
 
 Solang has a few test suites. These are all run on each pull request via
-`github actions <https://github.com/hyperledger-labs/solang/actions>`_.
+`github actions <https://github.com/hyperledger/solang/actions>`_.
 
 
 Solidity parser and semantics tests
 -----------------------------------
 
-In the `tests <https://github.com/hyperledger-labs/solang/tree/main/tests>`_ directory, there are
+In the `tests <https://github.com/hyperledger/solang/tree/main/tests>`_ directory, there are
 a lot of tests which call `fn parse_and_resolve()`. This function parses Solidity, and returns
 the *namespace*: all the resolved contracts, types, functions, etc (as much as could be resolved),
 and all the compiler diagnositics, i.e. compiler warnings and errors. These tests check that
@@ -25,7 +25,7 @@ Codegen tests
 The stage after semantic analysis is codegen. Codegen generates an IR which is a CFG, so it is
 simply called CFG. The codegen tests ensure that the CFG matches what should be created. These
 tests are inspired by LLVM lit tests. The tests can found in
-`codegen_testcases <https://github.com/hyperledger-labs/solang/tree/main/tests/codegen_testcases>`_.
+`codegen_testcases <https://github.com/hyperledger/solang/tree/main/tests/codegen_testcases>`_.
 
 These tests do the following:
 
@@ -56,6 +56,6 @@ of the contract working memory to ensure there are no corruptions.
 Deploy contract on dev chain
 ----------------------------
 
-There are some tests in `integration <https://github.com/hyperledger-labs/solang/tree/main/integration/>`_
+There are some tests in `integration <https://github.com/hyperledger/solang/tree/main/integration/>`_
 which are written in node. These tests start an actual real chain via containers,
 and then deploying some tests contracts to them and interacting with them.

--- a/solang-parser/Cargo.toml
+++ b/solang-parser/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solang-parser"
 version = "0.1.17"
 authors = ["Sean Young <sean@mess.org>"]
-homepage = "https://github.com/hyperledger-labs/solang"
+homepage = "https://github.com/hyperledger/solang"
 documentation = "https://solang.readthedocs.io/"
 license = "Apache-2.0"
 build = "build.rs"

--- a/src/codegen/encoding/borsh_encoding.rs
+++ b/src/codegen/encoding/borsh_encoding.rs
@@ -563,7 +563,7 @@ impl BorshEncoding {
         if dims[dimension] == ArrayLength::Dynamic {
             // TODO: This is wired up for the support of dynamic multidimensional arrays, like
             // TODO: 'int[3][][4] vec', but it needs testing, as soon as Solang works with them.
-            // TODO: A discussion about this is under way here: https://github.com/hyperledger-labs/solang/issues/932
+            // TODO: A discussion about this is under way here: https://github.com/hyperledger/solang/issues/932
             // We only support dynamic arrays whose non-constant length is the outer one.
             let (sub_array, _) = load_sub_array(
                 arr.clone(),
@@ -1080,7 +1080,7 @@ impl BorshEncoding {
                 }
             } else {
                 // TODO: This is wired up for multidimensional dynamic arrays, but they do no work yet
-                // Check https://github.com/hyperledger-labs/solang/issues/932 for more information
+                // Check https://github.com/hyperledger/solang/issues/932 for more information
                 let (sub_arr, _) = load_sub_array(
                     array_var.clone(),
                     &dims[(dimension + 1)..dims.len()],

--- a/src/codegen/strength_reduce/reaching_values.rs
+++ b/src/codegen/strength_reduce/reaching_values.rs
@@ -96,7 +96,7 @@ pub(super) fn reaching_values(
 
 /// Update the Variable's map based on the incoming set of values. Returns true if there was any
 /// changes in the set.
-/// There is a discussion to improve this function: https://github.com/hyperledger-labs/solang/issues/934
+/// There is a discussion to improve this function: https://github.com/hyperledger/solang/issues/934
 fn update_map(var_no: &usize, set: &HashSet<Value>, map: &mut Variables) -> bool {
     return if let Some(existing) = map.get_mut(var_no) {
         if existing.iter().next().map_or(false, |v| v.all_unknown()) {

--- a/src/sema/yul/expression.rs
+++ b/src/sema/yul/expression.rs
@@ -394,7 +394,7 @@ pub(crate) fn resolve_function_call(
                 func_call.loc,
                 format!(
                     "builtin '{}' is not available for target {}. Please, open a GitHub issue \
-                at https://github.com/hyperledger-labs/solang/issues \
+                at https://github.com/hyperledger/solang/issues \
                 if there is need to support this function",
                     prototype.name, ns.target
                 ),
@@ -699,7 +699,7 @@ pub(crate) fn check_type(
                     Some(Diagnostic::error(
                         expr.loc(),
                         "assignment to length is not implemented. If there is need for this feature, please file a Github issue \
-                        at https://github.com/hyperledger-labs/solang/issues\
+                        at https://github.com/hyperledger/solang/issues\
                         ".to_string(),
                     ))
                 } else {

--- a/src/sema/yul/tests/expression.rs
+++ b/src/sema/yul/tests/expression.rs
@@ -1039,7 +1039,7 @@ contract testTypes {
     let ns = parse(file);
     assert!(ns
         .diagnostics
-        .contains_message("assignment to length is not implemented. If there is need for this feature, please file a Github issue at https://github.com/hyperledger-labs/solang/issues"));
+        .contains_message("assignment to length is not implemented. If there is need for this feature, please file a Github issue at https://github.com/hyperledger/solang/issues"));
 
     let file = r#"
 contract testTypes {
@@ -1585,7 +1585,7 @@ contract foo {
 
     let ns = parse_and_resolve(OsStr::new("test.sol"), &mut cache, Target::Solana);
 
-    assert!(ns.diagnostics.contains_message("builtin 'gaslimit' is not available for target solana. Please, open a GitHub issue at https://github.com/hyperledger-labs/solang/issues if there is need to support this function"));
+    assert!(ns.diagnostics.contains_message("builtin 'gaslimit' is not available for target solana. Please, open a GitHub issue at https://github.com/hyperledger/solang/issues if there is need to support this function"));
 
     let file = r#"
 contract foo {
@@ -1609,7 +1609,7 @@ contract foo {
         },
     );
 
-    assert!(ns.diagnostics.contains_message("builtin 'coinbase' is not available for target substrate. Please, open a GitHub issue at https://github.com/hyperledger-labs/solang/issues if there is need to support this function"));
+    assert!(ns.diagnostics.contains_message("builtin 'coinbase' is not available for target substrate. Please, open a GitHub issue at https://github.com/hyperledger/solang/issues if there is need to support this function"));
 
     let file = r#"
     contract foo {
@@ -1626,5 +1626,5 @@ contract foo {
 
     let ns = parse_and_resolve(OsStr::new("test.sol"), &mut cache, Target::Solana);
 
-    assert!(ns.diagnostics.contains_message("builtin 'log0' is not available for target solana. Please, open a GitHub issue at https://github.com/hyperledger-labs/solang/issues if there is need to support this function"));
+    assert!(ns.diagnostics.contains_message("builtin 'log0' is not available for target solana. Please, open a GitHub issue at https://github.com/hyperledger/solang/issues if there is need to support this function"));
 }

--- a/tests/contract_testcases/solana/destructure_assign_struct_member.dot
+++ b/tests/contract_testcases/solana/destructure_assign_struct_member.dot
@@ -1,6 +1,6 @@
 strict digraph "tests/contract_testcases/solana/destructure_assign_struct_member.sol" {
 	Data [label="name:Data\ncontract: TestContract\ntests/contract_testcases/solana/destructure_assign_struct_member.sol:3:12-16\nfield name:a1 ty:bytes32\nfield name:a2 ty:bytes32"]
-	contract [label="contract TestContract\ntests/contract_testcases/solana/destructure_assign_struct_member.sol:1:57-15:2"]
+	contract [label="contract TestContract\ntests/contract_testcases/solana/destructure_assign_struct_member.sol:1:52-15:2"]
 	var [label="variable Hashes\nvisibility internal\ntests/contract_testcases/solana/destructure_assign_struct_member.sol:8:5-39"]
 	node_5 [label="constructor \ncontract: TestContract\ntests/contract_testcases/solana/destructure_assign_struct_member.sol:10:5-19\nsignature ()\nvisibility public\nmutability nonpayable"]
 	getdata [label="function getdata\ncontract: TestContract\ntests/contract_testcases/solana/destructure_assign_struct_member.sol:12:5-84\nsignature getdata(uint176,bool)\nvisibility public\nmutability view"]
@@ -22,7 +22,7 @@ strict digraph "tests/contract_testcases/solana/destructure_assign_struct_member
 	add_22 [label="add\nuint176\ntests/contract_testcases/solana/destructure_assign_struct_member.sol:13:46-50"]
 	variable_23 [label="variable: id\nuint176\ntests/contract_testcases/solana/destructure_assign_struct_member.sol:13:46-48"]
 	number_literal_24 [label="uint176 literal: 2\ntests/contract_testcases/solana/destructure_assign_struct_member.sol:13:49-50"]
-	diagnostic [label="found contract 'TestContract'\nlevel Debug\ntests/contract_testcases/solana/destructure_assign_struct_member.sol:1:57-15:2"]
+	diagnostic [label="found contract 'TestContract'\nlevel Debug\ntests/contract_testcases/solana/destructure_assign_struct_member.sol:1:52-15:2"]
 	diagnostic_27 [label="function parameter 'needHash' has never been read\nlevel Warning\ntests/contract_testcases/solana/destructure_assign_struct_member.sol:12:39-47"]
 	structs -> Data
 	contracts -> contract

--- a/tests/contract_testcases/solana/destructure_assign_struct_member.sol
+++ b/tests/contract_testcases/solana/destructure_assign_struct_member.sol
@@ -1,4 +1,4 @@
-// https://github.com/hyperledger-labs/solang/issues/731
+// https://github.com/hyperledger/solang/issues/731
 contract TestContract {
     struct Data {
         bytes32 a1;

--- a/tests/contract_testcases/solana/destructure_assign_struct_member_2.dot
+++ b/tests/contract_testcases/solana/destructure_assign_struct_member_2.dot
@@ -29,7 +29,7 @@ strict digraph "tests/contract_testcases/solana/destructure_assign_struct_member
 	subscript_29 [label="subscript address[]\ntests/contract_testcases/solana/destructure_assign_struct_member_2.sol:22:58-68"]
 	variable_30 [label="variable: _tokens\naddress[]\ntests/contract_testcases/solana/destructure_assign_struct_member_2.sol:22:58-65"]
 	number_literal_31 [label="uint32 literal: 0\ntests/contract_testcases/solana/destructure_assign_struct_member_2.sol:22:66-67"]
-	diagnostic [label="pragma 'solidity' is ignored\nlevel Debug\ntests/contract_testcases/solana/destructure_assign_struct_member_2.sol:1:57-2:23"]
+	diagnostic [label="pragma 'solidity' is ignored\nlevel Debug\ntests/contract_testcases/solana/destructure_assign_struct_member_2.sol:1:52-2:23"]
 	diagnostic_34 [label="found interface 'IUniswapV2Pair'\nlevel Debug\ntests/contract_testcases/solana/destructure_assign_struct_member_2.sol:3:1-6:2"]
 	diagnostic_35 [label="found contract 'Contract'\nlevel Debug\ntests/contract_testcases/solana/destructure_assign_struct_member_2.sol:8:1-25:2"]
 	diagnostic_36 [label="local variable 'struct_1' has been assigned, but never read\nlevel Warning\ntests/contract_testcases/solana/destructure_assign_struct_member_2.sol:20:26-34"]

--- a/tests/contract_testcases/solana/destructure_assign_struct_member_2.sol
+++ b/tests/contract_testcases/solana/destructure_assign_struct_member_2.sol
@@ -1,13 +1,13 @@
-// https://github.com/hyperledger-labs/solang/issues/731
+// https://github.com/hyperledger/solang/issues/731
 pragma solidity 0.6.12;
 
 interface IUniswapV2Pair {
-    function getReserves() external view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast);   
+    function getReserves() external view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast);
 }
 
 
 contract Contract {
-   
+
     struct Struct1 {
         uint256 a;
         uint256 b;

--- a/tests/contract_testcases/solana/shift_struct_member.dot
+++ b/tests/contract_testcases/solana/shift_struct_member.dot
@@ -1,7 +1,7 @@
 strict digraph "tests/contract_testcases/solana/shift_struct_member.sol" {
 	uq144x112 [label="name:uq144x112\ncontract: FixedPoint\ntests/contract_testcases/solana/shift_struct_member.sol:4:12-21\nfield name:_x ty:uint256"]
 	uq112x112 [label="name:uq112x112\ncontract: FixedPoint\ntests/contract_testcases/solana/shift_struct_member.sol:8:12-21\nfield name:_x ty:uint224"]
-	contract [label="contract FixedPoint\ntests/contract_testcases/solana/shift_struct_member.sol:1:71-21:2"]
+	contract [label="contract FixedPoint\ntests/contract_testcases/solana/shift_struct_member.sol:1:66-21:2"]
 	decode [label="function decode\ncontract: FixedPoint\ntests/contract_testcases/solana/shift_struct_member.sol:13:5-75\nsignature decode((uint224))\nvisibility internal\nmutability pure"]
 	parameters [label="parameters\nstruct FixedPoint.uq112x112 self"]
 	returns [label="returns\nuint112 "]
@@ -24,7 +24,7 @@ strict digraph "tests/contract_testcases/solana/shift_struct_member.sol" {
 	variable_24 [label="variable: self\nstruct FixedPoint.uq144x112\ntests/contract_testcases/solana/shift_struct_member.sol:19:24-28"]
 	zero_ext_25 [label="zero extend uint256\ntests/contract_testcases/solana/shift_struct_member.sol:19:24-38"]
 	number_literal_26 [label="uint8 literal: 112\ntests/contract_testcases/solana/shift_struct_member.sol:19:35-38"]
-	diagnostic [label="found library 'FixedPoint'\nlevel Debug\ntests/contract_testcases/solana/shift_struct_member.sol:1:71-21:2"]
+	diagnostic [label="found library 'FixedPoint'\nlevel Debug\ntests/contract_testcases/solana/shift_struct_member.sol:1:66-21:2"]
 	structs -> uq144x112
 	structs -> uq112x112
 	contracts -> contract

--- a/tests/contract_testcases/solana/shift_struct_member.sol
+++ b/tests/contract_testcases/solana/shift_struct_member.sol
@@ -1,6 +1,6 @@
-// Test case for https://github.com/hyperledger-labs/solang/issues/732
+// Test case for https://github.com/hyperledger/solang/issues/732
 library FixedPoint {
-   
+
     struct uq144x112 {
         uint _x;
     }

--- a/tests/contract_testcases/solana/yul/parse.dot
+++ b/tests/contract_testcases/solana/yul/parse.dot
@@ -3,7 +3,7 @@ strict digraph "tests/contract_testcases/solana/yul/parse.sol" {
 	get [label="function get\ncontract: foo\ntests/contract_testcases/solana/yul/parse.sol:3:13-51\nsignature get()\nvisibility public\nmutability nonpayable"]
 	returns [label="returns\nbytes4 "]
 	diagnostic [label="found contract 'foo'\nlevel Debug\ntests/contract_testcases/solana/yul/parse.sol:2:9-9:10"]
-	diagnostic_6 [label="builtin 'mload' is not available for target solana. Please, open a GitHub issue at https://github.com/hyperledger-labs/solang/issues if there is need to support this function\nlevel Error\ntests/contract_testcases/solana/yul/parse.sol:5:44-55"]
+	diagnostic_6 [label="builtin 'mload' is not available for target solana. Please, open a GitHub issue at https://github.com/hyperledger/solang/issues if there is need to support this function\nlevel Error\ntests/contract_testcases/solana/yul/parse.sol:5:44-55"]
 	diagnostic_7 [label="missing return statement\nlevel Error\ntests/contract_testcases/solana/yul/parse.sol:8:14"]
 	contracts -> contract
 	contract -> get [label="function"]

--- a/tests/contract_testcases/solana/yul/return_in_asm.dot
+++ b/tests/contract_testcases/solana/yul/return_in_asm.dot
@@ -4,7 +4,7 @@ strict digraph "tests/contract_testcases/solana/yul/return_in_asm.sol" {
 	inline_assembly [label="inline assembly\ntests/contract_testcases/solana/yul/return_in_asm.sol:3:9-5:10"]
 	diagnostic [label="found contract 'Contract'\nlevel Debug\ntests/contract_testcases/solana/yul/return_in_asm.sol:1:1-7:2"]
 	diagnostic_6 [label="flag 'memory-safe' not supported\nlevel Error\ntests/contract_testcases/solana/yul/return_in_asm.sol:3:19-32"]
-	diagnostic_7 [label="builtin 'return' is not available for target solana. Please, open a GitHub issue at https://github.com/hyperledger-labs/solang/issues if there is need to support this function\nlevel Error\ntests/contract_testcases/solana/yul/return_in_asm.sol:4:13-25"]
+	diagnostic_7 [label="builtin 'return' is not available for target solana. Please, open a GitHub issue at https://github.com/hyperledger/solang/issues if there is need to support this function\nlevel Error\ntests/contract_testcases/solana/yul/return_in_asm.sol:4:13-25"]
 	contracts -> contract
 	contract -> node_2 [label="constructor"]
 	node_2 -> inline_assembly [label="body"]

--- a/tests/contract_testcases/substrate/arrays/multi_dim.dot
+++ b/tests/contract_testcases/substrate/arrays/multi_dim.dot
@@ -1,5 +1,5 @@
 strict digraph "tests/contract_testcases/substrate/arrays/multi_dim.sol" {
-	contract [label="contract c\ntests/contract_testcases/substrate/arrays/multi_dim.sol:1:57-8:2"]
+	contract [label="contract c\ntests/contract_testcases/substrate/arrays/multi_dim.sol:1:52-8:2"]
 	test [label="function test\ncontract: c\ntests/contract_testcases/substrate/arrays/multi_dim.sol:3:2-52\nsignature test()\nvisibility public\nmutability pure"]
 	returns [label="returns\nuint256 ret1"]
 	var_decl [label="variable decl uint256[3][] vec\ntests/contract_testcases/substrate/arrays/multi_dim.sol:4:3-19"]
@@ -17,7 +17,7 @@ strict digraph "tests/contract_testcases/substrate/arrays/multi_dim.sol" {
 	variable_16 [label="variable: vec\nuint256[3][]\ntests/contract_testcases/substrate/arrays/multi_dim.sol:6:10-13"]
 	number_literal_17 [label="uint32 literal: 1\ntests/contract_testcases/substrate/arrays/multi_dim.sol:6:14-15"]
 	number_literal_18 [label="uint32 literal: 1\ntests/contract_testcases/substrate/arrays/multi_dim.sol:6:17-18"]
-	diagnostic [label="found contract 'c'\nlevel Debug\ntests/contract_testcases/substrate/arrays/multi_dim.sol:1:57-8:2"]
+	diagnostic [label="found contract 'c'\nlevel Debug\ntests/contract_testcases/substrate/arrays/multi_dim.sol:1:52-8:2"]
 	contracts -> contract
 	contract -> test [label="function"]
 	test -> returns [label="returns"]

--- a/tests/contract_testcases/substrate/arrays/multi_dim.sol
+++ b/tests/contract_testcases/substrate/arrays/multi_dim.sol
@@ -1,4 +1,4 @@
-// https://github.com/hyperledger-labs/solang/issues/860
+// https://github.com/hyperledger/solang/issues/860
 contract c {
 	function test() public pure returns (uint256 ret1) {
 		uint256[3][] vec;

--- a/tests/contract_testcases/substrate/arrays/push_array_literal.dot
+++ b/tests/contract_testcases/substrate/arrays/push_array_literal.dot
@@ -1,5 +1,5 @@
 strict digraph "tests/contract_testcases/substrate/arrays/push_array_literal.sol" {
-	contract [label="contract c\ntests/contract_testcases/substrate/arrays/push_array_literal.sol:1:57-8:2"]
+	contract [label="contract c\ntests/contract_testcases/substrate/arrays/push_array_literal.sol:1:52-8:2"]
 	var [label="variable s_vec\nvisibility internal\ntests/contract_testcases/substrate/arrays/push_array_literal.sol:3:2-20"]
 	test [label="function test\ncontract: c\ntests/contract_testcases/substrate/arrays/push_array_literal.sol:4:2-47\nsignature test()\nvisibility public\nmutability nonpayable"]
 	returns [label="returns\nuint256 ret1"]
@@ -17,7 +17,7 @@ strict digraph "tests/contract_testcases/substrate/arrays/push_array_literal.sol
 	storage_var_16 [label="storage variable\nc.s_vec\nuint256[3][] storage\ntests/contract_testcases/substrate/arrays/push_array_literal.sol:6:10-15"]
 	number_literal_17 [label="uint256 literal: 1\ntests/contract_testcases/substrate/arrays/push_array_literal.sol:6:16-17"]
 	number_literal_18 [label="uint256 literal: 1\ntests/contract_testcases/substrate/arrays/push_array_literal.sol:6:19-20"]
-	diagnostic [label="found contract 'c'\nlevel Debug\ntests/contract_testcases/substrate/arrays/push_array_literal.sol:1:57-8:2"]
+	diagnostic [label="found contract 'c'\nlevel Debug\ntests/contract_testcases/substrate/arrays/push_array_literal.sol:1:52-8:2"]
 	contracts -> contract
 	contract -> var [label="variable"]
 	contract -> test [label="function"]

--- a/tests/contract_testcases/substrate/arrays/push_array_literal.sol
+++ b/tests/contract_testcases/substrate/arrays/push_array_literal.sol
@@ -1,4 +1,4 @@
-// https://github.com/hyperledger-labs/solang/issues/859
+// https://github.com/hyperledger/solang/issues/859
 contract c {
 	uint256[3][] s_vec;
 	function test() public returns (uint256 ret1) {

--- a/tests/solana_tests/simple.rs
+++ b/tests/solana_tests/simple.rs
@@ -187,7 +187,7 @@ fn incrementer() {
         contract foo {
             // make sure incrementer has a base contract with an empty constructor
             // is to check that the correct constructor is selected at emit time
-            // https://github.com/hyperledger-labs/solang/issues/487
+            // https://github.com/hyperledger/solang/issues/487
             constructor() {}
         }
 

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -16,7 +16,7 @@ For more information on Solang itself and the extension, please go to the [docum
 ## Dependencies
 
 The solang compiler executable needs to be installed, which can be downloaded from
-the [Solang Releases Page](https://github.com/hyperledger-labs/solang/releases). Then
+the [Solang Releases Page](https://github.com/hyperledger/solang/releases). Then
 you have to configure the path to the solang executable extension settings, and also
 which target you wish to compile file.
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -5,7 +5,7 @@
 	"publisher": "solang",
 	"author": "Shivam Balikondwar <shivambalikondwar@icloud.com>",
 	"version": "0.3.0",
-	"repository": "github.com/hyperledger-labs/solang",
+	"repository": "github.com/hyperledger/solang",
 	"engines": {
 		"vscode": "^1.43.0"
 	},

--- a/vscode/src/utils/fetchLatestRelease.ts
+++ b/vscode/src/utils/fetchLatestRelease.ts
@@ -1,7 +1,7 @@
 import fetch from 'node-fetch';
 
 export default async function fetchLatestRelease() {
-  const RELEASE_URL = 'https://api.github.com/repos/hyperledger-labs/solang/releases/latest';
+  const RELEASE_URL = 'https://api.github.com/repos/hyperledger/solang/releases/latest';
   const response = await fetch(RELEASE_URL);
 
   if (!response.ok) {


### PR DESCRIPTION
solang has moved into incubation, so now the repo can be found at
https://github.com/hyperledger/solang

Signed-off-by: Sean Young <sean@mess.org>