### PR TITLE
Disallow try-catch statements on Solana

### DIFF
--- a/docs/language/statements.rst
+++ b/docs/language/statements.rst
@@ -218,6 +218,10 @@ An internal function cannot be called from a try catch statement. Not all proble
 for example, out of gas cannot be caught. The ``revert()`` and ``require()`` builtins may
 be passed a reason code, which can be inspected using the ``catch Error(string)`` syntax.
 
+.. warning::
+    On Solana, any transaction that fails halts the execution of a contract. The try-catch statement, thus,
+    is not supported for Solana contracts and the compiler will raise an error if it detects its usage.
+
 .. code-block:: solidity
 
     contract aborting {

--- a/src/sema/statements.rs
+++ b/src/sema/statements.rs
@@ -15,6 +15,7 @@ use crate::sema::symtable::{VariableInitializer, VariableUsage};
 use crate::sema::unused_variable::{assigned_variable, check_function_call, used_variable};
 use crate::sema::yul::resolve_inline_assembly;
 use crate::sema::Recurse;
+use crate::Target;
 use solang_parser::pt;
 use solang_parser::pt::CatchClause;
 use solang_parser::pt::CodeLocation;
@@ -1810,6 +1811,17 @@ fn try_catch(
     ns: &mut Namespace,
     diagnostics: &mut Diagnostics,
 ) -> Result<(Statement, bool), ()> {
+    if ns.target == Target::Solana {
+        diagnostics.push(Diagnostic::error(
+            *loc,
+            "The try-catch statement is not supported on Solana. Please, go to \
+             https://solang.readthedocs.io/en/latest/language/statements.html#try-catch-statement \
+             for more information"
+                .to_string(),
+        ));
+        return Err(());
+    }
+
     let mut expr = expr.remove_parenthesis();
     let mut ok = None;
 


### PR DESCRIPTION
Try-catch statements are not supported on Solana. This PR updates the documentation to inform so and adds an error message when someone tries to use such a construct on Solana.

PS: The intention for this PR is to avoid using ABI decoding/encoding for try-catches on Solana, a construction that requires a special case of decoding with a basic block to handle a decoding failure.