### PR TITLE
Rename ast::Expression::AllocDynamicArray to AllocDynamicBytes

### DIFF
--- a/src/bin/languageserver/mod.rs
+++ b/src/bin/languageserver/mod.rs
@@ -685,7 +685,7 @@ impl SolangServer {
             }
 
             // Array operation expression
-            ast::Expression::AllocDynamicArray(_locs, _typ, expr1, _valvec) => {
+            ast::Expression::AllocDynamicBytes(_locs, _typ, expr1, _valvec) => {
                 SolangServer::construct_expr(expr1, lookup_tbl, symtab, ns);
             }
             ast::Expression::StorageArrayLength { array, .. } => {

--- a/src/codegen/expression.rs
+++ b/src/codegen/expression.rs
@@ -695,7 +695,7 @@ pub fn expression(
         ast::Expression::FormatString(loc, args) => {
             format_string(args, cfg, contract_no, func, ns, vartab, loc, opt)
         }
-        ast::Expression::AllocDynamicArray(loc, ty, size, init) => {
+        ast::Expression::AllocDynamicBytes(loc, ty, size, init) => {
             alloc_dynamic_array(size, cfg, contract_no, func, ns, vartab, loc, ty, init, opt)
         }
         ast::Expression::ConditionalOperator(loc, ty, cond, left, right) => conditional_operator(

--- a/src/sema/ast.rs
+++ b/src/sema/ast.rs
@@ -719,7 +719,7 @@ pub enum Expression {
     Subscript(pt::Loc, Type, Type, Box<Expression>, Box<Expression>),
     StructMember(pt::Loc, Type, Box<Expression>, usize),
 
-    AllocDynamicArray(pt::Loc, Type, Box<Expression>, Option<Vec<u8>>),
+    AllocDynamicBytes(pt::Loc, Type, Box<Expression>, Option<Vec<u8>>),
     StorageArrayLength {
         loc: pt::Loc,
         ty: Type,
@@ -876,7 +876,7 @@ impl Recurse for Expression {
                 }
                 Expression::StructMember(_, _, expr, _) => expr.recurse(cx, f),
 
-                Expression::AllocDynamicArray(_, _, expr, _) => expr.recurse(cx, f),
+                Expression::AllocDynamicBytes(_, _, expr, _) => expr.recurse(cx, f),
                 Expression::StorageArrayLength { array, .. } => array.recurse(cx, f),
                 Expression::StringCompare(_, left, right)
                 | Expression::StringConcat(_, _, left, right) => {
@@ -989,7 +989,7 @@ impl CodeLocation for Expression {
             | Expression::Subscript(loc, ..)
             | Expression::StructMember(loc, ..)
             | Expression::Or(loc, ..)
-            | Expression::AllocDynamicArray(loc, ..)
+            | Expression::AllocDynamicBytes(loc, ..)
             | Expression::StorageArrayLength { loc, .. }
             | Expression::StringCompare(loc, ..)
             | Expression::StringConcat(loc, ..)

--- a/src/sema/dotgraphviz.rs
+++ b/src/sema/dotgraphviz.rs
@@ -886,7 +886,7 @@ impl Dot {
                 self.add_expression(var, func, ns, node, String::from("var"));
             }
 
-            Expression::AllocDynamicArray(loc, ty, length, initializer) => {
+            Expression::AllocDynamicBytes(loc, ty, length, initializer) => {
                 let mut labels = vec![
                     format!("alloc array {}", ty.to_string(ns)),
                     ns.loc_to_string(loc),

--- a/src/sema/expression.rs
+++ b/src/sema/expression.rs
@@ -80,7 +80,7 @@ impl RetrieveType for Expression {
             | Expression::UnaryMinus(_, ty, _)
             | Expression::ConditionalOperator(_, ty, ..)
             | Expression::StructMember(_, ty, ..)
-            | Expression::AllocDynamicArray(_, ty, ..)
+            | Expression::AllocDynamicBytes(_, ty, ..)
             | Expression::PreIncrement(_, ty, ..)
             | Expression::PreDecrement(_, ty, ..)
             | Expression::PostIncrement(_, ty, ..)
@@ -355,7 +355,7 @@ impl Expression {
             }
             (&Expression::BytesLiteral(loc, _, ref init), _, &Type::DynamicBytes)
             | (&Expression::BytesLiteral(loc, _, ref init), _, &Type::String) => {
-                return Ok(Expression::AllocDynamicArray(
+                return Ok(Expression::AllocDynamicBytes(
                     loc,
                     to.clone(),
                     Box::new(Expression::NumberLiteral(
@@ -2189,7 +2189,7 @@ fn string_literal(
     let length = result.len();
 
     match resolve_to {
-        ResolveTo::Type(Type::String) => Expression::AllocDynamicArray(
+        ResolveTo::Type(Type::String) => Expression::AllocDynamicBytes(
             loc,
             Type::String,
             Box::new(Expression::NumberLiteral(
@@ -2200,7 +2200,7 @@ fn string_literal(
             Some(result),
         ),
         ResolveTo::Type(Type::Slice(ty)) if ty.as_ref() == &Type::Bytes(1) => {
-            Expression::AllocDynamicArray(
+            Expression::AllocDynamicBytes(
                 loc,
                 Type::Slice(ty.clone()),
                 Box::new(Expression::NumberLiteral(
@@ -2240,7 +2240,7 @@ fn hex_literal(
 
     match resolve_to {
         ResolveTo::Type(Type::Slice(ty)) if ty.as_ref() == &Type::Bytes(1) => {
-            Ok(Expression::AllocDynamicArray(
+            Ok(Expression::AllocDynamicBytes(
                 loc,
                 Type::Slice(ty.clone()),
                 Box::new(Expression::NumberLiteral(
@@ -2251,7 +2251,7 @@ fn hex_literal(
                 Some(result),
             ))
         }
-        ResolveTo::Type(Type::DynamicBytes) => Ok(Expression::AllocDynamicArray(
+        ResolveTo::Type(Type::DynamicBytes) => Ok(Expression::AllocDynamicBytes(
             loc,
             Type::DynamicBytes,
             Box::new(Expression::NumberLiteral(
@@ -3665,7 +3665,7 @@ pub fn new(
         size_expr.cast(&size_loc, &expected_ty, true, ns, diagnostics)?
     };
 
-    Ok(Expression::AllocDynamicArray(
+    Ok(Expression::AllocDynamicBytes(
         *loc,
         ty,
         Box::new(size),

--- a/src/sema/symtable.rs
+++ b/src/sema/symtable.rs
@@ -51,7 +51,7 @@ impl Variable {
                 // the variable is not a reference to another.
                 return !matches!(
                     **expr,
-                    Expression::AllocDynamicArray(..)
+                    Expression::AllocDynamicBytes(..)
                         | Expression::ArrayLiteral(..)
                         | Expression::Constructor { .. }
                         | Expression::StructLiteral(..)


### PR DESCRIPTION
The CFG expression was already renamed, rename the AST expression to match.

Signed-off-by: Sean Young <sean@mess.org>