### PR TITLE
Make solang build with inkwell 0.1.0-beta.5

### DIFF
--- a/src/emit/cfg.rs
+++ b/src/emit/cfg.rs
@@ -220,7 +220,7 @@ pub(super) fn create_block<'a>(
     block_no: usize,
     bin: &Binary<'a>,
     cfg: &ControlFlowGraph,
-    function: FunctionValue,
+    function: FunctionValue<'a>,
     ns: &Namespace,
 ) -> BasicBlock<'a> {
     let cfg_bb = &cfg.blocks[block_no];

--- a/src/emit/instructions.rs
+++ b/src/emit/instructions.rs
@@ -1198,7 +1198,7 @@ fn add_or_retrieve_block<'a>(
     block_no: usize,
     pos: inkwell::basic_block::BasicBlock<'a>,
     bin: &Binary<'a>,
-    function: FunctionValue,
+    function: FunctionValue<'a>,
     blocks: &mut HashMap<usize, BasicBlock<'a>>,
     work: &mut VecDeque<Work<'a>>,
     w: &mut Work<'a>,

--- a/src/emit/loop_builder.rs
+++ b/src/emit/loop_builder.rs
@@ -22,7 +22,7 @@ pub struct LoopBuilder<'a> {
 impl<'a> LoopBuilder<'a> {
     /// Create a new loop. This creates the basic blocks and inserts a branch to start of the loop at
     /// the current location. This function should be called first.
-    pub fn new(binary: &Binary<'a>, function: FunctionValue) -> Self {
+    pub fn new(binary: &Binary<'a>, function: FunctionValue<'a>) -> Self {
         let entry_block = binary.builder.get_insert_block().unwrap();
         let condition_block = binary.context.append_basic_block(function, "cond");
         let body_block = binary.context.append_basic_block(function, "body");

--- a/src/emit/mod.rs
+++ b/src/emit/mod.rs
@@ -104,7 +104,7 @@ pub trait TargetRuntime<'a> {
         binary: &Binary<'a>,
         ty: &ast::Type,
         slot: &mut IntValue<'a>,
-        function: FunctionValue,
+        function: FunctionValue<'a>,
         ns: &ast::Namespace,
     ) -> BasicValueEnum<'a>;
 

--- a/src/emit/solana/target.rs
+++ b/src/emit/solana/target.rs
@@ -540,7 +540,7 @@ impl<'a> TargetRuntime<'a> for SolanaTarget {
         binary: &Binary<'a>,
         ty: &ast::Type,
         slot: &mut IntValue<'a>,
-        function: FunctionValue,
+        function: FunctionValue<'a>,
         ns: &ast::Namespace,
     ) -> BasicValueEnum<'a> {
         let data = self.contract_storage_data(binary);


### PR DESCRIPTION
Offender in Cargo.toml is:

`inkwell = { version = "^0.1.0-beta.4", features = ["target-webassembly", "target-bpf", "no-libffi-linking", "llvm13-0"], optional = true }`

I can't find any release notes for `inkwell`? I guess since everything green on our CI it is fine for us to ape `0.1.0-beta.5` in. But would be nice to know what's changed.