### PR TITLE
Arrays whose elements are dynamic should be properly Borsh decoded

### DIFF
--- a/src/codegen/encoding/borsh_encoding.rs
+++ b/src/codegen/encoding/borsh_encoding.rs
@@ -1047,10 +1047,12 @@ impl BorshEncoding {
     ) {
         // If we have a 'int[3][4][] vec', we can only validate the buffer after we have
         // allocated the outer dimension, i.e., we are about to read a 'int[3][4]' item.
+        // Arrays whose elements are dynamic cannot be verified.
         if validator.validation_necessary()
             && !dims[0..(dimension + 1)]
                 .iter()
                 .any(|d| *d == ArrayLength::Dynamic)
+            && !elem_ty.is_dynamic(ns)
         {
             let mut elems = BigInt::one();
             for item in &dims[0..(dimension + 1)] {

--- a/tests/solana_tests/abi_decode.rs
+++ b/tests/solana_tests/abi_decode.rs
@@ -1173,3 +1173,37 @@ fn test_struct_validation_invalid() {
     let encoded = input.try_to_vec().unwrap();
     let _ = vm.function("test", &[Token::Bytes(encoded)], &[], None);
 }
+
+#[test]
+fn string_fixed_array() {
+    let mut vm = build_solidity(
+        r#"
+        contract test {
+    function testing(bytes memory data) public pure {
+        string[4] arr = abi.borshDecode(data, (string[4]));
+        assert(arr[0] == "a");
+        assert(arr[1] == "b");
+        assert(arr[2] == "c");
+        assert(arr[3] == "d");
+    }
+}
+        "#,
+    );
+    vm.constructor("test", &[]);
+
+    #[derive(Debug, BorshSerialize)]
+    struct Input {
+        a: [String; 4],
+    }
+
+    let input = Input {
+        a: [
+            "a".to_string(),
+            "b".to_string(),
+            "c".to_string(),
+            "d".to_string(),
+        ],
+    };
+    let encoded = input.try_to_vec().unwrap();
+    let _ = vm.function("testing", &[Token::Bytes(encoded)], &[], None);
+}


### PR DESCRIPTION
When we try to decoded a fixed array whose type is dynamic, we cannot validate the buffer length before fetching more information about each element. I found this bug while migrating the Solana target to Borsh encoding.

This PR fixes this bug.