### PR TITLE
Create switch instruction

### DIFF
--- a/src/codegen/constant_folding.rs
+++ b/src/codegen/constant_folding.rs
@@ -315,6 +315,22 @@ pub fn constant_folding(cfg: &mut ControlFlowGraph, ns: &mut Namespace) {
                         bytes: bytes.0,
                     };
                 }
+                Instr::Switch {
+                    cond,
+                    cases,
+                    default,
+                } => {
+                    let cond = expression(cond, Some(&vars), cfg, ns);
+                    let cases = cases
+                        .iter()
+                        .map(|(exp, goto)| (expression(exp, Some(&vars), cfg, ns).0, *goto))
+                        .collect::<Vec<(Expression, usize)>>();
+                    cfg.blocks[block_no].instr[instr_no].1 = Instr::Switch {
+                        cond: cond.0,
+                        cases,
+                        default: *default,
+                    };
+                }
                 _ => (),
             }
 

--- a/src/codegen/reaching_definitions.rs
+++ b/src/codegen/reaching_definitions.rs
@@ -223,7 +223,8 @@ pub fn apply_transfers(transfers: &[Transfer], vars: &mut IndexMap<usize, IndexM
     }
 }
 
-pub fn block_edges(block: &BasicBlock) -> Vec<usize> {
+/// Fetch the blocks that can be executed after the block passed as argument
+pub(super) fn block_edges(block: &BasicBlock) -> Vec<usize> {
     let mut out = Vec::new();
 
     // out cfg has edge as the last instruction in a block; EXCEPT
@@ -246,6 +247,12 @@ pub fn block_edges(block: &BasicBlock) -> Vec<usize> {
                 ..
             } => {
                 out.push(*block);
+            }
+            Instr::Switch { default, cases, .. } => {
+                out.push(*default);
+                for (_, goto) in cases {
+                    out.push(*goto);
+                }
             }
             _ => (),
         }

--- a/src/codegen/subexpression_elimination/instruction.rs
+++ b/src/codegen/subexpression_elimination/instruction.rs
@@ -164,6 +164,13 @@ impl AvailableExpressionSet {
                 let _ = self.gen_expression(bytes, ave, cst);
             }
 
+            Instr::Switch { cond, cases, .. } => {
+                let _ = self.gen_expression(cond, ave, cst);
+                for (case, _) in cases {
+                    let _ = self.gen_expression(case, ave, cst);
+                }
+            }
+
             Instr::AssertFailure { expr: None }
             | Instr::Unreachable
             | Instr::Nop
@@ -423,6 +430,19 @@ impl AvailableExpressionSet {
                 source: self.regenerate_expression(from, ave, cst).1,
                 destination: self.regenerate_expression(to, ave, cst).1,
                 bytes: self.regenerate_expression(bytes, ave, cst).1,
+            },
+
+            Instr::Switch {
+                cond,
+                cases,
+                default,
+            } => Instr::Switch {
+                cond: self.regenerate_expression(cond, ave, cst).1,
+                cases: cases
+                    .iter()
+                    .map(|(case, goto)| (self.regenerate_expression(case, ave, cst).1, *goto))
+                    .collect::<Vec<(Expression, usize)>>(),
+                default: *default,
             },
 
             Instr::WriteBuffer { buf, offset, value } => Instr::WriteBuffer {

--- a/src/codegen/vector_to_slice.rs
+++ b/src/codegen/vector_to_slice.rs
@@ -101,6 +101,7 @@ fn find_writable_vectors(
             | Instr::Nop
             | Instr::Branch { .. }
             | Instr::BranchCond { .. }
+            | Instr::Switch { .. }
             | Instr::PopMemory { .. }
             | Instr::LoadStorage { .. }
             | Instr::SetStorage { .. }

--- a/src/codegen/yul/statements.rs
+++ b/src/codegen/yul/statements.rs
@@ -72,7 +72,7 @@ pub(crate) fn statement(
             cases,
             default,
             ..
-        } => resolve_switch(
+        } => switch(
             condition,
             cases,
             default,
@@ -480,7 +480,7 @@ fn process_for_block(
 }
 
 /// Generate CFG code for a switch statement
-fn resolve_switch(
+fn switch(
     condition: &YulExpression,
     cases: &[CaseBlock],
     default: &Option<YulBlock>,

--- a/src/sema/ast.rs
+++ b/src/sema/ast.rs
@@ -1056,6 +1056,7 @@ impl CodeLocation for Instr {
                 pt::Loc::File(_, _, _) => source.loc(),
                 _ => destination.loc(),
             },
+            Instr::Switch { cond, .. } => cond.loc(),
             Instr::Branch { .. }
             | Instr::Unreachable
             | Instr::Nop

--- a/src/sema/yul/statements.rs
+++ b/src/sema/yul/statements.rs
@@ -110,13 +110,6 @@ pub(crate) fn resolve_yul_statement(
                 ns,
             )?;
             resolved_statements.push(resolved_switch.0);
-            ns.diagnostics.push(
-                Diagnostic::error(
-                    switch_statement.loc,
-                    "switch statements have no implementation in code generation yet. Please, file a GitHub issue \
-                    if there is urgent need for such a feature".to_string()
-                )
-            );
             Ok(resolved_switch.1)
         }
 

--- a/src/sema/yul/tests/block.rs
+++ b/src/sema/yul/tests/block.rs
@@ -186,7 +186,10 @@ contract testTypes {
     "#;
 
     let ns = parse(file);
-    assert!(ns.diagnostics.contains_message("switch statements have no implementation in code generation yet. Please, file a GitHub issue if there is urgent need for such a feature"));
+    for item in ns.diagnostics.iter() {
+        std::println!("{}", item.message);
+    }
+    assert!(ns.diagnostics.contains_message("unreachable yul statement"));
 
     let file = r#"
 contract testTypes {
@@ -209,12 +212,10 @@ contract testTypes {
     }
 }    "#;
     let ns = parse(file);
+    assert_eq!(ns.diagnostics.len(), 1);
     assert!(ns
         .diagnostics
         .contains_message("found contract 'testTypes'"));
-    assert!(ns
-        .diagnostics
-        .contains_message("switch statements have no implementation in code generation yet. Please, file a GitHub issue if there is urgent need for such a feature"));
 
     let file = r#"
     contract testTypes {
@@ -237,12 +238,10 @@ contract testTypes {
 }    "#;
 
     let ns = parse(file);
+    assert_eq!(ns.diagnostics.len(), 1);
     assert!(ns
         .diagnostics
         .contains_message("found contract 'testTypes'"));
-    assert!(ns
-        .diagnostics
-        .contains_message("switch statements have no implementation in code generation yet. Please, file a GitHub issue if there is urgent need for such a feature"));
 }
 
 #[test]

--- a/src/sema/yul/tests/mutability.rs
+++ b/src/sema/yul/tests/mutability.rs
@@ -178,7 +178,6 @@ fn if_block() {
 
 #[test]
 fn switch() {
-    // TODO: switch statements are not yet supported, so there is no way to test mutability here
     let file = r#"
     contract testTypes {
     function testAsm(uint[] calldata vl) public pure {
@@ -198,7 +197,7 @@ fn switch() {
     let ns = parse(file);
     assert!(ns
         .diagnostics
-        .contains_message("switch statements have no implementation in code generation yet. Please, file a GitHub issue if there is urgent need for such a feature"));
+        .contains_message("function declared 'pure' but this expression reads from state"));
 
     let file = r#"
     contract testTypes {
@@ -220,7 +219,7 @@ fn switch() {
     let ns = parse(file);
     assert!(ns
         .diagnostics
-        .contains_message("switch statements have no implementation in code generation yet. Please, file a GitHub issue if there is urgent need for such a feature"));
+        .contains_message("function declared 'pure' but this expression reads from state"));
 
     let file = r#"
     contract testTypes {
@@ -242,7 +241,7 @@ fn switch() {
     let ns = parse(file);
     assert!(ns
         .diagnostics
-        .contains_message("switch statements have no implementation in code generation yet. Please, file a GitHub issue if there is urgent need for such a feature"));
+        .contains_message("function declared 'pure' but this expression reads from state"));
 }
 
 #[test]

--- a/src/sema/yul/tests/switch.rs
+++ b/src/sema/yul/tests/switch.rs
@@ -74,7 +74,6 @@ contract testTypes {
 
 #[test]
 fn correct_switch() {
-    // TODO: switch statements are not yet implemented
     let file = r#"
 contract testTypes {
     function testAsm() public pure {
@@ -101,7 +100,12 @@ contract testTypes {
     "#;
 
     let ns = parse(file);
-    assert!(ns
-        .diagnostics
-        .contains_message("switch statements have no implementation in code generation yet. Please, file a GitHub issue if there is urgent need for such a feature"));
+    for item in ns.diagnostics.iter() {
+        std::println!("{}", item.message);
+    }
+    assert_eq!(ns.diagnostics.len(), 1);
+    assert_eq!(
+        ns.diagnostics.iter().next().unwrap().message,
+        "found contract 'testTypes'"
+    );
 }

--- a/src/sema/yul/tests/switch.rs
+++ b/src/sema/yul/tests/switch.rs
@@ -109,3 +109,126 @@ contract testTypes {
         "found contract 'testTypes'"
     );
 }
+
+#[test]
+fn repeated_switch_case() {
+    let file = r#"
+contract Testing {
+    function duplicate_cases(uint a) public pure returns (uint b) {
+        assembly {
+            switch a
+            case hex"019a" {
+                b := 5
+            }
+            case 410 {
+                b := 6
+            }
+        }
+    }
+}
+    "#;
+    let ns = parse(file);
+    assert_eq!(ns.diagnostics.len(), 2);
+    assert!(ns.diagnostics.contains_message("found contract 'Testing'"));
+    assert!(ns.diagnostics.contains_message("duplicate case for switch"));
+    let errors = ns.diagnostics.errors();
+    assert_eq!(errors.len(), 1);
+    assert_eq!(errors[0].notes.len(), 1);
+    assert_eq!(errors[0].notes[0].message, "repeated case found here");
+
+    let file = r#"
+contract Testing {
+    function duplicate_cases(uint a) public pure returns (uint b) {
+        assembly {
+            switch a
+            case true {
+                b := 5
+            }
+            case 1 {
+                b := 6
+            }
+        }
+    }
+}
+    "#;
+    let ns = parse(file);
+    assert_eq!(ns.diagnostics.len(), 2);
+    assert!(ns.diagnostics.contains_message("found contract 'Testing'"));
+    assert!(ns.diagnostics.contains_message("duplicate case for switch"));
+    let errors = ns.diagnostics.errors();
+    assert_eq!(errors.len(), 1);
+    assert_eq!(errors[0].notes.len(), 1);
+    assert_eq!(errors[0].notes[0].message, "repeated case found here");
+
+    let file = r#"
+contract Testing {
+    function duplicate_cases(uint a) public pure returns (uint b) {
+        assembly {
+            switch a
+            case 0 {
+                b := 5
+            }
+            case false {
+                b := 6
+            }
+        }
+    }
+}
+    "#;
+    let ns = parse(file);
+    assert_eq!(ns.diagnostics.len(), 2);
+    assert!(ns.diagnostics.contains_message("found contract 'Testing'"));
+    assert!(ns.diagnostics.contains_message("duplicate case for switch"));
+    let errors = ns.diagnostics.errors();
+    assert_eq!(errors.len(), 1);
+    assert_eq!(errors[0].notes.len(), 1);
+    assert_eq!(errors[0].notes[0].message, "repeated case found here");
+
+    let file = r#"
+contract Testing {
+    function duplicate_cases(uint a) public pure returns (uint b) {
+        assembly {
+            switch a
+            case 16705 {
+                b := 5
+            }
+            case "AA" {
+                b := 6
+            }
+        }
+    }
+}
+    "#;
+    let ns = parse(file);
+    assert_eq!(ns.diagnostics.len(), 2);
+    assert!(ns.diagnostics.contains_message("found contract 'Testing'"));
+    assert!(ns.diagnostics.contains_message("duplicate case for switch"));
+    let errors = ns.diagnostics.errors();
+    assert_eq!(errors.len(), 1);
+    assert_eq!(errors[0].notes.len(), 1);
+    assert_eq!(errors[0].notes[0].message, "repeated case found here");
+
+    let file = r#"
+contract Testing {
+    function duplicate_cases(uint a) public pure returns (uint b) {
+        assembly {
+            switch a
+            case 16705 {
+                b := 5
+            }
+            case 16705 {
+                b := 6
+            }
+        }
+    }
+}
+    "#;
+    let ns = parse(file);
+    assert_eq!(ns.diagnostics.len(), 2);
+    assert!(ns.diagnostics.contains_message("found contract 'Testing'"));
+    assert!(ns.diagnostics.contains_message("duplicate case for switch"));
+    let errors = ns.diagnostics.errors();
+    assert_eq!(errors.len(), 1);
+    assert_eq!(errors[0].notes.len(), 1);
+    assert_eq!(errors[0].notes[0].message, "repeated case found here");
+}

--- a/tests/codegen_testcases/yul/switch.sol
+++ b/tests/codegen_testcases/yul/switch.sol
@@ -1,0 +1,70 @@
+// RUN: --target solana --emit cfg 
+
+contract Testing {
+    // BEGIN-CHECK: Testing::Testing::function::switch_default__uint256
+    function switch_default(uint a) public pure returns (uint b) {
+        assembly {
+            // CHECK: switch (arg #0):
+            switch a
+            // CHECK: case uint256 1: goto block #2
+            // CHECK: case uint256 2: goto block #3
+            // CHECK: default: goto block #4
+
+            // CHECK: block1: # end_switch
+            // CHECK: branchcond (%b == uint256 7), block5, block6
+            case 1 {
+                // CHECK: block2: # case_0
+                // CHECK: ty:uint256 %b = uint256 5
+                b := 5
+                // CHECK: branch block1
+            }
+            case 2 {
+                // CHECK: block3: # case_1
+                // CHECK: ty:uint256 %b = uint256 6
+                b := 6
+                // CHECK: branch block1
+            }
+            default {
+                // CHECK: block4: # default
+                // CHECK: ty:uint256 %b = uint256 7
+                b := 7
+                // CHECK: branch block1
+            }
+        }
+
+        if (b == 7) {
+            b += 1;
+        }
+    }
+
+    // BEGIN-CHECK: Testing::Testing::function::switch_no_default__uint256
+    function switch_no_default(uint a) public pure returns (uint b) {
+        assembly {
+            switch a
+            // CHECK: switch (arg #0):
+		    // CHECK: case uint256 1: goto block #2
+		    // CHECK: case uint256 2: goto block #3
+		    // CHECK: default: goto block #1
+
+            // CHECK: block1: # end_switch
+	        // CHECK: branchcond (%b == uint256 5), block4, block5
+
+            case 1 {
+            // CHECK: block2: # case_0
+            // CHECK: ty:uint256 %b = uint256 5
+            // CHECK: branch block1
+                b := 5
+            }
+            case 2 {
+            // CHECK: block3: # case_1
+            // CHECK: ty:uint256 %b = uint256 6
+	        // CHECK: branch block1
+                b := 6
+            }
+        }
+
+        if (b == 5) {
+            b += 1;
+        }
+    }
+}

--- a/tests/contract_testcases/solana/yul/yul_switch.dot
+++ b/tests/contract_testcases/solana/yul/yul_switch.dot
@@ -41,7 +41,6 @@ strict digraph "tests/contract_testcases/solana/yul/yul_switch.sol" {
 	return [label="return\ntests/contract_testcases/solana/yul/yul_switch.sol:16:9-17"]
 	variable [label="variable: y\nuint256\ntests/contract_testcases/solana/yul/yul_switch.sol:16:16-17"]
 	diagnostic [label="found contract 'testTypes'\nlevel Debug\ntests/contract_testcases/solana/yul/yul_switch.sol:1:1-18:2"]
-	diagnostic_44 [label="switch statements have no implementation in code generation yet. Please, file a GitHub issue if there is urgent need for such a feature\nlevel Error\ntests/contract_testcases/solana/yul/yul_switch.sol:6:13-11:14"]
 	contracts -> contract
 	contract -> var [label="variable"]
 	contract -> testAsm [label="function"]
@@ -84,5 +83,4 @@ strict digraph "tests/contract_testcases/solana/yul/yul_switch.sol" {
 	inline_assembly -> return [label="next"]
 	return -> variable [label="expr"]
 	diagnostics -> diagnostic [label="Debug"]
-	diagnostics -> diagnostic_44 [label="Error"]
 }

--- a/tests/solana_tests/yul.rs
+++ b/tests/solana_tests/yul.rs
@@ -392,6 +392,7 @@ fn addmod_mulmod() {
 fn switch_statement() {
     let mut vm = build_solidity(
         r#"
+
 contract Testing {
     function switch_default(uint a) public pure returns (uint b) {
         b = 4;
@@ -427,6 +428,20 @@ contract Testing {
 
         if (b == 5) {
             b -= 2;
+        }
+    }
+
+    function switch_no_case(uint a) public pure returns (uint b) {
+        b = 7;
+        assembly {
+            switch a
+            default {
+                b := 5
+            }
+        }
+
+        if (b == 5) {
+            b -= 1;
         }
     }
 }
@@ -466,5 +481,8 @@ contract Testing {
         &[],
         None,
     );
+    assert_eq!(returns[0], Token::Uint(Uint::from(4)));
+
+    let returns = vm.function("switch_no_case", &[Token::Uint(Uint::from(3))], &[], None);
     assert_eq!(returns[0], Token::Uint(Uint::from(4)));
 }

--- a/tests/solana_tests/yul.rs
+++ b/tests/solana_tests/yul.rs
@@ -384,6 +384,87 @@ fn addmod_mulmod() {
     let returns = vm.function("testMod", &[], &[], None);
     assert_eq!(
         returns,
-        vec![Token::Uint(Uint::from(0)), Token::Uint(Uint::from(7)),]
+        vec![Token::Uint(Uint::from(0)), Token::Uint(Uint::from(7))]
     );
+}
+
+#[test]
+fn switch_statement() {
+    let mut vm = build_solidity(
+        r#"
+contract Testing {
+    function switch_default(uint a) public pure returns (uint b) {
+        b = 4;
+        assembly {
+            switch a
+            case 1 {
+                b := 5
+            }
+            case 2 {
+                b := 6
+            }
+            default {
+                b := 7
+            }
+        }
+
+        if (b == 7) {
+            b += 2;
+        }
+    }
+
+    function switch_no_default(uint a) public pure returns (uint b) {
+        b = 4;
+        assembly {
+            switch a
+            case 1 {
+                b := 5
+            }
+            case 2 {
+                b := 6
+            }
+        }
+
+        if (b == 5) {
+            b -= 2;
+        }
+    }
+}
+        "#,
+    );
+
+    vm.constructor("Testing", &[]);
+
+    let returns = vm.function("switch_default", &[Token::Uint(Uint::from(1))], &[], None);
+    assert_eq!(returns[0], Token::Uint(Uint::from(5)));
+
+    let returns = vm.function("switch_default", &[Token::Uint(Uint::from(2))], &[], None);
+    assert_eq!(returns[0], Token::Uint(Uint::from(6)));
+
+    let returns = vm.function("switch_default", &[Token::Uint(Uint::from(6))], &[], None);
+    assert_eq!(returns[0], Token::Uint(Uint::from(9)));
+
+    let returns = vm.function(
+        "switch_no_default",
+        &[Token::Uint(Uint::from(1))],
+        &[],
+        None,
+    );
+    assert_eq!(returns[0], Token::Uint(Uint::from(3)));
+
+    let returns = vm.function(
+        "switch_no_default",
+        &[Token::Uint(Uint::from(2))],
+        &[],
+        None,
+    );
+    assert_eq!(returns[0], Token::Uint(Uint::from(6)));
+
+    let returns = vm.function(
+        "switch_no_default",
+        &[Token::Uint(Uint::from(6))],
+        &[],
+        None,
+    );
+    assert_eq!(returns[0], Token::Uint(Uint::from(4)));
 }

--- a/tests/substrate_tests/yul.rs
+++ b/tests/substrate_tests/yul.rs
@@ -234,6 +234,20 @@ contract Testing {
             b -= 2;
         }
     }
+
+    function switch_no_case(uint a) public pure returns (uint b) {
+        b = 7;
+        assembly {
+            switch a
+            default {
+                b := 5
+            }
+        }
+
+        if (b == 5) {
+            b -= 1;
+        }
+    }
 }
         "#,
     );
@@ -256,5 +270,8 @@ contract Testing {
     assert_eq!(runtime.vm.output, Val256(U256::from(6)).encode());
 
     runtime.function("switch_no_default", Val256(U256::from(6)).encode());
+    assert_eq!(runtime.vm.output, Val256(U256::from(4)).encode());
+
+    runtime.function("switch_no_case", Val256(U256::from(3)).encode());
     assert_eq!(runtime.vm.output, Val256(U256::from(4)).encode());
 }

--- a/tests/substrate_tests/yul.rs
+++ b/tests/substrate_tests/yul.rs
@@ -192,3 +192,69 @@ contract testing  {
 
     assert_eq!(runtime.vm.output, expected);
 }
+
+#[test]
+fn switch_statement() {
+    let mut runtime = build_solidity(
+        r#"
+contract Testing {
+    function switch_default(uint a) public pure returns (uint b) {
+        b = 4;
+        assembly {
+            switch a
+            case 1 {
+                b := 5
+            }
+            case 2 {
+                b := 6
+            }
+            default {
+                b := 7
+            }
+        }
+
+        if (b == 7) {
+            b += 2;
+        }
+    }
+
+    function switch_no_default(uint a) public pure returns (uint b) {
+        b = 4;
+        assembly {
+            switch a
+            case 1 {
+                b := 5
+            }
+            case 2 {
+                b := 6
+            }
+        }
+
+        if (b == 5) {
+            b -= 2;
+        }
+    }
+}
+        "#,
+    );
+
+    runtime.constructor(0, Vec::new());
+
+    runtime.function("switch_default", Val256(U256::from(1)).encode());
+    assert_eq!(runtime.vm.output, Val256(U256::from(5)).encode());
+
+    runtime.function("switch_default", Val256(U256::from(2)).encode());
+    assert_eq!(runtime.vm.output, Val256(U256::from(6)).encode());
+
+    runtime.function("switch_default", Val256(U256::from(6)).encode());
+    assert_eq!(runtime.vm.output, Val256(U256::from(9)).encode());
+
+    runtime.function("switch_no_default", Val256(U256::from(1)).encode());
+    assert_eq!(runtime.vm.output, Val256(U256::from(3)).encode());
+
+    runtime.function("switch_no_default", Val256(U256::from(2)).encode());
+    assert_eq!(runtime.vm.output, Val256(U256::from(6)).encode());
+
+    runtime.function("switch_no_default", Val256(U256::from(6)).encode());
+    assert_eq!(runtime.vm.output, Val256(U256::from(4)).encode());
+}


### PR DESCRIPTION
We aim at moving the dispatch code to codegen. It means we'll need new instructions and builtin structs there, like the `switch` instruction, utilized in [this line](https://github.com/hyperledger/solang/blob/6083938df34d288ba85a19d72338ee5abcb85b85/src/emit/dispatch.rs#L103).

This PR wires up the `switch` instruction for that and enables the code generation for switch statements in Yul, using the newly added instruction.