### PR TITLE
Freeze Borsh library version

### DIFF
--- a/integration/anchor/package.json
+++ b/integration/anchor/package.json
@@ -7,7 +7,7 @@
     },
     "dependencies": {
         "@project-serum/anchor": "^0.25.0",
-        "@solana/solidity": "^0.0.22",
+        "@solana/solidity": "0.0.23",
         "ts-node": "^10.9.1",
         "tsc-node": "^0.0.3"
     },

--- a/integration/solana/package.json
+++ b/integration/solana/package.json
@@ -17,8 +17,8 @@
     "typescript": "^4.1.2"
   },
   "dependencies": {
-    "@dao-xyz/borsh": "^3.1.0",
-    "@solana/solidity": "0.0.22",
+    "@dao-xyz/borsh": "3.3.0",
+    "@solana/solidity": "0.0.23",
     "@solana/spl-token": "0.2.0",
     "@solana/web3.js": "^1.30.2 <1.40.0",
     "ethers": "^5.2.0",


### PR DESCRIPTION
The `@dao-xyz/borsh` library had an update with breaking changes. This PR freezes the version that currently works with our Typescript tests.