### PR TITLE
Add semantic information to CFG

### DIFF
--- a/src/codegen/constant_folding.rs
+++ b/src/codegen/constant_folding.rs
@@ -22,7 +22,7 @@ pub fn constant_folding(cfg: &mut ControlFlowGraph, ns: &mut Namespace) {
         let mut vars = cfg.blocks[block_no].defs.clone();
 
         for instr_no in 0..cfg.blocks[block_no].instr.len() {
-            match &cfg.blocks[block_no].instr[instr_no] {
+            match &cfg.blocks[block_no].instr[instr_no].1 {
                 Instr::Set { loc, res, expr, .. } => {
                     let (expr, expr_constant) = expression(expr, Some(&vars), cfg, ns);
 
@@ -30,7 +30,7 @@ pub fn constant_folding(cfg: &mut ControlFlowGraph, ns: &mut Namespace) {
                         ns.var_constants.insert(*loc, expr.clone());
                     }
 
-                    cfg.blocks[block_no].instr[instr_no] = Instr::Set {
+                    cfg.blocks[block_no].instr[instr_no].1 = Instr::Set {
                         loc: *loc,
                         res: *res,
                         expr,
@@ -47,7 +47,7 @@ pub fn constant_folding(cfg: &mut ControlFlowGraph, ns: &mut Namespace) {
                         .map(|e| expression(e, Some(&vars), cfg, ns).0)
                         .collect();
 
-                    cfg.blocks[block_no].instr[instr_no] = Instr::Call {
+                    cfg.blocks[block_no].instr[instr_no].1 = Instr::Call {
                         res: res.clone(),
                         call: call.clone(),
                         args,
@@ -60,7 +60,7 @@ pub fn constant_folding(cfg: &mut ControlFlowGraph, ns: &mut Namespace) {
                         .map(|e| expression(e, Some(&vars), cfg, ns).0)
                         .collect();
 
-                    cfg.blocks[block_no].instr[instr_no] = Instr::Return { value };
+                    cfg.blocks[block_no].instr[instr_no].1 = Instr::Return { value };
                 }
                 Instr::BranchCond {
                     cond,
@@ -70,11 +70,11 @@ pub fn constant_folding(cfg: &mut ControlFlowGraph, ns: &mut Namespace) {
                     let (cond, _) = expression(cond, Some(&vars), cfg, ns);
 
                     if let Expression::BoolLiteral(_, cond) = cond {
-                        cfg.blocks[block_no].instr[instr_no] = Instr::Branch {
+                        cfg.blocks[block_no].instr[instr_no].1 = Instr::Branch {
                             block: if cond { *true_block } else { *false_block },
                         };
                     } else {
-                        cfg.blocks[block_no].instr[instr_no] = Instr::BranchCond {
+                        cfg.blocks[block_no].instr[instr_no].1 = Instr::BranchCond {
                             cond,
                             true_block: *true_block,
                             false_block: *false_block,
@@ -85,23 +85,23 @@ pub fn constant_folding(cfg: &mut ControlFlowGraph, ns: &mut Namespace) {
                     let (dest, _) = expression(dest, Some(&vars), cfg, ns);
                     let (data, _) = expression(data, Some(&vars), cfg, ns);
 
-                    cfg.blocks[block_no].instr[instr_no] = Instr::Store { dest, data };
+                    cfg.blocks[block_no].instr[instr_no].1 = Instr::Store { dest, data };
                 }
                 Instr::AssertFailure { expr: Some(expr) } => {
                     let (expr, _) = expression(expr, Some(&vars), cfg, ns);
 
-                    cfg.blocks[block_no].instr[instr_no] =
+                    cfg.blocks[block_no].instr[instr_no].1 =
                         Instr::AssertFailure { expr: Some(expr) };
                 }
                 Instr::Print { expr } => {
                     let (expr, _) = expression(expr, Some(&vars), cfg, ns);
 
-                    cfg.blocks[block_no].instr[instr_no] = Instr::Print { expr };
+                    cfg.blocks[block_no].instr[instr_no].1 = Instr::Print { expr };
                 }
                 Instr::ClearStorage { ty, storage } => {
                     let (storage, _) = expression(storage, Some(&vars), cfg, ns);
 
-                    cfg.blocks[block_no].instr[instr_no] = Instr::ClearStorage {
+                    cfg.blocks[block_no].instr[instr_no].1 = Instr::ClearStorage {
                         ty: ty.clone(),
                         storage,
                     };
@@ -110,7 +110,7 @@ pub fn constant_folding(cfg: &mut ControlFlowGraph, ns: &mut Namespace) {
                     let (storage, _) = expression(storage, Some(&vars), cfg, ns);
                     let (value, _) = expression(value, Some(&vars), cfg, ns);
 
-                    cfg.blocks[block_no].instr[instr_no] = Instr::SetStorage {
+                    cfg.blocks[block_no].instr[instr_no].1 = Instr::SetStorage {
                         ty: ty.clone(),
                         storage,
                         value,
@@ -119,7 +119,7 @@ pub fn constant_folding(cfg: &mut ControlFlowGraph, ns: &mut Namespace) {
                 Instr::LoadStorage { ty, storage, res } => {
                     let (storage, _) = expression(storage, Some(&vars), cfg, ns);
 
-                    cfg.blocks[block_no].instr[instr_no] = Instr::LoadStorage {
+                    cfg.blocks[block_no].instr[instr_no].1 = Instr::LoadStorage {
                         ty: ty.clone(),
                         storage,
                         res: *res,
@@ -134,7 +134,7 @@ pub fn constant_folding(cfg: &mut ControlFlowGraph, ns: &mut Namespace) {
                     let (value, _) = expression(value, Some(&vars), cfg, ns);
                     let (offset, _) = expression(offset, Some(&vars), cfg, ns);
 
-                    cfg.blocks[block_no].instr[instr_no] = Instr::SetStorageBytes {
+                    cfg.blocks[block_no].instr[instr_no].1 = Instr::SetStorageBytes {
                         storage,
                         value,
                         offset,
@@ -151,7 +151,7 @@ pub fn constant_folding(cfg: &mut ControlFlowGraph, ns: &mut Namespace) {
                         .as_ref()
                         .map(|expr| expression(expr, Some(&vars), cfg, ns).0);
 
-                    cfg.blocks[block_no].instr[instr_no] = Instr::PushStorage {
+                    cfg.blocks[block_no].instr[instr_no].1 = Instr::PushStorage {
                         res: *res,
                         ty: ty.clone(),
                         storage,
@@ -161,7 +161,7 @@ pub fn constant_folding(cfg: &mut ControlFlowGraph, ns: &mut Namespace) {
                 Instr::PopStorage { res, ty, storage } => {
                     let (storage, _) = expression(storage, Some(&vars), cfg, ns);
 
-                    cfg.blocks[block_no].instr[instr_no] = Instr::PopStorage {
+                    cfg.blocks[block_no].instr[instr_no].1 = Instr::PopStorage {
                         res: *res,
                         ty: ty.clone(),
                         storage,
@@ -175,7 +175,7 @@ pub fn constant_folding(cfg: &mut ControlFlowGraph, ns: &mut Namespace) {
                 } => {
                     let (value, _) = expression(value, Some(&vars), cfg, ns);
 
-                    cfg.blocks[block_no].instr[instr_no] = Instr::PushMemory {
+                    cfg.blocks[block_no].instr[instr_no].1 = Instr::PushMemory {
                         res: *res,
                         ty: ty.clone(),
                         array: *array,
@@ -208,7 +208,7 @@ pub fn constant_folding(cfg: &mut ControlFlowGraph, ns: &mut Namespace) {
                         .as_ref()
                         .map(|expr| expression(expr, Some(&vars), cfg, ns).0);
 
-                    cfg.blocks[block_no].instr[instr_no] = Instr::Constructor {
+                    cfg.blocks[block_no].instr[instr_no].1 = Instr::Constructor {
                         success: *success,
                         res: *res,
                         contract_no: *contract_no,
@@ -243,7 +243,7 @@ pub fn constant_folding(cfg: &mut ControlFlowGraph, ns: &mut Namespace) {
                         .as_ref()
                         .map(|expr| expression(expr, Some(&vars), cfg, ns).0);
 
-                    cfg.blocks[block_no].instr[instr_no] = Instr::ExternalCall {
+                    cfg.blocks[block_no].instr[instr_no].1 = Instr::ExternalCall {
                         success: *success,
                         address,
                         accounts,
@@ -263,7 +263,7 @@ pub fn constant_folding(cfg: &mut ControlFlowGraph, ns: &mut Namespace) {
                 } => {
                     let (data, _) = expression(data, Some(&vars), cfg, ns);
 
-                    cfg.blocks[block_no].instr[instr_no] = Instr::AbiDecode {
+                    cfg.blocks[block_no].instr[instr_no].1 = Instr::AbiDecode {
                         res: res.clone(),
                         selector: *selector,
                         exception_block: *exception_block,
@@ -274,7 +274,7 @@ pub fn constant_folding(cfg: &mut ControlFlowGraph, ns: &mut Namespace) {
                 Instr::SelfDestruct { recipient } => {
                     let (recipient, _) = expression(recipient, Some(&vars), cfg, ns);
 
-                    cfg.blocks[block_no].instr[instr_no] = Instr::SelfDestruct { recipient };
+                    cfg.blocks[block_no].instr[instr_no].1 = Instr::SelfDestruct { recipient };
                 }
                 Instr::EmitEvent {
                     event_no,
@@ -293,7 +293,7 @@ pub fn constant_folding(cfg: &mut ControlFlowGraph, ns: &mut Namespace) {
                         .map(|e| expression(e, Some(&vars), cfg, ns).0)
                         .collect();
 
-                    cfg.blocks[block_no].instr[instr_no] = Instr::EmitEvent {
+                    cfg.blocks[block_no].instr[instr_no].1 = Instr::EmitEvent {
                         event_no: *event_no,
                         data,
                         data_tys: data_tys.clone(),
@@ -309,7 +309,7 @@ pub fn constant_folding(cfg: &mut ControlFlowGraph, ns: &mut Namespace) {
                     let bytes = expression(bytes, Some(&vars), cfg, ns);
                     let source = expression(source, Some(&vars), cfg, ns);
                     let destination = expression(destination, Some(&vars), cfg, ns);
-                    cfg.blocks[block_no].instr[instr_no] = Instr::MemCopy {
+                    cfg.blocks[block_no].instr[instr_no].1 = Instr::MemCopy {
                         source: source.0,
                         destination: destination.0,
                         bytes: bytes.0,
@@ -1159,7 +1159,7 @@ fn get_definition<'a>(
     def: &reaching_definitions::Def,
     cfg: &'a ControlFlowGraph,
 ) -> Option<&'a Expression> {
-    if let Instr::Set { expr, .. } = &cfg.blocks[def.block_no].instr[def.instr_no] {
+    if let Instr::Set { expr, .. } = &cfg.blocks[def.block_no].instr[def.instr_no].1 {
         Some(expr)
     } else {
         None

--- a/src/codegen/reaching_definitions.rs
+++ b/src/codegen/reaching_definitions.rs
@@ -98,7 +98,7 @@ pub fn find(cfg: &mut ControlFlowGraph) {
 fn instr_transfers(block_no: usize, block: &BasicBlock) -> Vec<Vec<Transfer>> {
     let mut transfers = Vec::new();
 
-    for (instr_no, instr) in block.instr.iter().enumerate() {
+    for (instr_no, (_, instr)) in block.instr.iter().enumerate() {
         let set_var = |var_nos: &[usize]| {
             let mut transfer = Vec::new();
 
@@ -228,7 +228,7 @@ pub fn block_edges(block: &BasicBlock) -> Vec<usize> {
 
     // out cfg has edge as the last instruction in a block; EXCEPT
     // Instr::AbiDecode() which has an edge when decoding fails
-    for instr in &block.instr {
+    for (_, instr) in &block.instr {
         match instr {
             Instr::Branch { block } => {
                 out.push(*block);

--- a/src/codegen/strength_reduce/mod.rs
+++ b/src/codegen/strength_reduce/mod.rs
@@ -101,7 +101,7 @@ fn block_reduce(
     mut vars: Variables,
     ns: &mut Namespace,
 ) {
-    for instr in &mut cfg.blocks[block_no].instr {
+    for (_, instr) in &mut cfg.blocks[block_no].instr {
         match instr {
             Instr::Set { expr, .. } => {
                 *expr = expression_reduce(expr, &vars, ns);

--- a/src/codegen/strength_reduce/reaching_values.rs
+++ b/src/codegen/strength_reduce/reaching_values.rs
@@ -36,7 +36,7 @@ pub(super) fn reaching_values(
         block_vars.insert(block_no, vars.clone());
     }
 
-    for instr in &cfg.blocks[block_no].instr {
+    for (_, instr) in &cfg.blocks[block_no].instr {
         transfer(instr, vars, ns);
 
         match instr {

--- a/src/codegen/undefined_variable.rs
+++ b/src/codegen/undefined_variable.rs
@@ -29,7 +29,7 @@ pub fn find_undefined_variables(
     let mut diagnostics: HashMap<usize, Diagnostic> = HashMap::new();
     for block in &cfg.blocks {
         let mut var_defs: VarDefs = block.defs.clone();
-        for (instr_no, instruction) in block.instr.iter().enumerate() {
+        for (instr_no, (_, instruction)) in block.instr.iter().enumerate() {
             check_variables_in_expression(
                 func_no,
                 instruction,
@@ -94,7 +94,7 @@ pub fn find_undefined_variables_in_expression(
                 for (def, modified) in def_map {
                     if let Instr::Set {
                         expr: instr_expr, ..
-                    } = &ctx.cfg.blocks[def.block_no].instr[def.instr_no]
+                    } = &ctx.cfg.blocks[def.block_no].instr[def.instr_no].1
                     {
                         // If an undefined definition reaches this read and the variable
                         // has not been modified since its definition, it is undefined

--- a/src/codegen/vector_to_slice.rs
+++ b/src/codegen/vector_to_slice.rs
@@ -37,7 +37,7 @@ fn find_writable_vectors(
     writable: &mut HashSet<Def>,
 ) {
     for instr_no in 0..block.instr.len() {
-        match &block.instr[instr_no] {
+        match &block.instr[instr_no].1 {
             Instr::Set {
                 res,
                 expr: Expression::Variable(_, _, var_no),
@@ -174,7 +174,7 @@ fn update_vectors_to_slice(
             if let Instr::Set {
                 expr: Expression::AllocDynamicArray(..),
                 ..
-            } = &cfg.blocks[block_no].instr[instr_no]
+            } = &cfg.blocks[block_no].instr[instr_no].1
             {
                 let cur = Def {
                     block_no,
@@ -213,10 +213,10 @@ fn update_vectors_to_slice(
             loc,
             res,
             expr: Expression::AllocDynamicArray(_, _, len, Some(bs)),
-        } = &cfg.blocks[def.block_no].instr[def.instr_no]
+        } = &cfg.blocks[def.block_no].instr[def.instr_no].1
         {
             let res = *res;
-            cfg.blocks[def.block_no].instr[def.instr_no] = Instr::Set {
+            cfg.blocks[def.block_no].instr[def.instr_no].1 = Instr::Set {
                 loc: *loc,
                 res,
                 expr: Expression::AllocDynamicArray(

--- a/src/codegen/yul/builtin.rs
+++ b/src/codegen/yul/builtin.rs
@@ -178,12 +178,12 @@ pub(crate) fn process_builtin(
 
         YulBuiltInFunction::SelfDestruct => {
             let recipient = expression(&args[0], contract_no, ns, vartab, cfg, opt).cast(&Type::Address(true), ns);
-            cfg.add(vartab, Instr::SelfDestruct { recipient });
+            cfg.add_yul(vartab, Instr::SelfDestruct { recipient });
             Expression::Poison
         }
 
         YulBuiltInFunction::Invalid => {
-            cfg.add(vartab, Instr::AssertFailure { expr: None });
+            cfg.add_yul(vartab, Instr::AssertFailure { expr: None });
             Expression::Poison
         }
 
@@ -373,7 +373,7 @@ fn branch_if_zero(
     let then = cfg.new_basic_block("then".to_string());
     let else_ = cfg.new_basic_block("else".to_string());
     let endif = cfg.new_basic_block("endif".to_string());
-    cfg.add(
+    cfg.add_yul(
         vartab,
         Instr::BranchCond {
             cond,
@@ -384,7 +384,7 @@ fn branch_if_zero(
 
     cfg.set_basic_block(then);
     vartab.new_dirty_tracker();
-    cfg.add(
+    cfg.add_yul(
         vartab,
         Instr::Set {
             loc: pt::Loc::Codegen,
@@ -392,10 +392,10 @@ fn branch_if_zero(
             expr: Expression::NumberLiteral(pt::Loc::Codegen, Type::Uint(256), BigInt::from(0)),
         },
     );
-    cfg.add(vartab, Instr::Branch { block: endif });
+    cfg.add_yul(vartab, Instr::Branch { block: endif });
 
     cfg.set_basic_block(else_);
-    cfg.add(
+    cfg.add_yul(
         vartab,
         Instr::Set {
             loc: pt::Loc::Codegen,
@@ -403,7 +403,7 @@ fn branch_if_zero(
             expr: codegen_expr,
         },
     );
-    cfg.add(vartab, Instr::Branch { block: endif });
+    cfg.add_yul(vartab, Instr::Branch { block: endif });
     cfg.set_phis(endif, vartab.pop_dirty_tracker());
     cfg.set_basic_block(endif);
 
@@ -437,7 +437,7 @@ fn byte_builtin(
     let else_ = cfg.new_basic_block("else".to_string());
     let endif = cfg.new_basic_block("endif".to_string());
 
-    cfg.add(
+    cfg.add_yul(
         vartab,
         Instr::BranchCond {
             cond,
@@ -448,7 +448,7 @@ fn byte_builtin(
 
     cfg.set_basic_block(then);
     vartab.new_dirty_tracker();
-    cfg.add(
+    cfg.add_yul(
         vartab,
         Instr::Set {
             loc: pt::Loc::Codegen,
@@ -456,7 +456,7 @@ fn byte_builtin(
             expr: Expression::NumberLiteral(pt::Loc::Codegen, Type::Uint(256), BigInt::zero()),
         },
     );
-    cfg.add(vartab, Instr::Branch { block: endif });
+    cfg.add_yul(vartab, Instr::Branch { block: endif });
 
     cfg.set_basic_block(else_);
 
@@ -502,7 +502,7 @@ fn byte_builtin(
         )),
     );
 
-    cfg.add(
+    cfg.add_yul(
         vartab,
         Instr::Set {
             loc: *loc,
@@ -510,7 +510,7 @@ fn byte_builtin(
             expr: masked_result,
         },
     );
-    cfg.add(vartab, Instr::Branch { block: endif });
+    cfg.add_yul(vartab, Instr::Branch { block: endif });
 
     cfg.set_phis(endif, vartab.pop_dirty_tracker());
     cfg.set_basic_block(endif);

--- a/src/codegen/yul/expression.rs
+++ b/src/codegen/yul/expression.rs
@@ -214,7 +214,7 @@ pub(crate) fn process_function_call(
     let cfg_no = ns.yul_functions[function_no].cfg_no;
 
     if ns.yul_functions[function_no].returns.is_empty() {
-        cfg.add(
+        cfg.add_yul(
             vartab,
             Instr::Call {
                 res: Vec::new(),
@@ -243,7 +243,7 @@ pub(crate) fn process_function_call(
         returns.push(Expression::Variable(id.loc, ret.ty.clone(), temp_pos));
     }
 
-    cfg.add(
+    cfg.add_yul(
         vartab,
         Instr::Call {
             res,

--- a/src/codegen/yul/mod.rs
+++ b/src/codegen/yul/mod.rs
@@ -113,7 +113,7 @@ fn yul_function_cfg(
     if yul_func.body.is_empty()
         || (!yul_func.body.is_empty() && yul_func.body.last().unwrap().is_reachable())
     {
-        cfg.add(&mut vartab, returns);
+        cfg.add_yul(&mut vartab, returns);
     }
 
     let (vars, next_id) = vartab.drain();

--- a/src/codegen/yul/statements.rs
+++ b/src/codegen/yul/statements.rs
@@ -96,14 +96,14 @@ pub(crate) fn statement(
 
         YulStatement::Leave(..) => {
             if let Some(early_leave) = early_return {
-                cfg.add(vartab, early_leave.clone());
+                cfg.add_yul(vartab, early_leave.clone());
             } else {
-                cfg.add(vartab, Instr::Return { value: vec![] });
+                cfg.add_yul(vartab, Instr::Return { value: vec![] });
             }
         }
 
         YulStatement::Break(..) => {
-            cfg.add(
+            cfg.add_yul(
                 vartab,
                 Instr::Branch {
                     block: loops.do_break(),
@@ -112,7 +112,7 @@ pub(crate) fn statement(
         }
 
         YulStatement::Continue(..) => {
-            cfg.add(
+            cfg.add_yul(
                 vartab,
                 Instr::Branch {
                     block: loops.do_continue(),
@@ -149,7 +149,7 @@ fn process_variable_declaration(
     };
 
     for (var_index, item) in vars.iter().enumerate() {
-        cfg.add(
+        cfg.add_yul(
             vartab,
             Instr::Set {
                 loc: *loc,
@@ -203,7 +203,7 @@ fn cfg_single_assigment(
         | ast::YulExpression::SolidityLocalVariable(_, ty, None, var_no) => {
             // Ensure both types are compatible
             let rhs = rhs.cast(ty, ns);
-            cfg.add(
+            cfg.add_yul(
                 vartab,
                 Instr::Set {
                     loc: *loc,
@@ -221,7 +221,7 @@ fn cfg_single_assigment(
         ) => {
             // This is an assignment to a pointer, so we make sure the rhs has a compatible size
             let rhs = rhs.cast(ty, ns);
-            cfg.add(
+            cfg.add_yul(
                 vartab,
                 Instr::Set {
                     loc: *loc,
@@ -241,7 +241,7 @@ fn cfg_single_assigment(
                 ) => match suffix {
                     YulSuffix::Offset => {
                         let rhs = rhs.cast(&lhs.ty(), ns);
-                        cfg.add(
+                        cfg.add_yul(
                             vartab,
                             Instr::Set {
                                 loc: *loc,
@@ -277,7 +277,7 @@ fn cfg_single_assigment(
                         member_no,
                     );
 
-                    cfg.add(
+                    cfg.add_yul(
                         vartab,
                         Instr::Store {
                             dest: ptr,
@@ -295,7 +295,7 @@ fn cfg_single_assigment(
                     // This assignment changes the value of a pointer to storage
                     if matches!(suffix, YulSuffix::Slot) {
                         let rhs = rhs.cast(&lhs.ty(), ns);
-                        cfg.add(
+                        cfg.add_yul(
                             vartab,
                             Instr::Set {
                                 loc: *loc,
@@ -354,7 +354,7 @@ fn process_if_block(
     let then = cfg.new_basic_block("then".to_string());
     let endif = cfg.new_basic_block("endif".to_string());
 
-    cfg.add(
+    cfg.add_yul(
         vartab,
         Instr::BranchCond {
             cond: bool_cond,
@@ -371,7 +371,7 @@ fn process_if_block(
     }
 
     if block.is_next_reachable() {
-        cfg.add(vartab, Instr::Branch { block: endif });
+        cfg.add_yul(vartab, Instr::Branch { block: endif });
     }
 
     cfg.set_phis(endif, vartab.pop_dirty_tracker());
@@ -407,7 +407,7 @@ fn process_for_block(
     let body_block = cfg.new_basic_block("body".to_string());
     let end_block = cfg.new_basic_block("end_for".to_string());
 
-    cfg.add(vartab, Instr::Branch { block: cond_block });
+    cfg.add_yul(vartab, Instr::Branch { block: cond_block });
     cfg.set_basic_block(cond_block);
 
     let cond_expr = expression(condition, contract_no, ns, vartab, cfg, opt);
@@ -426,7 +426,7 @@ fn process_for_block(
         )
     };
 
-    cfg.add(
+    cfg.add_yul(
         vartab,
         Instr::BranchCond {
             cond: cond_expr,
@@ -444,7 +444,7 @@ fn process_for_block(
     }
 
     if execution_block.is_next_reachable() {
-        cfg.add(vartab, Instr::Branch { block: next_block });
+        cfg.add_yul(vartab, Instr::Branch { block: next_block });
     }
 
     loops.leave_scope();
@@ -456,7 +456,7 @@ fn process_for_block(
     }
 
     if post_block.is_next_reachable() {
-        cfg.add(vartab, Instr::Branch { block: cond_block });
+        cfg.add_yul(vartab, Instr::Branch { block: cond_block });
     }
 
     cfg.set_basic_block(end_block);

--- a/src/emit/mod.rs
+++ b/src/emit/mod.rs
@@ -3297,7 +3297,7 @@ pub trait TargetRuntime<'a> {
                         di_flags,
                     );
 
-                    let func_loc = cfg.blocks[0].instr.first().unwrap().loc();
+                    let func_loc = cfg.blocks[0].instr.first().unwrap().1.loc();
                     let line_num = if let Loc::File(file_offset, offset, _) = func_loc {
                         let (line, _) = ns.files[file_offset].offset_to_line_column(offset);
                         line
@@ -3437,7 +3437,7 @@ pub trait TargetRuntime<'a> {
                 w.vars.get_mut(v).unwrap().value = (*phi).as_basic_value();
             }
 
-            for ins in &cfg.blocks[w.block_no].instr {
+            for (_, ins) in &cfg.blocks[w.block_no].instr {
                 if bin.generate_debug_info {
                     let debug_loc = ins.loc();
                     if let Loc::File(file_offset, offset, _) = debug_loc {


### PR DESCRIPTION
This PR should help @salaheldinsoliman implement overflow detection for constants in the CFG. It adds information about the origin of each instruction to the CFG. Each instruction is now classified either as from Solidity, Yul or Codegen.