### PR TITLE
Use IndexMap for enum declaration

### DIFF
--- a/src/abi/substrate.rs
+++ b/src/abi/substrate.rs
@@ -9,7 +9,6 @@ use ink_metadata::{
     MessageSpec, ReturnTypeSpec, TypeSpec,
 };
 
-use itertools::Itertools;
 use serde_json::Value;
 
 use num_bigint::BigInt;
@@ -175,15 +174,14 @@ fn resolve_ast(ty: &ast::Type, ns: &ast::Namespace, registry: &mut PortableRegis
         }
         ast::Type::Enum(n) => {
             let decl = &ns.enums[*n];
-            let mut variants = decl.values.iter().collect_vec();
-            // sort by discriminant
-            variants.sort_by(|a, b| a.1 .1.cmp(&b.1 .1));
-            let variants = variants
-                .into_iter()
-                .map(|(k, v)| Variant {
+            let variants = decl
+                .values
+                .iter()
+                .enumerate()
+                .map(|(idx, (k, _))| Variant {
                     name: k.clone(),
                     fields: Default::default(),
-                    index: v.1 as u8,
+                    index: idx as u8,
                     docs: Default::default(),
                 })
                 .collect::<Vec<_>>();

--- a/src/bin/doc/mod.rs
+++ b/src/bin/doc/mod.rs
@@ -236,8 +236,8 @@ pub fn generate_docs(outdir: &OsString, files: &[ast::Namespace], verbose: bool)
 
             let mut field: Vec<&str> = Vec::new();
             field.resize(enum_decl.values.len(), "");
-            for (value, (_, pos)) in &enum_decl.values {
-                field[*pos] = value;
+            for (idx, (value, _)) in enum_decl.values.iter().enumerate() {
+                field[idx] = value;
             }
 
             top.enums.push(EnumDecl {

--- a/src/bin/languageserver/mod.rs
+++ b/src/bin/languageserver/mod.rs
@@ -923,11 +923,11 @@ impl SolangServer {
     // Traverses namespace to build messages stored in the lookup table for hover feature.
     fn traverse(ns: &ast::Namespace, lookup_tbl: &mut Vec<HoverEntry>) {
         for enm in &ns.enums {
-            for (nam, vals) in &enm.values {
-                let val = format!("{} {}, \n\n", nam, vals.1);
+            for (idx, (nam, loc)) in enm.values.iter().enumerate() {
+                let val = format!("{} {}, \n\n", nam, idx);
                 lookup_tbl.push(HoverEntry {
-                    start: vals.0.start(),
-                    stop: vals.0.end(),
+                    start: loc.start(),
+                    stop: loc.end(),
                     val,
                 });
             }
@@ -1078,8 +1078,8 @@ impl SolangServer {
                 let mut values = Vec::new();
                 values.resize(enm.values.len(), "");
 
-                for (name, value) in &enm.values {
-                    values[value.1] = name;
+                for (idx, value) in enm.values.iter().enumerate() {
+                    values[idx] = value.0;
                 }
 
                 let mut iter = values.iter().peekable();

--- a/src/sema/ast.rs
+++ b/src/sema/ast.rs
@@ -6,6 +6,7 @@ use crate::diagnostics::Diagnostics;
 use crate::sema::yul::ast::{InlineAssembly, YulFunction};
 use crate::sema::Recurse;
 use crate::{codegen, Target};
+use indexmap::IndexMap;
 use num_bigint::BigInt;
 use num_rational::BigRational;
 pub use solang_parser::diagnostics::*;
@@ -174,7 +175,7 @@ pub struct EnumDecl {
     pub contract: Option<String>,
     pub loc: pt::Loc,
     pub ty: Type,
-    pub values: HashMap<String, (pt::Loc, usize)>,
+    pub values: IndexMap<String, pt::Loc>,
 }
 
 impl fmt::Display for EnumDecl {

--- a/src/sema/dotgraphviz.rs
+++ b/src/sema/dotgraphviz.rs
@@ -2070,11 +2070,11 @@ impl Namespace {
             let enums = dot.add_node(Node::new("enums", Vec::new()), None, None);
 
             for decl in &self.enums {
-                let mut labels = vec![String::new(); decl.values.len()];
-
-                for (name, (_, pos)) in &decl.values {
-                    labels[*pos] = format!("value: {}", name);
-                }
+                let mut labels = decl
+                    .values
+                    .iter()
+                    .map(|(name, _)| format!("value: {}", name))
+                    .collect::<Vec<String>>();
 
                 labels.insert(0, self.loc_to_string(&decl.loc));
                 if let Some(contract) = &decl.contract {

--- a/src/sema/expression.rs
+++ b/src/sema/expression.rs
@@ -436,7 +436,7 @@ impl Expression {
                 // TODO would be help to have current contract to resolve contract constants
                 if let Ok((_, big_number)) = eval_const_number(self, ns) {
                     if let Some(number) = big_number.to_usize() {
-                        if enum_ty.values.values().any(|(_, v)| *v == number) {
+                        if enum_ty.values.len() > number {
                             return Ok(Expression::NumberLiteral(
                                 self.loc(),
                                 to.clone(),
@@ -4411,11 +4411,11 @@ fn enum_value(
     }
 
     if let Some(e) = ns.resolve_enum(file_no, contract_no, namespace[0]) {
-        match ns.enums[e].values.get(&id.name) {
-            Some((_, val)) => Ok(Some(Expression::NumberLiteral(
+        match ns.enums[e].values.get_full(&id.name) {
+            Some((val, _, _)) => Ok(Some(Expression::NumberLiteral(
                 *loc,
                 Type::Enum(e),
-                BigInt::from_usize(*val).unwrap(),
+                BigInt::from_usize(val).unwrap(),
             ))),
             None => {
                 diagnostics.push(Diagnostic::error(

--- a/src/sema/types.rs
+++ b/src/sema/types.rs
@@ -11,6 +11,7 @@ use super::{
     SOLANA_SPARSE_ARRAY_SIZE,
 };
 use crate::Target;
+use indexmap::IndexMap;
 use num_bigint::BigInt;
 use num_traits::{One, Zero};
 use solang_parser::{
@@ -19,7 +20,7 @@ use solang_parser::{
     pt::CodeLocation,
 };
 use std::collections::HashSet;
-use std::{collections::HashMap, fmt::Write, ops::Mul};
+use std::{fmt::Write, ops::Mul};
 
 /// List the types which should be resolved later
 pub struct ResolveFields<'a> {
@@ -657,14 +658,14 @@ fn enum_decl(
     }
 
     // check for duplicates
-    let mut entries: HashMap<String, (pt::Loc, usize)> = HashMap::new();
+    let mut entries: IndexMap<String, pt::Loc> = IndexMap::new();
 
-    for (i, e) in enum_.values.iter().enumerate() {
+    for e in enum_.values.iter() {
         if let Some(prev) = entries.get(&e.as_ref().unwrap().name.to_string()) {
             ns.diagnostics.push(Diagnostic::error_with_note(
                 e.as_ref().unwrap().loc,
                 format!("duplicate enum value {}", e.as_ref().unwrap().name),
-                prev.0,
+                *prev,
                 "location of previous definition".to_string(),
             ));
             valid = false;
@@ -673,7 +674,7 @@ fn enum_decl(
 
         entries.insert(
             e.as_ref().unwrap().name.to_string(),
-            (e.as_ref().unwrap().loc, i),
+            e.as_ref().unwrap().loc,
         );
     }
 


### PR DESCRIPTION
Previously, we had a `HashMap<String, (Loc, usize)>` to save the items of an enumeration. Retrieving the item name having its index is awful, so I changed the structure to `IndexMap<String, Loc>`, from which we can retrieve its name and Loc when we index it with an `usize`.

The context for this PR is that I need to retrieve the item name from its index when generating the Anchor IDL from a Solidity contract.