### PR TITLE
Emit events using Borsh encoding for Solana

### DIFF
--- a/docs/language/events.rst
+++ b/docs/language/events.rst
@@ -21,6 +21,13 @@ not. ``indexed`` fields are stored as topics, so there can only be a limited num
 fields are stored in the data section of the event. The event name does not need to be unique; just like
 functions, they can be overloaded as long as the fields are of different types, or the event has
 a different number of arguments.
+
+.. warning::
+    On Solana, writing ``indexed`` besides an event field has no impact when emitting events. The ``indexed``
+    keyword serves only to generate metadata information for IDL files. All event attributes will be encoded as data to
+    be passed for Solana's ``sol_log_data`` system call, regardless of the ``indexed`` keyword being present. This
+    behavior follows what Solana's Anchor framework does.
+
 In Parity Substrate, the topic fields are always the hash of the value of the field. Ethereum only hashes fields
 which do not fit in the 32 bytes. Since a cryptographic hash is used, it is only possible to compare the topic against a
 known value.

--- a/docs/language/events.rst
+++ b/docs/language/events.rst
@@ -23,10 +23,9 @@ functions, they can be overloaded as long as the fields are of different types, 
 a different number of arguments.
 
 .. warning::
-    On Solana, writing ``indexed`` besides an event field has no impact when emitting events. The ``indexed``
-    keyword serves only to generate metadata information for IDL files. All event attributes will be encoded as data to
-    be passed for Solana's ``sol_log_data`` system call, regardless of the ``indexed`` keyword being present. This
-    behavior follows what Solana's Anchor framework does.
+    On Solana, the ``indexed`` event field attribute has no effect. All event attributes will be encoded as data to
+    be passed for Solana's ``sol_log_data`` system call, regardless if the ``indexed`` keyword is present or not.
+    This behavior follows what Solana's Anchor framework does.
 
 In Parity Substrate, the topic fields are always the hash of the value of the field. Ethereum only hashes fields
 which do not fit in the 32 bytes. Since a cryptographic hash is used, it is only possible to compare the topic against a

--- a/integration/solana/events.sol
+++ b/integration/solana/events.sol
@@ -1,19 +1,19 @@
 
 event First(
-	int indexed a,
+	uint32 indexed a,
 	bool b,
 	string c
 );
 
 event Second(
-	int indexed a,
-	bytes4 b,
-	bytes c
+	uint32 indexed a,
+	string b,
+	string c
 );
 
-contract events {
+contract MyContractEvents {
 	function test() public {
 		emit First(102, true, "foobar");
-		emit Second(500332, "ABCD", hex"CAFE0123");
+		emit Second(500332, "ABCD", "CAFE0123");
 	}
 }

--- a/integration/solana/events.spec.ts
+++ b/integration/solana/events.spec.ts
@@ -1,50 +1,113 @@
 import expect from 'expect';
 import { loadContract } from './setup';
+import {deserialize, field} from "@dao-xyz/borsh";
+import * as sha256 from "fast-sha256";
 
-describe('Deploy solang contract and test', function () {
+describe('Test events', function () {
     this.timeout(500000);
+    const LOG_DATA_PREFIX = 'Program data: ';
+    class First {
+        @field({type: "u64"})
+        discriminator: bigint
+
+        @field({type: "u32"})
+        a : number
+
+        @field({type: "bool"})
+        b : boolean
+
+        @field({type: "string"})
+        c : string
+
+        constructor(data?: {discriminator: bigint, a: number, b: boolean, c: string}) {
+            if (data) {
+                this.discriminator = data.discriminator;
+                this.a = data.a;
+                this.b = data.b;
+                this.c = data.c;
+            } else {
+                this.discriminator = BigInt(0);
+                this.a = 0;
+                this.b = false;
+                this.c = "";
+            }
+        }
+    }
+
+    class Second {
+        @field({type: "u64"})
+        discriminator: bigint
+
+        @field({type: "u32"})
+        a : number
+
+        @field({type: "string"})
+        b : string
+
+        @field({type: "string"})
+        c : string
+
+        constructor(data?: { discriminator: bigint, a: number, b: string, c: string }) {
+            if(data) {
+                this.discriminator = data.discriminator;
+                this.a = data.a;
+                this.b = data.b;
+                this.c = data.c;
+            } else {
+                this.discriminator = BigInt(0);
+                this.a = 0;
+                this.b = "";
+                this.c = "";
+            }
+        }
+    }
+
+    function changeEndiannes(bytes: string) : string {
+        let result : string = "";
+        for(let i=0; i < bytes.length; i+=2) {
+            result += bytes.substring(bytes.length - i - 2, bytes.length - i);
+        }
+        return result;
+    }
 
     it('events', async function () {
-        const { contract } = await loadContract('events', 'events.abi');
-
-        await new Promise((resolve) => {
-            let first = true;
-            let listenId = contract.addEventListener(async (ev) => {
-
-                if (first) {
-                    expect(Number(ev.args[0])).toEqual(102);
-                    expect(ev.args[1]).toEqual(true);
-                    expect(ev.args[2]).toEqual('foobar');
-
-                    first = false;
-                } else {
-                    expect(Number(ev.args[0])).toEqual(500332);
-                    expect(ev.args[1]).toEqual("0x41424344");
-                    expect(ev.args[2]).toEqual("0xcafe0123");
-                }
-
-                await contract.removeEventListener(listenId);
-                resolve(true);
-            });
-
-            contract.functions.test();
-        });
+        const { contract, connection, program, storage } = await loadContract('MyContractEvents', 'MyContractEvents.abi');
 
         let res = await contract.functions.test({ simulate: true });
 
         expect(res.result).toBeNull();
-        expect(res.events.length).toBe(2);
+        let eventData : Buffer[] = [];
+        for (let programLog of res.logs) {
+            if (programLog.startsWith(LOG_DATA_PREFIX)) {
+                const fields = programLog.slice(LOG_DATA_PREFIX.length).split(' ');
+                if (fields.length == 1) {
+                    eventData.push(Buffer.from(fields[0], 'base64'));
+                }
+            }
+        }
+        expect(eventData.length).toBe(2);
+        let event_1 = deserialize(eventData[0], First);
 
-        let args = res.events[0].args;
+        let discriminator_image = "event:First";
+        let hasher = new sha256.Hash();
+        hasher.update(new TextEncoder().encode(discriminator_image));
+        let result = hasher.digest();
+        let received_discriminator = changeEndiannes(event_1.discriminator.toString(16));
+        expect(received_discriminator).toBe(Buffer.from(result.slice(0, 8)).toString('hex'));
+        expect(event_1.a).toBe(102);
+        expect(event_1.b).toBe(true);
+        expect(event_1.c).toBe("foobar");
 
-        expect(Number(args[0])).toEqual(102);
-        expect(args[1]).toEqual(true);
-        expect(args[2]).toEqual('foobar');
+        let event_2 = deserialize(eventData[1], Second);
 
-        args = res.events[1].args;
-
-        expect(Number(args[0])).toEqual(500332);
-        expect(args[1]).toEqual("0x41424344");
-        expect(args[2]).toEqual("0xcafe0123");
+        discriminator_image = "event:Second";
+        hasher = new sha256.Hash();
+        hasher.update(new TextEncoder().encode(discriminator_image));
+        result = hasher.digest();
+        received_discriminator = changeEndiannes(event_2.discriminator.toString(16));
+        expect(received_discriminator).toBe(Buffer.from(result.slice(0, 8)).toString('hex'));
+        expect(event_2.a).toBe(500332);
+        expect(event_2.b).toBe("ABCD");
+        expect(event_2.c).toBe("CAFE0123");
     });
 });

--- a/integration/solana/package.json
+++ b/integration/solana/package.json
@@ -17,12 +17,14 @@
     "typescript": "^4.1.2"
   },
   "dependencies": {
+    "@dao-xyz/borsh": "^3.1.0",
     "@solana/solidity": "0.0.20",
-    "@solana/web3.js": "^1.30.2 <1.40.0",
     "@solana/spl-token": "0.2.0",
+    "@solana/web3.js": "^1.30.2 <1.40.0",
     "ethers": "^5.2.0",
+    "fast-sha256": "^1.3.0",
+    "tweetnacl": "^1.0.3",
     "web3-eth-abi": "^1.3.0",
-    "web3-utils": "^1.3.0",
-    "tweetnacl": "^1.0.3"
+    "web3-utils": "^1.3.0"
   }
 }

--- a/integration/solana/tsconfig.json
+++ b/integration/solana/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "experimentalDecorators": true,
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
 
     /* Basic Options */

--- a/src/codegen/encoding/borsh_encoding.rs
+++ b/src/codegen/encoding/borsh_encoding.rs
@@ -41,7 +41,7 @@ impl AbiEncoding for BorshEncoding {
         ns: &Namespace,
         vartab: &mut Vartable,
         cfg: &mut ControlFlowGraph,
-    ) -> Expression {
+    ) -> (Expression, Expression) {
         let size = calculate_size_args(self, args, ns, vartab, cfg);
 
         let encoded_bytes = vartab.temp_name("abi_encoded", &Type::DynamicBytes);
@@ -50,7 +50,12 @@ impl AbiEncoding for BorshEncoding {
             Instr::Set {
                 loc: *loc,
                 res: encoded_bytes,
-                expr: Expression::AllocDynamicArray(*loc, Type::DynamicBytes, Box::new(size), None),
+                expr: Expression::AllocDynamicArray(
+                    *loc,
+                    Type::DynamicBytes,
+                    Box::new(size.clone()),
+                    None,
+                ),
             },
         );
 
@@ -68,7 +73,7 @@ impl AbiEncoding for BorshEncoding {
             );
         }
 
-        buffer
+        (buffer, size)
     }
 
     fn abi_decode(

--- a/src/codegen/encoding/mod.rs
+++ b/src/codegen/encoding/mod.rs
@@ -19,7 +19,7 @@ use std::ops::{AddAssign, MulAssign, Sub};
 /// This trait should be implemented by all encoding methods (ethabi, Scale and Borsh), so that
 /// we have the same interface for creating encode and decode functions.
 pub(super) trait AbiEncoding {
-    /// Receive the arguments and returns the variable containing a byte array
+    /// Receive the arguments and returns the variable containing a byte array and its size
     fn abi_encode(
         &mut self,
         loc: &Loc,
@@ -27,7 +27,7 @@ pub(super) trait AbiEncoding {
         ns: &Namespace,
         vartab: &mut Vartable,
         cfg: &mut ControlFlowGraph,
-    ) -> Expression;
+    ) -> (Expression, Expression);
 
     fn abi_decode(
         &self,

--- a/src/codegen/events/mod.rs
+++ b/src/codegen/events/mod.rs
@@ -14,7 +14,9 @@ use solang_parser::pt;
 /// This traits delineates the common behavior of event emission. As each target uses a different
 /// encoding scheme, there must be an implementation of this trait for each.
 pub(super) trait EventEmitter {
-    /// Generate the CFG instructions for emitting an event
+    /// Generate the CFG instructions for emitting an event.
+    /// All necessary code analysis should have been done during parsing and 'sema';
+    /// If code generation does not work here, there is a bug in the compiler.
     fn emit(
         &self,
         contract_no: usize,

--- a/src/codegen/events/mod.rs
+++ b/src/codegen/events/mod.rs
@@ -1,0 +1,47 @@
+mod solana;
+mod substrate;
+
+use crate::codegen::cfg::ControlFlowGraph;
+use crate::codegen::events::solana::SolanaEventEmitter;
+use crate::codegen::events::substrate::SubstrateEventEmitter;
+use crate::codegen::vartable::Vartable;
+use crate::codegen::Options;
+use crate::sema::ast;
+use crate::sema::ast::{Function, Namespace};
+use crate::Target;
+use solang_parser::pt;
+
+/// This traits delineates the common behavior of event emission. As each target uses a different
+/// encoding scheme, there must be an implementation of this trait for each.
+pub(super) trait EventEmitter {
+    /// Generate the CFG instructions for emitting an event
+    fn emit(
+        &self,
+        contract_no: usize,
+        func: &Function,
+        cfg: &mut ControlFlowGraph,
+        vartab: &mut Vartable,
+        opt: &Options,
+    );
+}
+
+/// Create a new event emitter based on the target blockchain
+pub(super) fn new_event_emitter<'a>(
+    loc: &pt::Loc,
+    event_no: usize,
+    args: &'a [ast::Expression],
+    ns: &'a Namespace,
+) -> Box<dyn EventEmitter + 'a> {
+    match ns.target {
+        Target::Substrate { .. } | Target::EVM => {
+            Box::new(SubstrateEventEmitter { args, ns, event_no })
+        }
+
+        Target::Solana => Box::new(SolanaEventEmitter {
+            loc: *loc,
+            args,
+            ns,
+            event_no,
+        }),
+    }
+}

--- a/src/codegen/events/solana.rs
+++ b/src/codegen/events/solana.rs
@@ -1,0 +1,63 @@
+use crate::codegen::cfg::{ControlFlowGraph, Instr};
+use crate::codegen::encoding::create_encoder;
+use crate::codegen::encoding::AbiEncoding;
+use crate::codegen::events::EventEmitter;
+use crate::codegen::expression::expression;
+use crate::codegen::vartable::Vartable;
+use crate::codegen::{Expression, Options};
+use crate::sema::ast;
+use crate::sema::ast::{Function, Namespace, Type};
+use sha2::{Digest, Sha256};
+use solang_parser::pt::Loc;
+
+/// This struct implements the trait 'EventEmitter' to handle the emission of events for Solana.
+pub(super) struct SolanaEventEmitter<'a> {
+    pub(super) loc: Loc,
+    /// Arguments passed to the event
+    pub(super) args: &'a [ast::Expression],
+    pub(super) ns: &'a Namespace,
+    pub(super) event_no: usize,
+}
+
+impl EventEmitter for SolanaEventEmitter<'_> {
+    fn emit(
+        &self,
+        contract_no: usize,
+        func: &Function,
+        cfg: &mut ControlFlowGraph,
+        vartab: &mut Vartable,
+        opt: &Options,
+    ) {
+        let discriminator_image = format!("event:{}", self.ns.events[self.event_no].name);
+        let mut hasher = Sha256::new();
+        hasher.update(discriminator_image.as_bytes());
+        let result = hasher.finalize();
+
+        let discriminator =
+            Expression::BytesLiteral(Loc::Codegen, Type::Bytes(8), result[..8].to_vec());
+
+        let mut codegen_args = self
+            .args
+            .iter()
+            .map(|e| expression(e, cfg, contract_no, Some(func), self.ns, vartab, opt))
+            .collect::<Vec<Expression>>();
+
+        let mut to_be_encoded: Vec<Expression> = vec![discriminator];
+        to_be_encoded.append(&mut codegen_args);
+
+        let mut encoder = create_encoder(self.ns);
+        let (abi_encoded, abi_encoded_size) =
+            encoder.abi_encode(&self.loc, &to_be_encoded, self.ns, vartab, cfg);
+
+        cfg.add(
+            vartab,
+            Instr::EmitEvent {
+                event_no: self.event_no,
+                data: vec![abi_encoded, abi_encoded_size],
+                data_tys: vec![],
+                topics: vec![],
+                topic_tys: vec![],
+            },
+        );
+    }
+}

--- a/src/codegen/events/substrate.rs
+++ b/src/codegen/events/substrate.rs
@@ -1,0 +1,108 @@
+use crate::codegen::cfg::{ControlFlowGraph, Instr};
+use crate::codegen::events::EventEmitter;
+use crate::codegen::expression::expression;
+use crate::codegen::vartable::Vartable;
+use crate::codegen::Options;
+use crate::sema::ast;
+use crate::sema::ast::{Function, Namespace, RetrieveType, Type};
+use solang_parser::pt;
+
+/// This struct implements the trait 'EventEmitter' in order to handle the emission of events
+/// for Substrate
+pub(super) struct SubstrateEventEmitter<'a> {
+    /// Arguments passed to the event
+    pub(super) args: &'a [ast::Expression],
+    pub(super) ns: &'a Namespace,
+    pub(super) event_no: usize,
+}
+
+impl EventEmitter for SubstrateEventEmitter<'_> {
+    fn emit(
+        &self,
+        contract_no: usize,
+        func: &Function,
+        cfg: &mut ControlFlowGraph,
+        vartab: &mut Vartable,
+        opt: &Options,
+    ) {
+        let mut data = Vec::new();
+        let mut data_tys = Vec::new();
+        let mut topics = Vec::new();
+        let mut topic_tys = Vec::new();
+
+        for (i, arg) in self.args.iter().enumerate() {
+            if self.ns.events[self.event_no].fields[i].indexed {
+                let ty = arg.ty();
+
+                match ty {
+                    Type::String | Type::DynamicBytes => {
+                        let e = expression(
+                            &ast::Expression::Builtin(
+                                pt::Loc::Codegen,
+                                vec![Type::Bytes(32)],
+                                ast::Builtin::Keccak256,
+                                vec![arg.clone()],
+                            ),
+                            cfg,
+                            contract_no,
+                            Some(func),
+                            self.ns,
+                            vartab,
+                            opt,
+                        );
+
+                        topics.push(e);
+                        topic_tys.push(Type::Bytes(32));
+                    }
+                    Type::Struct(_) | Type::Array(..) => {
+                        // We should have an AbiEncodePackedPad
+                        let e = expression(
+                            &ast::Expression::Builtin(
+                                pt::Loc::Codegen,
+                                vec![Type::Bytes(32)],
+                                ast::Builtin::Keccak256,
+                                vec![ast::Expression::Builtin(
+                                    pt::Loc::Codegen,
+                                    vec![Type::DynamicBytes],
+                                    ast::Builtin::AbiEncodePacked,
+                                    vec![arg.clone()],
+                                )],
+                            ),
+                            cfg,
+                            contract_no,
+                            Some(func),
+                            self.ns,
+                            vartab,
+                            opt,
+                        );
+
+                        topics.push(e);
+                        topic_tys.push(Type::Bytes(32));
+                    }
+                    _ => {
+                        let e = expression(arg, cfg, contract_no, Some(func), self.ns, vartab, opt);
+
+                        topics.push(e);
+                        topic_tys.push(ty);
+                    }
+                }
+            } else {
+                let e = expression(arg, cfg, contract_no, Some(func), self.ns, vartab, opt);
+
+                data.push(e);
+                data_tys.push(arg.ty());
+            }
+        }
+
+        cfg.add(
+            vartab,
+            Instr::EmitEvent {
+                event_no: self.event_no,
+                data,
+                data_tys,
+                topics,
+                topic_tys,
+            },
+        );
+    }
+}

--- a/src/codegen/expression.rs
+++ b/src/codegen/expression.rs
@@ -1301,7 +1301,7 @@ fn abi_encode(
 
     if ns.target == Target::Solana {
         let mut encoder = create_encoder(ns);
-        return encoder.abi_encode(loc, &args, ns, vartab, cfg);
+        return encoder.abi_encode(loc, &args, ns, vartab, cfg).0;
     }
 
     let res = vartab.temp(

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -5,6 +5,7 @@ pub mod cfg;
 mod constant_folding;
 mod dead_storage;
 mod encoding;
+mod events;
 mod expression;
 mod external_functions;
 mod reaching_definitions;

--- a/tests/solana.rs
+++ b/tests/solana.rs
@@ -2,7 +2,7 @@
 
 use base58::{FromBase58, ToBase58};
 use byteorder::{ByteOrder, LittleEndian, WriteBytesExt};
-use ethabi::{ethereum_types::H256, RawLog, Token};
+use ethabi::{RawLog, Token};
 use libc::c_char;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
@@ -1809,22 +1809,11 @@ impl VirtualMachine {
         self.events
             .iter()
             .map(|fields| {
-                assert_eq!(fields.len(), 2);
-
-                assert_eq!(fields[0].len() % 32, 0);
-                assert!(fields[0].len() <= 4 * 32);
-
-                let topics = fields[0]
-                    .chunks_exact(32)
-                    .map(|topic| {
-                        let topic: [u8; 32] = topic.try_into().unwrap();
-
-                        H256::from(topic)
-                    })
-                    .collect();
-                let data = fields[1].clone();
-
-                RawLog { topics, data }
+                assert_eq!(fields.len(), 1);
+                RawLog {
+                    topics: vec![],
+                    data: fields[0].clone(),
+                }
             })
             .collect()
     }


### PR DESCRIPTION
This PR implements the new scheme for events emission on Solana. It follows Anchor strategy for events.

[According to Anchor source code](https://github.com/coral-xyz/anchor/blob/0c70d183ef9187cef576749e4fee8f443e4dbc34/lang/attribute/event/src/lib.rs#L86-L88), `indexed` fields are emitted as data. In addition, all fields are encoded using borsh encoding, and [the result is passed directly](https://github.com/coral-xyz/anchor/blob/0c70d183ef9187cef576749e4fee8f443e4dbc34/lang/attribute/event/src/lib.rs#L77-L84) to `sol_log_data`.