### PR TITLE
Improve CI and other fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,6 @@ jobs:
         uses: actions/checkout@v3
       - name: Rust stable
         run: rustup default stable
-      - name: Install python3
-        run: apt-get -y install python3
       - uses: enarx/spdx@master
         with:
           licenses: Apache-2.0 MIT
@@ -44,11 +42,11 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
-      - name: Install Python
+      - name: Install Python and git
         run: |
           apt-get update
-          apt-get install -y python3-pip
-      - name: Install Docs requiremets
+          apt-get install -y python3-pip git
+      - name: Install Docs requirements.txt
         run : |
           pip install -r requirements.txt
       - name: Build docs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ tiny-keccak = { version = "2.0", features = ["keccak"] }
 serde_json = "1.0"
 serde = "1.0"
 serde_derive = { version = "1.0" }
-inkwell = { version = "^0.1.0-beta.4", features = ["target-webassembly", "target-bpf", "no-libffi-linking", "llvm13-0"], optional = true }
+inkwell = { version = "0.1.0-beta.5", features = ["target-webassembly", "target-bpf", "no-libffi-linking", "llvm13-0"], optional = true }
 blake2-rfc = "0.2.18"
 handlebars = "4.2"
 contract-metadata = "1.5.0"

--- a/solang-parser/Cargo.toml
+++ b/solang-parser/Cargo.toml
@@ -15,7 +15,7 @@ lalrpop = "0.19"
 
 [dependencies]
 lalrpop-util = "0.19"
-phf = { version = "0.10", features = ["macros"] }
+phf = { version = "0.11", features = ["macros"] }
 unicode-xid = "0.2.0"
 itertools = "0.10"
 serde = { version = "1.0.145", features = ["derive"], optional = true }

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -108,7 +108,7 @@
 	},
 	"__metadata": {
 		"id": "3134b20d-911a-4418-a461-3f2380f4a1c2",
-		"publisherDisplayName": "solang.io",
+		"publisherDisplayName": "Hyperledger Solang",
 		"publisherId": "6c1a8c6d-5493-4493-81d2-e899244f0def",
 		"isPreReleaseVersion": false
 	}


### PR DESCRIPTION
- Solang CI already has python3, no need to install
- Docs needs git
- solang.io domain no longer registered (expired)
- Do not use ^ for crates