### PR TITLE
Encode arguments for assert-failure in codegen

### DIFF
--- a/integration/solana/errors.spec.ts
+++ b/integration/solana/errors.spec.ts
@@ -19,7 +19,7 @@ describe('Deploy solang contract and test', function () {
             if (e instanceof TransactionError) {
                 expect(e.message).toBe('Do the revert thing');
                 expect(e.computeUnitsUsed).toBeGreaterThan(1000);
-                expect(e.computeUnitsUsed).toBeLessThan(1100);
+                expect(e.computeUnitsUsed).toBeLessThan(1110);
                 expect(e.logs.length).toBeGreaterThan(1);
             }
             return;

--- a/src/codegen/cfg.rs
+++ b/src/codegen/cfg.rs
@@ -60,9 +60,7 @@ pub enum Instr {
     /// Set array element in memory
     Store { dest: Expression, data: Expression },
     /// Abort execution
-    AssertFailure {
-        encoded_args_with_len: Option<(Expression, Expression)>,
-    },
+    AssertFailure { encoded_args: Option<Expression> },
     /// Print to log message
     Print { expr: Expression },
     /// Load storage (this is an instruction rather than an expression
@@ -212,6 +210,9 @@ impl Instr {
             | Instr::LoadStorage { storage: expr, .. }
             | Instr::ClearStorage { storage: expr, .. }
             | Instr::Print { expr }
+            | Instr::AssertFailure {
+                encoded_args: Some(expr),
+            }
             | Instr::PopStorage { storage: expr, .. }
             | Instr::AbiDecode { data: expr, .. }
             | Instr::SelfDestruct { recipient: expr }
@@ -231,9 +232,6 @@ impl Instr {
             | Instr::Store {
                 dest: item_1,
                 data: item_2,
-            }
-            | Instr::AssertFailure {
-                encoded_args_with_len: Some((item_1, item_2)),
             }
             | Instr::ReturnData {
                 data: item_1,
@@ -342,9 +340,7 @@ impl Instr {
                 }
             }
 
-            Instr::AssertFailure {
-                encoded_args_with_len: None,
-            }
+            Instr::AssertFailure { encoded_args: None }
             | Instr::Unreachable
             | Instr::Nop
             | Instr::ReturnCode { .. }
@@ -989,11 +985,10 @@ impl ControlFlowGraph {
                 self.vars[array].id.name,
                 ty.to_string(ns),
             ),
-            Instr::AssertFailure { encoded_args_with_len: None } => "assert-failure".to_string(),
-            Instr::AssertFailure { encoded_args_with_len: Some(expr) } => {
-                format!("assert-failure: buffer: {}, buffer len: {}",
-                        self.expr_to_string(contract, ns, &expr.0),
-                        self.expr_to_string(contract, ns, &expr.1)
+            Instr::AssertFailure { encoded_args: None } => "assert-failure".to_string(),
+            Instr::AssertFailure { encoded_args: Some(expr) } => {
+                format!("assert-failure: buffer: {}",
+                        self.expr_to_string(contract, ns, expr),
                 )
             }
             Instr::Call {

--- a/src/codegen/constant_folding.rs
+++ b/src/codegen/constant_folding.rs
@@ -88,13 +88,12 @@ pub fn constant_folding(cfg: &mut ControlFlowGraph, ns: &mut Namespace) {
                     cfg.blocks[block_no].instr[instr_no].1 = Instr::Store { dest, data };
                 }
                 Instr::AssertFailure {
-                    encoded_args_with_len: Some(expr),
+                    encoded_args: Some(expr),
                 } => {
-                    let (buf, _) = expression(&expr.0, Some(&vars), cfg, ns);
-                    let (len, _) = expression(&expr.1, Some(&vars), cfg, ns);
+                    let (buf, _) = expression(expr, Some(&vars), cfg, ns);
 
                     cfg.blocks[block_no].instr[instr_no].1 = Instr::AssertFailure {
-                        encoded_args_with_len: Some((buf, len)),
+                        encoded_args: Some(buf),
                     };
                 }
                 Instr::Print { expr } => {

--- a/src/codegen/constant_folding.rs
+++ b/src/codegen/constant_folding.rs
@@ -87,11 +87,15 @@ pub fn constant_folding(cfg: &mut ControlFlowGraph, ns: &mut Namespace) {
 
                     cfg.blocks[block_no].instr[instr_no].1 = Instr::Store { dest, data };
                 }
-                Instr::AssertFailure { expr: Some(expr) } => {
-                    let (expr, _) = expression(expr, Some(&vars), cfg, ns);
+                Instr::AssertFailure {
+                    encoded_args_with_len: Some(expr),
+                } => {
+                    let (buf, _) = expression(&expr.0, Some(&vars), cfg, ns);
+                    let (len, _) = expression(&expr.1, Some(&vars), cfg, ns);
 
-                    cfg.blocks[block_no].instr[instr_no].1 =
-                        Instr::AssertFailure { expr: Some(expr) };
+                    cfg.blocks[block_no].instr[instr_no].1 = Instr::AssertFailure {
+                        encoded_args_with_len: Some((buf, len)),
+                    };
                 }
                 Instr::Print { expr } => {
                     let (expr, _) = expression(expr, Some(&vars), cfg, ns);

--- a/src/codegen/encoding/buffer_validator.rs
+++ b/src/codegen/encoding/buffer_validator.rs
@@ -1,4 +1,5 @@
 use crate::codegen::cfg::{ControlFlowGraph, Instr};
+use crate::codegen::expression::assert_failure;
 use crate::codegen::vartable::Vartable;
 use crate::codegen::Expression;
 use crate::sema::ast::{Namespace, Type};
@@ -132,7 +133,7 @@ impl BufferValidator<'_> {
         cfg.set_basic_block(invalid);
 
         // TODO: This needs a proper error message
-        cfg.add(vartab, Instr::AssertFailure { expr: None });
+        assert_failure(&Loc::Codegen, None, cfg, vartab);
 
         cfg.set_basic_block(valid);
     }
@@ -204,7 +205,7 @@ impl BufferValidator<'_> {
 
         cfg.set_basic_block(out_of_bounds_block);
         // TODO: Add an error message here
-        cfg.add(vartab, Instr::AssertFailure { expr: None });
+        assert_failure(&Loc::Codegen, None, cfg, vartab);
         cfg.set_basic_block(inbounds_block);
     }
 

--- a/src/codegen/expression.rs
+++ b/src/codegen/expression.rs
@@ -3131,12 +3131,7 @@ pub(super) fn assert_failure(
     vartab: &mut Vartable,
 ) {
     if arg.is_none() {
-        cfg.add(
-            vartab,
-            Instr::AssertFailure {
-                encoded_args_with_len: None,
-            },
-        );
+        cfg.add(vartab, Instr::AssertFailure { encoded_args: None });
         return;
     }
 
@@ -3158,17 +3153,11 @@ pub(super) fn assert_failure(
         },
     );
     let encoded_buffer = Expression::Variable(Loc::Codegen, Type::DynamicBytes, encoded_var_no);
-    let encoded_buffer_len = Expression::Builtin(
-        Loc::Codegen,
-        vec![Type::Uint(32)],
-        Builtin::ArrayLength,
-        vec![encoded_buffer.clone()],
-    );
 
     cfg.add(
         vartab,
         Instr::AssertFailure {
-            encoded_args_with_len: Some((encoded_buffer, encoded_buffer_len)),
+            encoded_args: Some(encoded_buffer),
         },
     )
 }

--- a/src/codegen/storage.rs
+++ b/src/codegen/storage.rs
@@ -13,6 +13,7 @@ use super::{
     cfg::{ControlFlowGraph, Instr},
     vartable::Vartable,
 };
+use crate::codegen::expression::assert_failure;
 use crate::sema::ast::{Function, Namespace, RetrieveType, Type};
 use solang_parser::pt;
 
@@ -209,7 +210,7 @@ pub fn storage_slots_array_pop(
     );
 
     cfg.set_basic_block(empty_array);
-    cfg.add(vartab, Instr::AssertFailure { expr: None });
+    assert_failure(loc, None, cfg, vartab);
 
     cfg.set_basic_block(has_elements);
     let new_length = vartab.temp_anonymous(&slot_ty);

--- a/src/codegen/strength_reduce/mod.rs
+++ b/src/codegen/strength_reduce/mod.rs
@@ -123,10 +123,9 @@ fn block_reduce(
                 *data = expression_reduce(data, &vars, ns);
             }
             Instr::AssertFailure {
-                encoded_args_with_len: Some(expr),
+                encoded_args: Some(expr),
             } => {
-                expr.0 = expression_reduce(&expr.0, &vars, ns);
-                expr.1 = expression_reduce(&expr.1, &vars, ns);
+                *expr = expression_reduce(expr, &vars, ns);
             }
             Instr::Print { expr } => {
                 *expr = expression_reduce(expr, &vars, ns);

--- a/src/codegen/strength_reduce/mod.rs
+++ b/src/codegen/strength_reduce/mod.rs
@@ -122,8 +122,11 @@ fn block_reduce(
                 *dest = expression_reduce(dest, &vars, ns);
                 *data = expression_reduce(data, &vars, ns);
             }
-            Instr::AssertFailure { expr: Some(expr) } => {
-                *expr = expression_reduce(expr, &vars, ns);
+            Instr::AssertFailure {
+                encoded_args_with_len: Some(expr),
+            } => {
+                expr.0 = expression_reduce(&expr.0, &vars, ns);
+                expr.1 = expression_reduce(&expr.1, &vars, ns);
             }
             Instr::Print { expr } => {
                 *expr = expression_reduce(expr, &vars, ns);

--- a/src/codegen/subexpression_elimination/instruction.rs
+++ b/src/codegen/subexpression_elimination/instruction.rs
@@ -19,7 +19,6 @@ impl AvailableExpressionSet {
             | Instr::LoadStorage { storage: expr, .. }
             | Instr::ClearStorage { storage: expr, .. }
             | Instr::Print { expr }
-            | Instr::AssertFailure { expr: Some(expr) }
             | Instr::PopStorage { storage: expr, .. }
             | Instr::AbiDecode { data: expr, .. }
             | Instr::SelfDestruct { recipient: expr } => {
@@ -54,6 +53,9 @@ impl AvailableExpressionSet {
             | Instr::ReturnData {
                 data: item_1,
                 data_len: item_2,
+            }
+            | Instr::AssertFailure {
+                encoded_args_with_len: Some((item_1, item_2)),
             }
             | Instr::Store {
                 dest: item_1,
@@ -175,7 +177,9 @@ impl AvailableExpressionSet {
                 }
             }
 
-            Instr::AssertFailure { expr: None }
+            Instr::AssertFailure {
+                encoded_args_with_len: None,
+            }
             | Instr::Unreachable
             | Instr::Nop
             | Instr::ReturnCode { .. }
@@ -239,8 +243,13 @@ impl AvailableExpressionSet {
                 data: self.regenerate_expression(data, ave, cst).1,
             },
 
-            Instr::AssertFailure { expr: Some(exp) } => Instr::AssertFailure {
-                expr: Some(self.regenerate_expression(exp, ave, cst).1),
+            Instr::AssertFailure {
+                encoded_args_with_len: Some(exp),
+            } => Instr::AssertFailure {
+                encoded_args_with_len: Some((
+                    self.regenerate_expression(&exp.0, ave, cst).1,
+                    self.regenerate_expression(&exp.1, ave, cst).1,
+                )),
             },
 
             Instr::Print { expr } => Instr::Print {

--- a/src/codegen/subexpression_elimination/instruction.rs
+++ b/src/codegen/subexpression_elimination/instruction.rs
@@ -19,6 +19,9 @@ impl AvailableExpressionSet {
             | Instr::LoadStorage { storage: expr, .. }
             | Instr::ClearStorage { storage: expr, .. }
             | Instr::Print { expr }
+            | Instr::AssertFailure {
+                encoded_args: Some(expr),
+            }
             | Instr::PopStorage { storage: expr, .. }
             | Instr::AbiDecode { data: expr, .. }
             | Instr::SelfDestruct { recipient: expr } => {
@@ -53,9 +56,6 @@ impl AvailableExpressionSet {
             | Instr::ReturnData {
                 data: item_1,
                 data_len: item_2,
-            }
-            | Instr::AssertFailure {
-                encoded_args_with_len: Some((item_1, item_2)),
             }
             | Instr::Store {
                 dest: item_1,
@@ -177,9 +177,7 @@ impl AvailableExpressionSet {
                 }
             }
 
-            Instr::AssertFailure {
-                encoded_args_with_len: None,
-            }
+            Instr::AssertFailure { encoded_args: None }
             | Instr::Unreachable
             | Instr::Nop
             | Instr::ReturnCode { .. }
@@ -244,12 +242,9 @@ impl AvailableExpressionSet {
             },
 
             Instr::AssertFailure {
-                encoded_args_with_len: Some(exp),
+                encoded_args: Some(exp),
             } => Instr::AssertFailure {
-                encoded_args_with_len: Some((
-                    self.regenerate_expression(&exp.0, ave, cst).1,
-                    self.regenerate_expression(&exp.1, ave, cst).1,
-                )),
+                encoded_args: Some(self.regenerate_expression(exp, ave, cst).1),
             },
 
             Instr::Print { expr } => Instr::Print {

--- a/src/codegen/subexpression_elimination/tests.rs
+++ b/src/codegen/subexpression_elimination/tests.rs
@@ -123,7 +123,10 @@ fn non_commutative() {
     );
 
     let instr = Instr::AssertFailure {
-        expr: Some(sub.clone()),
+        encoded_args_with_len: Some((
+            sub.clone(),
+            Expression::NumberLiteral(Loc::Codegen, Type::Uint(32), BigInt::from(5u8)),
+        )),
     };
 
     let mut ave = AvailableExpression::default();

--- a/src/codegen/subexpression_elimination/tests.rs
+++ b/src/codegen/subexpression_elimination/tests.rs
@@ -123,10 +123,7 @@ fn non_commutative() {
     );
 
     let instr = Instr::AssertFailure {
-        encoded_args_with_len: Some((
-            sub.clone(),
-            Expression::NumberLiteral(Loc::Codegen, Type::Uint(32), BigInt::from(5u8)),
-        )),
+        encoded_args: Some(sub.clone()),
     };
 
     let mut ave = AvailableExpression::default();

--- a/src/codegen/yul/builtin.rs
+++ b/src/codegen/yul/builtin.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::codegen::expression::assert_failure;
 use crate::codegen::{
     cfg::{ControlFlowGraph, Instr},
     vartable::Vartable,
@@ -167,7 +168,7 @@ pub(crate) fn process_builtin(
         }
 
         YulBuiltInFunction::Invalid => {
-            cfg.add_yul(vartab, Instr::AssertFailure { expr: None });
+            assert_failure(loc, None, cfg, vartab);
             Expression::Poison
         }
 

--- a/src/emit/instructions.rs
+++ b/src/emit/instructions.rs
@@ -424,9 +424,7 @@ pub(super) fn process_instruction<'a, T: TargetRuntime<'a> + ?Sized>(
             );
             bin.builder.build_store(size_field, new_len);
         }
-        Instr::AssertFailure {
-            encoded_args_with_len: None,
-        } => {
+        Instr::AssertFailure { encoded_args: None } => {
             target.assert_failure(
                 bin,
                 bin.context
@@ -437,13 +435,13 @@ pub(super) fn process_instruction<'a, T: TargetRuntime<'a> + ?Sized>(
             );
         }
         Instr::AssertFailure {
-            encoded_args_with_len: Some(expr),
+            encoded_args: Some(expr),
         } => {
-            let data = expression(target, bin, &expr.0, &w.vars, function, ns);
+            let data = expression(target, bin, expr, &w.vars, function, ns);
             let vector_bytes = bin.vector_bytes(data);
-            let len = expression(target, bin, &expr.1, &w.vars, function, ns);
+            let len = bin.vector_len(data);
 
-            target.assert_failure(bin, vector_bytes, len.into_int_value());
+            target.assert_failure(bin, vector_bytes, len);
         }
         Instr::Print { expr } => {
             let expr = expression(target, bin, expr, &w.vars, function, ns);


### PR DESCRIPTION
Now that all runtime tests for Solana are working with bosh encoding, we can rid Solang of EthAbiEncoding. There is one more instruction that needed refactoring in order to make that a reality. `Instr::AssertFailure` utilizes the old abi encoding scheme implemented in emit (for Solana). This PR refactors the instruction so it encodes its arguments in codegen and allows a future integration with our `trait AbiEncoding`.