### PR TITLE
Post release cleanups

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,20 +241,6 @@ jobs:
         asset_name: solang-mac
         tag: ${{ github.ref }}
 
-  container:
-    name: Container Image
-    runs-on: ubuntu-20.04
-    if: ${{ github.repository_owner != 'hyperledger' }}
-    steps:
-    - name: Checkout sources
-      uses: actions/checkout@v2
-    - run:
-        docker build . -t ghcr.io/${GITHUB_REPOSITORY}:${GITHUB_REF/refs\/tags\//}
-            --label org.opencontainers.image.description="Solidity Compiler for Solana and Substrate version $(git describe --tags)"
-    - run: |
-        echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
-        docker push ghcr.io/${GITHUB_REPOSITORY}:${GITHUB_REF/refs\/tags\//}
-
   container-multiarch:
     name: Multiarch Container Image
     runs-on: linux-arm64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,7 +104,7 @@ jobs:
         fetch-depth: 0
         submodules: recursive
     - name: Download LLVM
-      run: curl -sSL -o c:\llvm.zip https://github.com/hyperledger/solang/releases/download/v0.1.12/llvm13.0-win.zip
+      run: curl -sSL -o c:\llvm.zip https://github.com/hyperledger/solang/releases/download/v0.1.13/llvm13.0-win.zip
     - name: Extract LLVM
       run: unzip c:\llvm.zip -d c:/
     - name: Add LLVM to Path
@@ -139,7 +139,7 @@ jobs:
         fetch-depth: 0
         submodules: recursive
     - name: Get LLVM
-      run: curl -L --output llvm13.0-mac-arm.tar.xz https://github.com/hyperledger/solang/releases/download/v0.1.12/llvm13.0-mac-arm.tar.xz
+      run: curl -L --output llvm13.0-mac-arm.tar.xz https://github.com/hyperledger/solang/releases/download/v0.1.13/llvm13.0-mac-arm.tar.xz
     - name: Extract LLVM
       run: tar Jxf llvm13.0-mac-arm.tar.xz
     - name: Add LLVM to Path
@@ -164,7 +164,7 @@ jobs:
         fetch-depth: 0
         submodules: recursive
     - name: Get LLVM
-      run: wget -q -O llvm13.0-mac-intel.tar.xz https://github.com/hyperledger/solang/releases/download/v0.1.12/llvm13.0-mac-intel.tar.xz
+      run: wget -q -O llvm13.0-mac-intel.tar.xz https://github.com/hyperledger/solang/releases/download/v0.1.13/llvm13.0-mac-intel.tar.xz
     - name: Extract LLVM
       run: tar Jxf llvm13.0-mac-intel.tar.xz
     - name: Add LLVM to Path
@@ -197,7 +197,7 @@ jobs:
         name: solang-mac
         path: solang-mac
 
-  image-multiarch:
+  container-multiarch:
     name: Multiarch Container Image
     runs-on: linux-arm64
     if: ${{ github.repository_owner == 'hyperledger' }}

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -4,7 +4,7 @@
 	"description": "Use the solang compiler for syntax highlighting, compiler warnings and errors, and hovers",
 	"publisher": "solang",
 	"author": "Shivam Balikondwar <shivambalikondwar@icloud.com>",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"repository": "github.com/hyperledger/solang",
 	"engines": {
 		"vscode": "^1.43.0"


### PR DESCRIPTION
- Use v0.1.3 label
- Remove unused parts of workflow
- vscode extension 0.3.1 was published