### PR TITLE
Documentation cleanup and rename Ternary to ConditionalOperator

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,8 +26,8 @@ def setup(sphinx):
 # -- Project information -----------------------------------------------------
 
 project = 'Solang Solidity Compiler'
-copyright = '2019 - 2021 Sean Young <sean@mess.org>'
-author = 'Sean Young <sean@mess.org>'
+copyright = '2019 - 2022 Solang Maintainers'
+author = 'Sean Young <sean@mess.org>, Cyrill Leutwiler <bigcyrill@hotmail.com>, Lucas Steuernagel <lucas.tnagel@gmail.com>'
 
 # The full version, including alpha/beta/rc tags
 release = os.popen('git describe --tags').readline().strip()

--- a/docs/extension.rst
+++ b/docs/extension.rst
@@ -23,18 +23,7 @@ Both the Visual Studio Code extension code and the language server were develope
 Solidity Language flavour
 -------------------------
 
-The Solidity language flavour depends on what target you are compiling for. For
-example:
-
-* Ethereum style address literals like ``0xE0f5206BBD039e7b0592d8918820024e2a7437b9`` are
-  not supported on Substrate or Solana, but are supported for EVM.
-* On Substrate and Solana, base58 style encoded address literals like
-  ``address"5GBWmgdFAMqm8ZgAHGobqDqX6tjLxJhv53ygjNtaaAn3sjeZ"`` are supported, but
-  not with EVM.
-* On Solana, there is special builtin import file called ``'solana'`` available.
-* Different blockchains offer different builtins. See the :ref:`builtins documentation <builtins>`.
-* See :ref:`language-status` for compatiblity with Ethereum Solidity (solc)
-* There are many more differences, which are noted throughout the documentation.
+The Solidity language flavour depends on what target you are compiling for, see :ref:`language-status` for a brief overview.
 
 You can choose the between the following targets:
 
@@ -48,7 +37,7 @@ evm
    Solidity for any EVM based chain like Ethereum
 
 Note that the language server has support for EVM, but Hyperledger Solang does
-not support compiling for EVM (yet).
+not support compiling for EVM.
 
 Using the extension
 -------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,13 +14,13 @@ Welcome to the Solang Solidity Compiler. Using Solang, you can compile smart con
 `Solana <https://www.solana.com/>`_ and
 `Parity Substrate <https://substrate.io/>`_. It uses the
 `llvm <https://www.llvm.org/>`_ compiler framework to produce WebAssembly
-(wasm) or BPF contract code. As result, the output is highly optimized, which saves you in gas costs.
+(WASM) or BPF contract code. As result, the output is highly optimized, which saves you in gas costs
+or compute units.
 
 Solang aims for source file compatibility with the Ethereum EVM Solidity compiler,
 version 0.8. Where differences exists, this is noted in the language documentation.
 The source code repository can be found on `github <https://github.com/hyperledger/solang>`_
-and we have a `channel #solang on Hyperledger Discord <https://discord.gg/jhn4rkqNsT>`_, and
-a `channel #solang-solidity-compiler on Solana Discord <https://discord.gg/TmE2Ek5ZbW>`_.
+and we have a `channel #solang on Hyperledger Discord <https://discord.gg/jhn4rkqNsT>`_.
 
 Contents
 ========

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -4,7 +4,7 @@ Installing Solang
 The Solang compiler is a single binary. It can be installed in different ways, listed below.
 
 1. :ref:`Download from Homebrew <download-brew>` (MacOS only)
-2. :ref:`Download pre-compiled binaries <download-binaries>`
+2. :ref:`Download binaries <download-binaries>`
 3. :ref:`Download from a Docker container <download-docker>`
 4. :ref:`Build using Dockerfile <build-dockerfile>`
 5. :ref:`Build from source <build-source>`
@@ -14,7 +14,7 @@ The Solang compiler is a single binary. It can be installed in different ways, l
 Option 1: Download from Brew
 ----------------------------
 
-Solang is available on Brew via a private tap. Currently, this works only for MacOS systems, both Intel and Apple Silicon.
+Solang is available on Brew via a private tap. This works only for MacOS systems, both Intel and Apple Silicon.
 To install Solang via Brew, run the following command:
 
 .. code-block:: text
@@ -23,8 +23,8 @@ To install Solang via Brew, run the following command:
 
 .. _download-binaries:
 
-Option 2: Download release binaries
------------------------------------
+Option 2: Download binaries
+---------------------------
 
 There are binaries available on github releases:
 
@@ -33,6 +33,9 @@ There are binaries available on github releases:
 - `Windows x64 <https://github.com/hyperledger/solang/releases/download/v0.1.13/solang.exe>`_
 - `MacOS intel <https://github.com/hyperledger/solang/releases/download/v0.1.13/solang-mac-intel>`_
 - `MacOS arm <https://github.com/hyperledger/solang/releases/download/v0.1.13/solang-mac-arm>`_
+
+Download the file and save it somewhere in your ``$PATH``, for example the bin directory in your home directory. If the
+path you use is not already in ``$PATH``, then you need to add it yourself.
 
 On MacOS, remember to give execution permission to the file and remove it from quarantine by executing the following commands:
 
@@ -85,7 +88,7 @@ Option 5: Build Solang from source
 ----------------------------------
 
 In order to build Solang from source, you will need rust 1.63.0 or higher,
-and a build of LLVM based on the Solana LLVM tree. There are a few patches which are not upstream yet.
+and a build of LLVM based on the Solana LLVM tree. There are a few LLVM patches required that are not upstream yet.
 First, follow the steps below for installing LLVM and then proceed from there.
 
 If you do not have the correct version of rust installed, go to `rustup <https://rustup.rs/>`_.
@@ -106,13 +109,13 @@ _____________________________________
 
 Solang needs a build of
 `LLVM with some extra patches <https://github.com/solana-labs/llvm-project/>`_.
-These patches make it possible to generate code for Solana, and fixes some
+These patches make it possible to generate code for Solana, and fixes
 concurrency issues in the lld linker.
 
 You can either download the pre-built libraries from
 `github <https://github.com/hyperledger/solang/releases/tag/v0.1.13>`_
-or :ref:`build your own from source <llvm-from-source>`. After that, you need to add the ``bin`` directory to your
-path, so that the build system of Solang can find the correct version of LLVM to use.
+or :ref:`build your own from source <llvm-from-source>`. After that, you need to add the ``bin`` of your
+LLVM directory to your path, so that the build system of Solang can find the correct version of LLVM to use.
 
 Linux
 ~~~~~

--- a/docs/language/contracts.rst
+++ b/docs/language/contracts.rst
@@ -24,15 +24,15 @@ If a constructor has arguments, they must be supplied when the contract is deplo
 If a contract is expected to receive value on instantiation, the constructor should be declared ``payable``.
 
 .. note::
-    On Substrate, constructors have a name. Solang allows naming constructors in the substrate target:
+    Solang allows naming constructors in the Substrate target:
 
     .. code-block:: solidity
- 
+
         contract Foo {
             constructor my_new_foo() {}
         }
 
-    Unnamed constructors will be called ``new`` in the metadata.
+    Constructors without a name will be called ``new`` in the metadata.
 
     Note that constructor names are only used in the generated metadata. For contract instantiation,
     the correct constructor matching the function signature will be selected automatically.
@@ -93,6 +93,9 @@ The constructor should be declared ``payable`` for this to work.
 .. note::
     If no value is specified, then on Parity Substrate the minimum balance (also know as the
     existential deposit) is sent.
+
+.. note::
+    On Solana, this functionality is not available.
 
 Setting the salt, gas, and space for the new contract
 _____________________________________________________

--- a/docs/language/expressions.rst
+++ b/docs/language/expressions.rst
@@ -47,10 +47,6 @@ line argument is specified. No overflow checking is generated in `unchecked` blo
         }
     }
 
-.. warning::
-
-  Overflow checking for types larger than ``int64`` (e.g. ``uint128``) is not implemented yet.
-
 Bitwise operators
 _________________
 
@@ -114,9 +110,9 @@ a bool.
 Increment and Decrement operators
 _________________________________
 
-The post-increment and pre-increment operators are implemented like you would expect. So, ``a++``
-evaluates to the value of ``a`` before incrementing, and ``++a`` evaluates to value of ``a``
-after incrementing.
+The post-increment and pre-increment operators are implemented by reading the variable's
+value before or after modifying it. ``i++``returns the value of ``i`` before incrementing,
+and ``++i`` returns the value of ``i`` after incrementing.
 
 this
 ____
@@ -149,6 +145,11 @@ this only works with public functions.
         }
     }
 
+.. note::
+
+    On Solana, this gives the account of contract data. If you want the account with the program code,
+    use ``tx.program_id``.
+
 type(..) operators
 __________________
 
@@ -177,10 +178,10 @@ an interface at runtime, which can be used to write a `supportsInterface()` func
 in the EIP.
 
 The contract code for a contract, i.e. the binary WebAssembly or BPF, can be retrieved using the
-``type(c).creationCode`` and ``type(c).runtimeCode`` fields, as ``bytes``. In Ethereum,
-the constructor code is in the ``creationCode`` WebAssembly and all the functions are in
-the ``runtimeCode`` WebAssembly or BPF. Parity Substrate has a single WebAssembly code for both,
-so both fields will evaluate to the same value.
+``type(c).creationCode`` and ``type(c).runtimeCode`` fields, as ``bytes``. On EVM,
+the constructor code is in the ``creationCode`` and all the functions are in
+the ``runtimeCode``. Parity Substrate and Solana use the same
+code for both, so those fields will evaluate to the same value.
 
 .. code-block:: solidity
 
@@ -227,7 +228,8 @@ Casting
 _______
 
 Solidity is very strict about the sign of operations, and whether an assignment can truncate a
-value. You can force the compiler to accept truncations or differences in sign by adding a cast.
+value. You can force the compiler to accept truncations or sign changes by adding an
+explicit cast.
 
 Some examples:
 
@@ -248,7 +250,7 @@ The compiler will say:
    implicit conversion would truncate from int256 to int64
 
 Now you can work around this by adding a cast to the argument to return ``return int64(bar);``,
-however it would be much nicer if the return value matched the argument. Instead, implement
+however it is idiomatic to match the return value type with the argument type. Instead, implement
 multiple overloaded abs() functions, so that there is an ``abs()`` for each type.
 
 It is allowed to cast from a ``bytes`` type to ``int`` or ``uint`` (or vice versa), only if the length
@@ -281,4 +283,5 @@ A similar example for truncation:
   bytes4 start2 = bytes4(bytes8(start));
   // first cast, then truncate as bytes: start2 = hex"dead"
 
-Since ``byte`` is array of one byte, a conversion from ``byte`` to ``uint8`` requires a cast.
+Since ``byte`` is an array of one byte, a conversion from ``byte`` to ``uint8`` requires a cast. This is
+because ``byte`` is an alias for ``bytes1``.

--- a/docs/language/imports.rst
+++ b/docs/language/imports.rst
@@ -2,7 +2,7 @@ Imports
 =======
 
 The ``import`` directive is used to import items from other Solidity files. This can be useful to
-keep a single definition in one file, which can be used in other files. For example
+keep a single definition in one file, which can be used in multiple other files. For example,
 you could have an interface in one source file, which several contracts implement or use
 which are in other files. Solidity imports are somewhat similar to JavaScript ES6, however
 there is no export statement, or default export.
@@ -15,10 +15,11 @@ another file.
 - enums definitions
 - event definitions
 - global functions
+- free standing functions
 - contracts, including abstract contract, libraries, and interfaces
 
 There are a few different flavours of import. You can specify if you want everything imported,
-or a just a select few. You can also rename the imports. The following directive imports only
+or just a select few items. You can also rename the imports. The following directive imports only
 `foo` and `bar`:
 
 .. code-block:: solidity
@@ -42,7 +43,7 @@ the command line option ``--importmap @openzeppelin=/opt/openzeppelin-contracts/
 
 .. code-block:: solidity
 
-    import "openzeppelin/interfaces/IERC20.sol";
+    import "@openzeppelin/interfaces/IERC20.sol";
 
 will automatically map to `/opt/openzeppelin-contracts/contracts/interfaces/IERC20.sol`.
 
@@ -67,7 +68,7 @@ there can be no naming conflict.
 
     import "defines.sol" as defs;
 
-This also has a slightly more baroque syntax, which does exactly the same.
+There is another syntax, which does exactly the same.
 
 .. code-block:: solidity
 

--- a/docs/language/introduction.rst
+++ b/docs/language/introduction.rst
@@ -18,6 +18,8 @@ Differences:
 
 - libraries are always statically linked into the contract code
 - Solang generates WebAssembly or BPF rather than EVM.
+- Packed encoded uses little endian encoding, as WASM and BPF are little endian
+  virtual machines.
 
 Unique features to Solang:
 
@@ -28,3 +30,12 @@ Unique features to Solang:
 - Base contracts can be declared in any order
 - There is a ``print()`` function for debugging
 - Strings can be formatted with python style format string, which is useful for debugging: ``print("x = {}".format(x));``
+- Ethereum style address literals like ``0xE0f5206BBD039e7b0592d8918820024e2a7437b9`` are
+  not supported on Substrate or Solana, but are supported for EVM.
+- On Substrate and Solana, base58 style encoded address literals like
+  ``address"5GBWmgdFAMqm8ZgAHGobqDqX6tjLxJhv53ygjNtaaAn3sjeZ"`` are supported, but
+  not with EVM.
+- On Solana, there is special builtin import file called ``'solana'`` available.
+- On Substrate, there is special builtin import file called ``'substrate'`` available.
+- Different blockchains offer different builtins. See the :ref:`builtins documentation <builtins>`.
+- There are many more differences, which are noted throughout the documentation.

--- a/docs/language/pragmas.rst
+++ b/docs/language/pragmas.rst
@@ -39,5 +39,5 @@ Solang takes a different view:
    but of the build environment. No other language set the compiler version in
    the source code.
 
-If anything some languages allow conditional compilation based on the compiler
+If anything, some languages allow conditional compilation based on the compiler
 version, which is much more useful.

--- a/docs/language/statements.rst
+++ b/docs/language/statements.rst
@@ -2,8 +2,8 @@ Statements
 ==========
 
 In functions, you can declare variables in code blocks. If the name is the same as
-an existing function, enum type, or another variable, then the compiler will generate a
-warning as the original item is no longer accessible.
+an existing function, enum type, or another variable, then the compiler will shadow
+the original item and generate a warning as it is no longer accessible.
 
 .. code-block:: solidity
 
@@ -56,12 +56,25 @@ condition must evaluate to a ``bool`` value.
 The statements enclosed by ``{`` and ``}`` (commonly known as a *block*) are executed only if
 the condition evaluates to true.
 
+You can optionally add an ``else`` block which is executed only if the condition evaluates to false.
+
+.. code-block:: solidity
+
+    function foo(uint32 n) private {
+        if (n > 10) {
+            // do something
+        } else {
+            // do something different
+        }
+    }
+
+
 While statement
 _______________
 
 Repeated execution of a block can be achieved using ``while``. It syntax is similar to ``if``,
 however the block is repeatedly executed until the condition evaluates to false.
-If the condition is not true on first execution, then the loop is never executed:
+If the condition is not true on first execution, then the loop body is never executed:
 
 .. code-block:: solidity
 
@@ -90,6 +103,9 @@ cease execution of the block, but repeat the loop if the condition still holds:
               // cease execution of this while loop and jump to the "n = 102" statement
               break;
           }
+
+          // only executed if both if statements were false
+          print("neither true");
       }
 
       n = 102;
@@ -99,7 +115,7 @@ Do While statement
 __________________
 
 A ``do { ... } while (condition);`` statement is much like the ``while (condition) { ... }`` except
-that the condition is evaluated after execution the block. This means that the block is executed
+that the condition is evaluated after executing the block. This means that the block is always executed
 at least once, which is not true for ``while`` statements:
 
 .. code-block:: solidity
@@ -209,9 +225,12 @@ of elements in both sides of the conditional must match the left hand side of th
 Try Catch Statement
 ___________________
 
+Solidity's try-catch statement can only be used with external calls or constructor calls using ``new``. The
+compiler will refuse to compile any other expression.
+
 Sometimes execution gets reverted due to a ``revert()`` or ``require()``. These types of problems
 usually cause the entire transaction to be aborted. However, it is possible to catch
-some of these problems and continue execution.
+some of these problems in the caller and continue execution.
 
 This is only possible for contract instantiation through new, and external function calls.
 An internal function cannot be called from a try catch statement. Not all problems can be handled,

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -29,24 +29,24 @@ followed by one or more solidity source filenames.
 
 Options:
 
--v, \\-\\-verbose
+-v, \-\-verbose
   Make the output more verbose. The compiler tell you what contracts have been
   found in the source, and what files are generated. Without this option Solang
   will be silent if there are no errors or warnings.
 
-\\-\\-target *target*
+\-\-target *target*
   This takes one argument, which can either be ``solana`` or ``substrate``. The target
   must be specified.
 
-\\-\\-address\\-length *length-in-bytes*
+\-\-address\-length *length-in-bytes*
   Change the default address length on Substrate. By default, Substate uses an address type of 32 bytes. This option
   is ignored for any other target.
 
-\\-\\-value\\-length *length-in-bytes*
+\-\-value\-length *length-in-bytes*
   Change the default value length on Substrate. By default, Substate uses an value type of 16 bytes. This option
   is ignored for any other target.
 
--o, \\-\\-output *directory*
+-o, \-\-output *directory*
   This option takes one argument, which is the directory where output should
   be saved. The default is the current directory.
 
@@ -54,25 +54,25 @@ Options:
   This takes one argument, which can either be ``none``, ``less``, ``default``,
   or ``aggressive``. These correspond to llvm optimization levels.
 
-\\-\\-importpath *directory*
+\-\-importpath *directory*
   When resolving ``import`` directives, search this directory. By default ``import``
   will only search the current directory. This option can be specified multiple times
   and the directories will be searched in the order specified.
 
-\\-\\-importmap *map=directory*
+\-\-importmap *map=directory*
   When resolving ``import`` directives, if the first part of the path matches *map*,
   search the directory provided for the file. This option can be specified multiple times
   with different values for map.
 
-\\-\\-help, -h
+\-\-help, -h
   This displays a short description of all the options
 
-\\-\\-standard-json
+\-\-standard-json
   This option causes Solang to emulate the behaviour of Solidity
   `standard json output <https://solidity.readthedocs.io/en/v0.5.13/using-the-compiler.html#output-description>`_. No output files are written, all the
   output will be in json on stdout.
 
-\\-\\-emit *phase*
+\-\-emit *phase*
   This option is can be used for debugging Solang itself. This is used to
   output early phases of compilation.
 
@@ -97,22 +97,22 @@ Options:
   object
     Output wasm object file; this is the contract before final linking.
 
-\\-\\-no\\-constant\\-folding
+\-\-no\-constant\-folding
    Disable the :ref:`constant-folding` codegen optimization
 
-\\-\\-no\\-strength\\-reduce
+\-\-no\-strength\-reduce
    Disable the :ref:`strength-reduce` codegen optimization
 
-\\-\\-no\\-dead\\-storage
+\-\-no\-dead\-storage
    Disable the :ref:`dead-storage` optimization
 
-\\-\\-no\\-vector\\-to\\-slice
+\-\-no\-vector\-to\-slice
    Disable the :ref:`vector-to-slice` optimization
 
-\\-\\-no\\-cse
+\-\-no\-cse
    Disable the :ref:`common-subexpression-elimination` optimization
 
-\\-\\-log\\-api\\-return\\-codes
+\-\-log\-api\-return\-codes
    Disable the :ref:`common-subexpression-elimination` optimization
 
 Generating Documentation Usage
@@ -129,37 +129,37 @@ followed by one or more solidity source filenames.
 
 Options:
 
-\\-\\-target *target*
+\-\-target *target*
   This takes one argument, which can either be ``solana`` or ``substrate``. The target
   must be specified.
 
-\\-\\-address\\-length *length-in-bytes*
+\-\-address\-length *length-in-bytes*
   Change the default address length on Substrate. By default, Substate uses an address type of 32 bytes. This option
   is ignored for any other target.
 
-\\-\\-value\\-length *length-in-bytes*
+\-\-value\-length *length-in-bytes*
   Change the default value length on Substrate. By default, Substate uses an value type of 16 bytes. This option
   is ignored for any other target.
 
-\\-\\-importpath *directory*
+\-\-importpath *directory*
   When resolving ``import`` directives, search this directory. By default ``import``
   will only search the current directory. This option can be specified multiple times
   and the directories will be searched in the order specified.
 
-\\-\\-importmap *map=directory*
+\-\-importmap *map=directory*
   When resolving ``import`` directives, if the first part of the path matches *map*,
   search the directory provided for the file. This option can be specified multiple times
   with different values for map.
 
-\\-\\-help, -h
+\-\-help, -h
   This displays a short description of all the options
 
 .. _idl_command:
 
-Using the idl command
-_____________________
+Generate Solidity interface from IDL
+____________________________________
 
-This command converts Anchor IDL into Solidity import files in order to call
+This command converts Anchor IDL into Solidity import files, so they can be used to call
 Anchor Programs from Solidity.
 
   solang idl [--output DIR] [IDLFILE]...
@@ -169,17 +169,17 @@ for an example of how to use this.
 
 .. note::
 
-  There is only support for Solana at this time.
+  There is only supported on Solana.
 
-Running Solang using container
-______________________________
+Running Solang using a container
+________________________________
 
 First pull the last Solang container from
 `solang containers <https://github.com/hyperledger/solang/pkgs/container/solang>`_:
 
 .. code-block:: bash
 
-    docker pull ghcr.io/hyperledger/solang
+    docker image pull ghcr.io/hyperledger/solang
 
 And if you are using podman:
 
@@ -199,8 +199,8 @@ Or podman:
 
 	  podman container run --rm -it ghcr.io/hyperledger/solang --version
 
-If you want to compile some solidity files, the source file needs to be
-available inside the container. You can do this via the -v command line.
+If you want to compile some Solidity files, the source files need to be
+available inside the container. You can do this via the ``-v`` docker command line.
 In this example ``/local/path`` should be replaced with the absolute path
 to your solidity files:
 

--- a/docs/targets/solana.rst
+++ b/docs/targets/solana.rst
@@ -9,9 +9,12 @@ Solana has the following differences to Ethereum Solidity:
 - An address literal has to be specified using the ``address"36VtvSbE6jVGGQytYWSaDPG7uZphaxEjpJHUUpuUbq4D"`` syntax
 - There is no ``ecrecover()`` builtin function, but there is a ``signatureVerify()`` function which can check ed25519
   signatures.
-- Solana has no concept of gas, so there is no gas functions
+- There is no concept of gas, so there is no gas functions
 - Solana balance is stored in a ``uint64``, so *address* ``.balance``, ``.transfer()`` and ``.send()``
   all use ``uint64`` rather than ``uint256``.
+- Solana uses different accounts for the program code, and the contract data.
+- Programs are upgradable. There is no need to implement upgrades in Solidity.
+- Solana provides different builtins, e.g. ``tx.program_id`` and ``tx.accounts``.
 
 This is how to build your Solidity for Solana:
 
@@ -79,14 +82,14 @@ Calling Anchor Programs from Solidity
 _____________________________________
 
 It is possible to call `Anchor Programs <https://github.com/coral-xyz/anchor>`_
-from Solidity. You first have to generate an interface file from the IDL file using
+from Solidity. You first have to generate a Solidity interface file from the IDL file using
 the :ref:`idl_command`. Then, import the Solidity file in your Solidity using the
-``import "...";`` syntax. Say you have an anchor program called `solidity_from_idl` with a
-function `idl_defined_function`, you can call it like so:
+``import "...";`` syntax. Say you have an anchor program called `bobcat` with a
+function `pounce`, you can call it like so:
 
 .. code-block:: solidity
 
-    import "solidity_from_idl.sol";
+    import "bobcat.sol";
     import "solana";
 
     contract example {
@@ -99,7 +102,7 @@ function `idl_defined_function`, you can call it like so:
             ];
 
             // Any return values are decoded automatically
-            int64 res = solidity_from_idl.idl_defined_function{accounts: am}(arg1, arg2);
+            int64 res = bobcat.pounce{accounts: am}(arg1, arg2);
         }
     }
 
@@ -118,7 +121,7 @@ Solana Cross Program Invocation (CPI) does not support this. This means that:
 
 .. note::
 
-    Hypothetically, this could be implemented like so: the caller could transfer
+    A naive way to implement this is to let the caller transfer
     native balance and then inform the callee about the amount transferred by
     specifying this in the instruction data. However, it would be trivial to
     forge such an operation.
@@ -137,7 +140,7 @@ Builtin Imports
 ________________
 
 Some builtin functionality is only available after importing. The following structs
-can be imported via the special import file ``solana``.
+can be imported via the special builtin import file ``solana``.
 
 .. code-block:: solidity
 
@@ -253,7 +256,7 @@ Solana Library
 ______________
 
 In Solang's Github repository, there is a directory called ``solana-library``. It contains libraries for Solidity contracts
-to interact with Solana specific instructions. Currently, there are two libraries there: one for SPL tokens and another
+to interact with Solana specific instructions. We provide two libraries: one for SPL tokens and another
 for Solana's system instructions. In order to use those functionalities, copy the correspondent library
 file to your project and import it.
 

--- a/docs/targets/substrate.rst
+++ b/docs/targets/substrate.rst
@@ -1,7 +1,7 @@
 Parity Substrate
 ================
 
-Solang works with Parity Substrate 3.0. Note that for recent Substrate Version, cross-contract calls as well as using `address`
+Solang works with Parity Substrate 3.0. Note that for recent Substrate versions, cross-contract calls as well as using `address`
 type as function argument or return values are not supported. We are currently working on fixing any regressions.
 
 The Parity Substrate has the following differences to Ethereum Solidity:

--- a/solang-parser/src/pt.rs
+++ b/solang-parser/src/pt.rs
@@ -497,7 +497,7 @@ pub enum Expression {
     NotEqual(Loc, Box<Expression>, Box<Expression>),
     And(Loc, Box<Expression>, Box<Expression>),
     Or(Loc, Box<Expression>, Box<Expression>),
-    Ternary(Loc, Box<Expression>, Box<Expression>, Box<Expression>),
+    ConditionalOperator(Loc, Box<Expression>, Box<Expression>, Box<Expression>),
     Assign(Loc, Box<Expression>, Box<Expression>),
     AssignOr(Loc, Box<Expression>, Box<Expression>),
     AssignAnd(Loc, Box<Expression>, Box<Expression>),
@@ -563,7 +563,7 @@ impl CodeLocation for Expression {
             | Expression::NotEqual(loc, ..)
             | Expression::And(loc, ..)
             | Expression::Or(loc, ..)
-            | Expression::Ternary(loc, ..)
+            | Expression::ConditionalOperator(loc, ..)
             | Expression::Assign(loc, ..)
             | Expression::AssignOr(loc, ..)
             | Expression::AssignAnd(loc, ..)

--- a/solang-parser/src/solidity.lalrpop
+++ b/solang-parser/src/solidity.lalrpop
@@ -316,7 +316,9 @@ Precedence14: Expression = {
     <a:@L> <l:Precedence13> "*=" <r:Precedence14> <b:@R> => Expression::AssignMultiply(Loc::File(file_no, a, b), Box::new(l), Box::new(r)),
     <a:@L> <l:Precedence13> "/=" <r:Precedence14> <b:@R> => Expression::AssignDivide(Loc::File(file_no, a, b), Box::new(l), Box::new(r)),
     <a:@L> <l:Precedence13> "%=" <r:Precedence14> <b:@R> => Expression::AssignModulo(Loc::File(file_no, a, b), Box::new(l), Box::new(r)),
-    <a:@L> <c:Precedence13> "?" <l:Precedence14> ":" <r:Precedence14> <b:@R> => Expression::Ternary(Loc::File(file_no, a, b), Box::new(c), Box::new(l), Box::new(r)),
+    <a:@L> <c:Precedence13> "?" <l:Precedence14> ":" <r:Precedence14> <b:@R> => {
+        Expression::ConditionalOperator(Loc::File(file_no, a, b), Box::new(c), Box::new(l), Box::new(r))
+    },
     Precedence13,
 }
 

--- a/src/bin/languageserver/mod.rs
+++ b/src/bin/languageserver/mod.rs
@@ -669,7 +669,7 @@ impl SolangServer {
                 SolangServer::construct_expr(expr1, lookup_tbl, symtab, ns);
             }
 
-            ast::Expression::Ternary(_locs, _typ, expr1, expr2, expr3) => {
+            ast::Expression::ConditionalOperator(_locs, _typ, expr1, expr2, expr3) => {
                 SolangServer::construct_expr(expr1, lookup_tbl, symtab, ns);
                 SolangServer::construct_expr(expr2, lookup_tbl, symtab, ns);
                 SolangServer::construct_expr(expr3, lookup_tbl, symtab, ns);

--- a/src/codegen/expression.rs
+++ b/src/codegen/expression.rs
@@ -698,7 +698,7 @@ pub fn expression(
         ast::Expression::AllocDynamicArray(loc, ty, size, init) => {
             alloc_dynamic_array(size, cfg, contract_no, func, ns, vartab, loc, ty, init, opt)
         }
-        ast::Expression::Ternary(loc, ty, cond, left, right) => ternary(
+        ast::Expression::ConditionalOperator(loc, ty, cond, left, right) => conditional_operator(
             loc,
             ty,
             cond,
@@ -1824,7 +1824,7 @@ fn format_string(
     Expression::FormatString(*loc, args)
 }
 
-fn ternary(
+fn conditional_operator(
     loc: &pt::Loc,
     ty: &Type,
     cond: &ast::Expression,
@@ -1851,7 +1851,7 @@ fn ternary(
 
     let left_block = cfg.new_basic_block("left_value".to_string());
     let right_block = cfg.new_basic_block("right_value".to_string());
-    let done_block = cfg.new_basic_block("ternary_done".to_string());
+    let done_block = cfg.new_basic_block("conditional_done".to_string());
 
     cfg.add(
         vartab,

--- a/src/codegen/statements.rs
+++ b/src/codegen/statements.rs
@@ -762,9 +762,9 @@ fn returns(
 ) {
     // Can only be another function call without returns
     let uncast_values = match expr {
-        // Explicitly recurse for ternary expressions.
+        // Explicitly recurse for conditinal operator expressions.
         // `return a ? b : c` is transformed into pseudo code `a ? return b : return c`
-        ast::Expression::Ternary(_, _, cond, left, right) => {
+        ast::Expression::ConditionalOperator(_, _, cond, left, right) => {
             let cond = expression(cond, cfg, contract_no, Some(func), ns, vartab, opt);
 
             let left_block = cfg.new_basic_block("left".to_string());
@@ -836,7 +836,7 @@ fn destructure(
     vartab: &mut Vartable,
     opt: &Options,
 ) {
-    if let ast::Expression::Ternary(_, _, cond, left, right) = expr {
+    if let ast::Expression::ConditionalOperator(_, _, cond, left, right) = expr {
         let cond = expression(cond, cfg, contract_no, Some(func), ns, vartab, opt);
 
         let left_block = cfg.new_basic_block("left".to_string());

--- a/src/sema/ast.rs
+++ b/src/sema/ast.rs
@@ -709,7 +709,7 @@ pub enum Expression {
     Complement(pt::Loc, Type, Box<Expression>),
     UnaryMinus(pt::Loc, Type, Box<Expression>),
 
-    Ternary(
+    ConditionalOperator(
         pt::Loc,
         Type,
         Box<Expression>,
@@ -865,7 +865,7 @@ impl Recurse for Expression {
                 | Expression::Complement(_, _, expr)
                 | Expression::UnaryMinus(_, _, expr) => expr.recurse(cx, f),
 
-                Expression::Ternary(_, _, cond, left, right) => {
+                Expression::ConditionalOperator(_, _, cond, left, right) => {
                     cond.recurse(cx, f);
                     left.recurse(cx, f);
                     right.recurse(cx, f);
@@ -985,7 +985,7 @@ impl CodeLocation for Expression {
             | Expression::Not(loc, _)
             | Expression::Complement(loc, ..)
             | Expression::UnaryMinus(loc, ..)
-            | Expression::Ternary(loc, ..)
+            | Expression::ConditionalOperator(loc, ..)
             | Expression::Subscript(loc, ..)
             | Expression::StructMember(loc, ..)
             | Expression::Or(loc, ..)

--- a/src/sema/dotgraphviz.rs
+++ b/src/sema/dotgraphviz.rs
@@ -837,12 +837,12 @@ impl Dot {
                 self.add_expression(expr, func, ns, node, String::from("expr"));
             }
 
-            Expression::Ternary(loc, ty, cond, left, right) => {
+            Expression::ConditionalOperator(loc, ty, cond, left, right) => {
                 let node = self.add_node(
                     Node::new(
                         "conditional",
                         vec![
-                            format!("conditiona {}", ty.to_string(ns)),
+                            format!("conditional operator {}", ty.to_string(ns)),
                             ns.loc_to_string(loc),
                         ],
                     ),

--- a/src/sema/expression.rs
+++ b/src/sema/expression.rs
@@ -78,7 +78,7 @@ impl RetrieveType for Expression {
             | Expression::BytesCast(_, _, ty, _)
             | Expression::Complement(_, ty, _)
             | Expression::UnaryMinus(_, ty, _)
-            | Expression::Ternary(_, ty, ..)
+            | Expression::ConditionalOperator(_, ty, ..)
             | Expression::StructMember(_, ty, ..)
             | Expression::AllocDynamicArray(_, ty, ..)
             | Expression::PreIncrement(_, ty, ..)
@@ -1862,7 +1862,7 @@ pub fn expression(
             Ok(expr)
         }
 
-        pt::Expression::Ternary(loc, c, l, r) => {
+        pt::Expression::ConditionalOperator(loc, c, l, r) => {
             let left = expression(l, context, ns, symtable, diagnostics, resolve_to)?;
             let right = expression(r, context, ns, symtable, diagnostics, resolve_to)?;
             check_var_usage_expression(ns, &left, &right, symtable);
@@ -1875,7 +1875,7 @@ pub fn expression(
             let left = left.cast(&l.loc(), &ty, true, ns, diagnostics)?;
             let right = right.cast(&r.loc(), &ty, true, ns, diagnostics)?;
 
-            Ok(Expression::Ternary(
+            Ok(Expression::ConditionalOperator(
                 *loc,
                 ty,
                 Box::new(cond),

--- a/src/sema/statements.rs
+++ b/src/sema/statements.rs
@@ -1374,7 +1374,7 @@ fn destructure_values(
             check_function_call(ns, &res, symtable);
             res
         }
-        pt::Expression::Ternary(loc, cond, left, right) => {
+        pt::Expression::ConditionalOperator(loc, cond, left, right) => {
             let cond = expression(
                 cond,
                 context,
@@ -1408,7 +1408,7 @@ fn destructure_values(
             )?;
             used_variable(ns, &right, symtable);
 
-            return Ok(Expression::Ternary(
+            return Ok(Expression::ConditionalOperator(
                 *loc,
                 Type::Unreachable,
                 Box::new(cond),
@@ -1596,7 +1596,7 @@ fn return_with_values(
             used_variable(ns, &expr, symtable);
             expr
         }
-        pt::Expression::Ternary(loc, cond, left, right) => {
+        pt::Expression::ConditionalOperator(loc, cond, left, right) => {
             let cond = expression(
                 cond,
                 context,
@@ -1614,7 +1614,7 @@ fn return_with_values(
                 return_with_values(right, &right.loc(), context, symtable, ns, diagnostics)?;
             used_variable(ns, &right, symtable);
 
-            return Ok(Expression::Ternary(
+            return Ok(Expression::ConditionalOperator(
                 *loc,
                 Type::Unreachable,
                 Box::new(cond),

--- a/tests/contract_testcases/substrate/libraries/using_02.dot
+++ b/tests/contract_testcases/substrate/libraries/using_02.dot
@@ -4,7 +4,7 @@ strict digraph "tests/contract_testcases/substrate/libraries/using_02.sol" {
 	parameters [label="parameters\nuint64 a\nuint64 b"]
 	returns [label="returns\nuint64 "]
 	return [label="return\ntests/contract_testcases/substrate/libraries/using_02.sol:4:17-37"]
-	conditional [label="conditiona unreachable\ntests/contract_testcases/substrate/libraries/using_02.sol:4:24-37"]
+	conditional [label="conditional operator unreachable\ntests/contract_testcases/substrate/libraries/using_02.sol:4:24-37"]
 	more [label="more\ntests/contract_testcases/substrate/libraries/using_02.sol:4:24-29"]
 	variable [label="variable: a\nuint64\ntests/contract_testcases/substrate/libraries/using_02.sol:4:24-25"]
 	variable_9 [label="variable: b\nuint64\ntests/contract_testcases/substrate/libraries/using_02.sol:4:28-29"]

--- a/tests/contract_testcases/substrate/libraries/using_03.dot
+++ b/tests/contract_testcases/substrate/libraries/using_03.dot
@@ -4,7 +4,7 @@ strict digraph "tests/contract_testcases/substrate/libraries/using_03.sol" {
 	parameters [label="parameters\nuint64 a\nuint64 b"]
 	returns [label="returns\nuint64 "]
 	return [label="return\ntests/contract_testcases/substrate/libraries/using_03.sol:4:17-37"]
-	conditional [label="conditiona unreachable\ntests/contract_testcases/substrate/libraries/using_03.sol:4:24-37"]
+	conditional [label="conditional operator unreachable\ntests/contract_testcases/substrate/libraries/using_03.sol:4:24-37"]
 	more [label="more\ntests/contract_testcases/substrate/libraries/using_03.sol:4:24-29"]
 	variable [label="variable: a\nuint64\ntests/contract_testcases/substrate/libraries/using_03.sol:4:24-25"]
 	variable_9 [label="variable: b\nuint64\ntests/contract_testcases/substrate/libraries/using_03.sol:4:28-29"]

--- a/tests/contract_testcases/substrate/libraries/using_04.dot
+++ b/tests/contract_testcases/substrate/libraries/using_04.dot
@@ -15,7 +15,7 @@ strict digraph "tests/contract_testcases/substrate/libraries/using_04.sol" {
 	parameters_14 [label="parameters\nuint64 a\nuint64 b"]
 	returns_15 [label="returns\nuint64 "]
 	return_16 [label="return\ntests/contract_testcases/substrate/libraries/using_04.sol:12:17-37"]
-	conditional [label="conditiona unreachable\ntests/contract_testcases/substrate/libraries/using_04.sol:12:24-37"]
+	conditional [label="conditional operator unreachable\ntests/contract_testcases/substrate/libraries/using_04.sol:12:24-37"]
 	more [label="more\ntests/contract_testcases/substrate/libraries/using_04.sol:12:24-29"]
 	variable_19 [label="variable: a\nuint64\ntests/contract_testcases/substrate/libraries/using_04.sol:12:24-25"]
 	variable_20 [label="variable: b\nuint64\ntests/contract_testcases/substrate/libraries/using_04.sol:12:28-29"]

--- a/tests/contract_testcases/substrate/libraries/using_05.dot
+++ b/tests/contract_testcases/substrate/libraries/using_05.dot
@@ -9,7 +9,7 @@ strict digraph "tests/contract_testcases/substrate/libraries/using_05.sol" {
 	parameters_8 [label="parameters\nuint64 a\nuint64 b"]
 	returns_9 [label="returns\nuint64 "]
 	return [label="return\ntests/contract_testcases/substrate/libraries/using_05.sol:12:17-37"]
-	conditional [label="conditiona unreachable\ntests/contract_testcases/substrate/libraries/using_05.sol:12:24-37"]
+	conditional [label="conditional operator unreachable\ntests/contract_testcases/substrate/libraries/using_05.sol:12:24-37"]
 	more [label="more\ntests/contract_testcases/substrate/libraries/using_05.sol:12:24-29"]
 	variable [label="variable: a\nuint64\ntests/contract_testcases/substrate/libraries/using_05.sol:12:24-25"]
 	variable_14 [label="variable: b\nuint64\ntests/contract_testcases/substrate/libraries/using_05.sol:12:28-29"]

--- a/tests/contract_testcases/substrate/libraries/using_06.dot
+++ b/tests/contract_testcases/substrate/libraries/using_06.dot
@@ -11,7 +11,7 @@ strict digraph "tests/contract_testcases/substrate/libraries/using_06.sol" {
 	parameters_10 [label="parameters\nuint64 a\nuint64 b"]
 	returns_11 [label="returns\nuint64 "]
 	return [label="return\ntests/contract_testcases/substrate/libraries/using_06.sol:14:17-37"]
-	conditional [label="conditiona unreachable\ntests/contract_testcases/substrate/libraries/using_06.sol:14:24-37"]
+	conditional [label="conditional operator unreachable\ntests/contract_testcases/substrate/libraries/using_06.sol:14:24-37"]
 	more [label="more\ntests/contract_testcases/substrate/libraries/using_06.sol:14:24-29"]
 	variable [label="variable: a\nuint64\ntests/contract_testcases/substrate/libraries/using_06.sol:14:24-25"]
 	variable_16 [label="variable: b\nuint64\ntests/contract_testcases/substrate/libraries/using_06.sol:14:28-29"]


### PR DESCRIPTION
I read through our documentation - only got halfway through!

Just because a conditional operator takes three parameters does not mean it should be called ternary. It's just not very descriptive. Also, we might invent another operator which also takes three operators.
