### PR TITLE
On Solana, stack allocations must happen in the first block

### DIFF
--- a/src/emit/instructions.rs
+++ b/src/emit/instructions.rs
@@ -580,10 +580,10 @@ pub(super) fn process_instruction<'a, T: TargetRuntime<'a> + ?Sized>(
                 .map(|p| expression(target, bin, p, &w.vars, function, ns).into())
                 .collect::<Vec<BasicMetadataValueEnum>>();
 
-            let func = &ns.functions[*ast_func_no];
+            let callee = &ns.functions[*ast_func_no];
 
             if !res.is_empty() {
-                for v in func.returns.iter() {
+                for v in callee.returns.iter() {
                     parms.push(if ns.target == Target::Solana {
                         bin.build_alloca(function, bin.llvm_var_ty(&v.ty, ns), v.name_as_str())
                             .into()
@@ -595,7 +595,7 @@ pub(super) fn process_instruction<'a, T: TargetRuntime<'a> + ?Sized>(
                 }
             }
 
-            let ret = target.builtin_function(bin, func, &parms, ns);
+            let ret = target.builtin_function(bin, function, callee, &parms, ns);
 
             let success = bin.builder.build_int_compare(
                 IntPredicate::EQ,
@@ -615,7 +615,7 @@ pub(super) fn process_instruction<'a, T: TargetRuntime<'a> + ?Sized>(
             bin.builder.position_at_end(success_block);
 
             if !res.is_empty() {
-                for (i, v) in func.returns.iter().enumerate() {
+                for (i, v) in callee.returns.iter().enumerate() {
                     let val = bin
                         .builder
                         .build_load(parms[args.len() + i].into_pointer_value(), v.name_as_str());

--- a/src/emit/mod.rs
+++ b/src/emit/mod.rs
@@ -248,7 +248,8 @@ pub trait TargetRuntime<'a> {
     fn builtin_function(
         &self,
         binary: &Binary<'a>,
-        func: &Function,
+        function: FunctionValue<'a>,
+        builtin_func: &Function,
         args: &[BasicMetadataValueEnum<'a>],
         ns: &Namespace,
     ) -> BasicValueEnum<'a>;

--- a/src/emit/solana/target.rs
+++ b/src/emit/solana/target.rs
@@ -1452,11 +1452,12 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
     fn builtin_function(
         &self,
         binary: &Binary<'a>,
-        func: &ast::Function,
+        function: FunctionValue<'a>,
+        builtin_func: &ast::Function,
         args: &[BasicMetadataValueEnum<'a>],
         ns: &ast::Namespace,
     ) -> BasicValueEnum<'a> {
-        if func.name == "create_program_address" {
+        if builtin_func.name == "create_program_address" {
             let func = binary
                 .module
                 .get_function("sol_create_program_address")
@@ -1483,9 +1484,7 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
             );
 
             // address
-            let address = binary
-                .builder
-                .build_alloca(binary.address_type(ns), "address");
+            let address = binary.build_alloca(function, binary.address_type(ns), "address");
 
             binary
                 .builder
@@ -1506,7 +1505,7 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
                 .try_as_basic_value()
                 .left()
                 .unwrap()
-        } else if func.name == "try_find_program_address" {
+        } else if builtin_func.name == "try_find_program_address" {
             let func = binary
                 .module
                 .get_function("sol_try_find_program_address")
@@ -1533,9 +1532,7 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
             );
 
             // address
-            let address = binary
-                .builder
-                .build_alloca(binary.address_type(ns), "address");
+            let address = binary.build_alloca(function, binary.address_type(ns), "address");
 
             binary
                 .builder

--- a/src/emit/substrate/target.rs
+++ b/src/emit/substrate/target.rs
@@ -2410,7 +2410,8 @@ impl<'a> TargetRuntime<'a> for SubstrateTarget {
     fn builtin_function(
         &self,
         _binary: &Binary<'a>,
-        _func: &Function,
+        _function: FunctionValue<'a>,
+        _builtin_func: &Function,
         _args: &[BasicMetadataValueEnum<'a>],
         _ns: &Namespace,
     ) -> BasicValueEnum<'a> {


### PR DESCRIPTION
If not, the Solana llvm target will fail to generate code with the error:

Unsupported dynamic stack allocation on create_program_address

Fixes https://github.com/hyperledger/solang/issues/1019

Signed-off-by: Sean Young <sean@mess.org>