### PR TITLE
Update @solana/solidity version

### DIFF
--- a/integration/anchor/package.json
+++ b/integration/anchor/package.json
@@ -7,7 +7,7 @@
     },
     "dependencies": {
         "@project-serum/anchor": "^0.25.0",
-        "@solana/solidity": "^0.0.21",
+        "@solana/solidity": "^0.0.22",
         "ts-node": "^10.9.1",
         "tsc-node": "^0.0.3"
     },

--- a/integration/solana/package.json
+++ b/integration/solana/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@dao-xyz/borsh": "^3.1.0",
-    "@solana/solidity": "0.0.21",
+    "@solana/solidity": "0.0.22",
     "@solana/spl-token": "0.2.0",
     "@solana/web3.js": "^1.30.2 <1.40.0",
     "ethers": "^5.2.0",


### PR DESCRIPTION
This PR updates the `@solana/solidity.js` library version in order to make integration tests pass again.