### PR TITLE
Fix overflow detection tests

### DIFF
--- a/tests/solana_tests/primitives.rs
+++ b/tests/solana_tests/primitives.rs
@@ -3,7 +3,7 @@
 use crate::build_solidity;
 use crate::build_solidity_with_overflow_check;
 use ethabi::ethereum_types::U256;
-use num_bigint::{BigInt, BigUint, RandBigInt, Sign};
+use num_bigint::{BigInt, BigUint, RandBigInt};
 use rand::seq::SliceRandom;
 use rand::Rng;
 use std::ops::Add;

--- a/tests/solana_tests/primitives.rs
+++ b/tests/solana_tests/primitives.rs
@@ -843,10 +843,7 @@ fn test_mul_within_range() {
             let limit = BigUint::from(2_u32).pow(width).sub(1_u32);
 
             // Generate a random number within the the range [0, 2^N -1]
-            let mut first_operand_rand = rng.gen_biguint(width.into());
-            if first_operand_rand == BigUint::from(0_u32) {
-                first_operand_rand = BigUint::from(1_u32);
-            }
+            let first_operand_rand = rng.gen_biguint_range(&BigUint::from(1usize), &limit);
 
             // Calculate a number that when multiplied by first_operand_rand, the result will not overflow N bits (the result of this division will cast the float result to int result, therefore lowering it. The result of multiplication will never overflow).
             let second_operand_rand = limit.div(&first_operand_rand);
@@ -887,26 +884,15 @@ fn test_overflow_detect_signed() {
 
         contract.constructor("test", &[]);
 
-        // The range of values that can be held in signed N bits is [-2^(N-1), 2^(N-1)-1] .Generate a value that will overflow this range:
-        let limit = BigInt::from(2_u32).pow(width - 1).add(1_u32);
+        // The range of values that can be held in signed N bits is [-2^(N-1), 2^(N-1)-1] .
+        let limit = BigInt::from(2_u32).pow(width - 1).sub(1usize);
 
-        // Divide Limit by a random number
-        let mut first_operand_rand = rng.gen_bigint((width - 1).into());
-
-        if first_operand_rand == BigInt::from(0_u32) {
-            first_operand_rand = BigInt::from(1_u32);
-        }
+        // Generate a random number within the the range [(2^N-1)/2, (2^N-1) -1]
+        let first_operand_rand =
+            rng.gen_bigint_range(&(limit.clone().div(2usize)).add(1usize), &limit);
 
         // Calculate a number that when multiplied by first_operand_rand, the result will overflow N bits
-        let mut second_operand_rand = limit / &first_operand_rand;
-
-        if let Sign::Minus = second_operand_rand.sign() {
-            // Decrease by 1 if negative, this is to make sure the result will overflow
-            second_operand_rand = second_operand_rand.sub(1);
-        } else {
-            // Increase by 1 if psotive
-            second_operand_rand = second_operand_rand.add(1);
-        }
+        let second_operand_rand = rng.gen_bigint_range(&BigInt::from(2usize), &limit);
 
         let res = contract.function_must_fail(
             "mul",
@@ -945,17 +931,14 @@ fn test_overflow_detect_unsigned() {
 
         for _ in 0..10 {
             // N bits can hold the range [0, (2^N)-1]. Generate a value that overflows N bits
-            let limit = BigUint::from(2_u32).pow(width);
+            let limit = BigUint::from(2_u32).pow(width).sub(1usize);
 
-            // Generate a random number within the the range [0, 2^N -1]
-            let mut first_operand_rand = rng.gen_biguint(width.into());
-
-            if first_operand_rand == BigUint::from(0_u32) {
-                first_operand_rand = BigUint::from(1_u32);
-            }
+            // Generate a random number within the the range [(2^N-1)/2, 2^N -1]
+            let first_operand_rand =
+                rng.gen_biguint_range(&(limit.clone().div(2usize)).add(1usize), &limit);
 
             // Calculate a number that when multiplied by first_operand_rand, the result will overflow N bits
-            let second_operand_rand = limit.div(&first_operand_rand).add(2_usize);
+            let second_operand_rand = rng.gen_biguint_range(&BigUint::from(2usize), &limit);
 
             let res = contract.function_must_fail(
                 "mul",

--- a/tests/solana_tests/primitives.rs
+++ b/tests/solana_tests/primitives.rs
@@ -911,6 +911,31 @@ fn test_overflow_detect_signed() {
         );
 
         assert_ne!(res, Ok(0));
+
+        // The range of values that can be held in signed N bits is [-2^(N-1), 2^(N-1)-1] .
+        let lower_limit = BigInt::from(2_u32).pow(width - 1).sub(1usize).mul(-1_i32);
+
+        // Generate a random number within the the range [-(2^N-1), -(2^N-1)/2]
+        let first_operand_rand =
+            rng.gen_bigint_range(&lower_limit, &(lower_limit.clone().div(2usize)).add(1usize));
+
+        let res = contract.function_must_fail(
+            "mul",
+            &[
+                ethabi::Token::Int(bigint_to_eth(
+                    &first_operand_rand,
+                    width.try_into().unwrap(),
+                )),
+                ethabi::Token::Int(bigint_to_eth(
+                    &second_operand_rand,
+                    width.try_into().unwrap(),
+                )),
+            ],
+            &[],
+            None,
+        );
+
+        assert_ne!(res, Ok(0));
     }
 }
 

--- a/tests/solana_tests/primitives.rs
+++ b/tests/solana_tests/primitives.rs
@@ -843,7 +843,10 @@ fn test_mul_within_range() {
             let limit = BigUint::from(2_u32).pow(width).sub(1_u32);
 
             // Generate a random number within the the range [0, 2^N -1]
-            let first_operand_rand = rng.gen_biguint(width.into()).add(1_u32);
+            let mut first_operand_rand = rng.gen_biguint(width.into());
+            if first_operand_rand == BigUint::from(0_u32) {
+                first_operand_rand = BigUint::from(1_u32);
+            }
 
             // Calculate a number that when multiplied by first_operand_rand, the result will not overflow N bits (the result of this division will cast the float result to int result, therefore lowering it. The result of multiplication will never overflow).
             let second_operand_rand = limit.div(&first_operand_rand);
@@ -888,7 +891,11 @@ fn test_overflow_detect_signed() {
         let limit = BigInt::from(2_u32).pow(width - 1).add(1_u32);
 
         // Divide Limit by a random number
-        let first_operand_rand = rng.gen_bigint((width - 1).into()).sub(1_u32);
+        let mut first_operand_rand = rng.gen_bigint((width - 1).into());
+
+        if first_operand_rand == BigInt::from(0_u32) {
+            first_operand_rand = BigInt::from(1_u32);
+        }
 
         // Calculate a number that when multiplied by first_operand_rand, the result will overflow N bits
         let mut second_operand_rand = limit / &first_operand_rand;
@@ -941,10 +948,14 @@ fn test_overflow_detect_unsigned() {
             let limit = BigUint::from(2_u32).pow(width);
 
             // Generate a random number within the the range [0, 2^N -1]
-            let first_operand_rand = rng.gen_biguint(width.into()).add(1_u32);
+            let mut first_operand_rand = rng.gen_biguint(width.into());
+
+            if first_operand_rand == BigUint::from(0_u32) {
+                first_operand_rand = BigUint::from(1_u32);
+            }
 
             // Calculate a number that when multiplied by first_operand_rand, the result will overflow N bits
-            let second_operand_rand = limit.div(&first_operand_rand).add(1_usize);
+            let second_operand_rand = limit.div(&first_operand_rand).add(2_usize);
 
             let res = contract.function_must_fail(
                 "mul",

--- a/tests/substrate_tests/expressions.rs
+++ b/tests/substrate_tests/expressions.rs
@@ -1292,7 +1292,10 @@ fn test_overflow_detect_signed() {
         // The range of values that can be held in signed N bits is [-2^(N-1), 2^(N-1)-1] .Generate a value that will overflow this range:
         let limit = BigInt::from(2_u32).pow(width - 1).add(1_u32);
 
-        let first_operand_rand = rng.gen_bigint((width - 1).into()).sub(1_u32);
+        let mut first_operand_rand = rng.gen_bigint((width - 1).into()).sub(1_u32);
+        if first_operand_rand == BigInt::from(0_u32) {
+            first_operand_rand = BigInt::from(1_u32);
+        }
         let first_op_sign = first_operand_rand.sign();
         let mut first_op_data = first_operand_rand.to_signed_bytes_le();
 
@@ -1340,7 +1343,10 @@ fn test_overflow_detect_unsigned() {
         // The range of values that can be held in signed N bits is [-2^(N-1), 2^(N-1)-1] .Generate a value that will overflow this range:
         let limit = BigUint::from(2_u32).pow(width).add(1_u32);
 
-        let first_operand_rand = rng.gen_biguint((width).into()).sub(1_u32);
+        let mut first_operand_rand = rng.gen_biguint((width).into());
+        if first_operand_rand == BigUint::from(0_u32) {
+            first_operand_rand = BigUint::from(1_u32);
+        }
         let mut first_op_data = first_operand_rand.to_bytes_le();
 
         let width_rounded = (width as usize / 8).next_power_of_two();

--- a/tests/substrate_tests/expressions.rs
+++ b/tests/substrate_tests/expressions.rs
@@ -1313,6 +1313,25 @@ fn test_overflow_detect_signed() {
             "mul",
             first_op_data
                 .into_iter()
+                .chain(second_op_data.clone().into_iter())
+                .collect(),
+        );
+
+        // The range of values that can be held in signed N bits is [-2^(N-1), 2^(N-1)-1] .
+        let lower_limit = BigInt::from(2_u32).pow(width - 1).sub(1usize).mul(-1_i32);
+
+        // Generate a random number within the the range [-(2^N-1), -(2^N-1)/2]
+        let first_operand_rand =
+            rng.gen_bigint_range(&lower_limit, &(lower_limit.clone().div(2usize)).add(1usize));
+
+        let first_op_sign = first_operand_rand.sign();
+        let mut first_op_data = first_operand_rand.to_signed_bytes_le();
+        first_op_data.resize((width_rounded) as usize, sign_extend(first_op_sign));
+
+        contract.function_expect_failure(
+            "mul",
+            first_op_data
+                .into_iter()
                 .chain(second_op_data.into_iter())
                 .collect(),
         );


### PR DESCRIPTION
Numbers that overflow the input type was generated, causing some overflow detection tests to fail