### PR TITLE
Release v0.1.13: Genoa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,60 @@
 All notable changes to [Solang](https://github.com/hyperledger/solang/)
 will be documented here.
 
-## Unreleased
+## v0.1.13 Genoa
+
+### Changed
+- Introduce sub-commands to the CLI. Now we have dedicated sub-commands for
+  `compile`, `doc`, `shell-completion` and the `language-server`, which makes
+  for a cleaner CLI.
+  [seanyoung](https://github.com/seanyoung)
+- On Solana, emitted events are encoded with Borsh encoding following the Anchor
+  format.
+  [LucasSte](https://github.com/LucasSte)
+- The ewasm target has been removed, since ewasm is not going to implemented on
+  Ethereum. The target has been reused for an new EVM target, which is not complete
+  yet.
+  [seanyoung](https://github.com/seanyoung)
+- Substrate: Concrete contracts must now have at least one public function. A
+  public function is in a contract, if it has public or external functions, if
+  it has a receive or any fallback function or if it has public storage items
+  (those will yield public getters). This aligns solang up with `ink!`.
+  [xermicus](https://github.com/xermicus)
 
 ### Added
+- Solana v1.11 is now supported.
+  [seanyoung](https://github.com/seanyoung)
 - On Solana, programs now use a custom heap implementation, just like on
   Substrate. As result, it is now possible to `.push()` and `.pop()` on
   dynamic arrays in memory.
+  [seanyoung](https://github.com/seanyoung)
+- Arithmetic overflow tests are implemented for all integer widths,
+  [salaheldinsoliman](https://github.com/salaheldinsoliman)
+- Add an NFT example for Solana
+  [LucasSte](https://github.com/LucasSte)
+- Add a wrapper for the Solana System Program
+  [LucasSte](https://github.com/LucasSte)
+- The selector for functions can be overriden with the `selector=hex"abcd0123"`
+  syntax.
+  [seanyoung](https://github.com/seanyoung)
+- Shell completion is available using the `solang shell-completion` subcommand.
+  [xermicus](https://github.com/xermicus)
+- Add support for the `create_program_address()` and `try_find_program_address()`
+  system call on Solana
+  [seanyoung](https://github.com/seanyoung)
+- Substrate: The `print()` builtin is now supported and will write to the debug
+  buffer. Additionally, error messages from the `require` statements will now be
+  written to the debug buffer as well. The Substrate contracts pallet prints the
+  contents of the debug buffer to the console for RPC ("dry-run") calls in case
+  the `runtime::contracts=debug` log level is configured.
+  [xermicus](https://github.com/xermicus)
+
+### Fixed
+- DocComments `/** ... */` are now permitted anywhere.
+  [seanyoung](https://github.com/seanyoung)
+- Function calls to contract functions via contract name are no longer possible,
+  except for functions of base contracts.
+  [xermicus](https://github.com/xermicus)
 
 ## v0.1.12 Cairo
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solang"
-version = "0.1.12"
+version = "0.1.13"
 authors = ["Sean Young <sean@mess.org>"]
 homepage = "https://github.com/hyperledger/solang"
 documentation = "https://solang.readthedocs.io/"
@@ -46,7 +46,7 @@ itertools = "0.10"
 num-rational = "0.4"
 indexmap = "1.8"
 once_cell = "1.10"
-solang-parser = { path = "solang-parser", version = "0.1.17" }
+solang-parser = { path = "solang-parser", version = "0.1.18" }
 codespan-reporting = "0.11"
 phf = "0.10.1"
 rust-lapper = "1.0"

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -28,11 +28,11 @@ Option 2: Download release binaries
 
 There are binaries available on github releases:
 
-- `Linux x86-64 <https://github.com/hyperledger/solang/releases/download/v0.1.12/solang-linux-x86-64>`_
-- `Linux arm64 <https://github.com/hyperledger/solang/releases/download/v0.1.12/solang-linux-arm64>`_
-- `Windows x64 <https://github.com/hyperledger/solang/releases/download/v0.1.12/solang.exe>`_
-- `MacOS intel <https://github.com/hyperledger/solang/releases/download/v0.1.12/solang-mac-intel>`_
-- `MacOS arm <https://github.com/hyperledger/solang/releases/download/v0.1.12/solang-mac-arm>`_
+- `Linux x86-64 <https://github.com/hyperledger/solang/releases/download/v0.1.13/solang-linux-x86-64>`_
+- `Linux arm64 <https://github.com/hyperledger/solang/releases/download/v0.1.13/solang-linux-arm64>`_
+- `Windows x64 <https://github.com/hyperledger/solang/releases/download/v0.1.13/solang.exe>`_
+- `MacOS intel <https://github.com/hyperledger/solang/releases/download/v0.1.13/solang-mac-intel>`_
+- `MacOS arm <https://github.com/hyperledger/solang/releases/download/v0.1.13/solang-mac-arm>`_
 
 On MacOS, remember to give execution permission to the file and remove it from quarantine by executing the following commands:
 
@@ -53,7 +53,7 @@ Option 3: Use ghcr.io/hyperledger/solang containers
 
 New images are automatically made available on
 `solang containers <https://github.com/hyperledger/solang/pkgs/container/solang>`_.
-There is a release `v0.1.12` tag and a `latest` tag:
+There is a release `v0.1.13` tag and a `latest` tag:
 
 .. code-block:: bash
 
@@ -110,7 +110,7 @@ These patches make it possible to generate code for Solana, and fixes some
 concurrency issues in the lld linker.
 
 You can either download the pre-built libraries from
-`github <https://github.com/hyperledger/solang/releases/tag/v0.1.12>`_
+`github <https://github.com/hyperledger/solang/releases/tag/v0.1.13>`_
 or :ref:`build your own from source <llvm-from-source>`. After that, you need to add the ``bin`` directory to your
 path, so that the build system of Solang can find the correct version of LLVM to use.
 
@@ -118,7 +118,7 @@ Linux
 ~~~~~
 
 A pre-built version of LLVM, specifically configured for Solang, is available at
-`<https://github.com/hyperledger/solang/releases/download/v0.1.12/llvm13.0-linux-x86-64.tar.xz>`_.
+`<https://github.com/hyperledger/solang/releases/download/v0.1.13/llvm13.0-linux-x86-64.tar.xz>`_.
 After downloading, untar the file in a terminal and add it to your path.
 
 .. code-block:: bash
@@ -130,7 +130,7 @@ Windows
 ~~~~~~~
 
 A pre-built version of LLVM, specifically configured for Solang, is available at
-`<https://github.com/hyperledger/solang/releases/download/v0.1.12/llvm13.0-win.zip>`_.
+`<https://github.com/hyperledger/solang/releases/download/v0.1.13/llvm13.0-win.zip>`_.
 
 After unzipping the file, add the bin directory to your path.
 
@@ -142,8 +142,8 @@ Mac
 ~~~
 
 A pre-built version of LLVM for intel macs, is available at
-`<https://github.com/hyperledger/solang/releases/download/v0.1.12/llvm13.0-mac-intel.tar.xz>`_ and for arm macs there is
-`<https://github.com/hyperledger/solang/releases/download/v0.1.12/llvm13.0-mac-arm.tar.xz>`_. After downloading,
+`<https://github.com/hyperledger/solang/releases/download/v0.1.13/llvm13.0-mac-intel.tar.xz>`_ and for arm macs there is
+`<https://github.com/hyperledger/solang/releases/download/v0.1.13/llvm13.0-mac-arm.tar.xz>`_. After downloading,
 untar the file in a terminal and add it to your path like so:
 
 .. code-block:: bash

--- a/solang-parser/Cargo.toml
+++ b/solang-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solang-parser"
-version = "0.1.17"
+version = "0.1.18"
 authors = ["Sean Young <sean@mess.org>"]
 homepage = "https://github.com/hyperledger/solang"
 documentation = "https://solang.readthedocs.io/"


### PR DESCRIPTION
v0.1.13 Genoa

### Changed
- Introduce sub-commands to the CLI. Now we have dedicated sub-commands for
  `compile`, `doc`, `shell-completion` and the `language-server`, which makes
  for a cleaner CLI.
  [seanyoung](https://github.com/seanyoung)
- On Solana, emitted events are encoded with Borsh encoding following the Anchor
  format.
  [LucasSte](https://github.com/LucasSte)
- The ewasm target has been removed, since ewasm is not going to implemented on
  Ethereum. The target has been reused for an new EVM target, which is not complete
  yet.
  [seanyoung](https://github.com/seanyoung)
- Substrate: Concrete contracts must now have at least one public function. A
  public function is in a contract, if it has public or external functions, if
  it has a receive or any fallback function or if it has public storage items
  (those will yield public getters). This aligns solang up with `ink!`.
  [xermicus](https://github.com/xermicus)

### Added
- Solana v1.11 is now supported.
  [seanyoung](https://github.com/seanyoung)
- On Solana, programs now use a custom heap implementation, just like on
  Substrate. As result, it is now possible to `.push()` and `.pop()` on
  dynamic arrays in memory.
  [seanyoung](https://github.com/seanyoung)
- Arithmetic overflow tests are implemented for all integer widths,
  [salaheldinsoliman](https://github.com/salaheldinsoliman)
- Add an NFT example for Solana
  [LucasSte](https://github.com/LucasSte)
- Add a wrapper for the Solana System Program
  [LucasSte](https://github.com/LucasSte)
- The selector for functions can be overriden with the `selector=hex"abcd0123"`
  syntax.
  [seanyoung](https://github.com/seanyoung)
- Shell completion is available using the `solang shell-completion` subcommand.
  [xermicus]([https://github.com/xermicus)
- Add support for the `create_program_address()` and `try_find_program_address()`
  system call on Solana
  [seanyoung](https://github.com/seanyoung)
- Substrate: The `print()` builtin is now supported and will write to the debug
  buffer. Additionally, error messages from the `require` statements will now be
  written to the debug buffer as well. The Substrate contracts pallet prints the
  contents of the debug buffer to the console for RPC ("dry-run") calls in case
  the `runtime::contracts=debug` log level is configured.
  [xermicus](https://github.com/xermicus)

### Fixed
- DocComments `/** ... */` are now permitted anywhere.
  [seanyoung](https://github.com/seanyoung)
- Function calls to contract functions via contract name are no longer possible,
  except for functions of base contracts.
  [xermicus](https://github.com/xermicus)
