### PR TITLE
Update `@solana/solidity.js` version to fix Solana integration tests

### DIFF
--- a/integration/anchor/package.json
+++ b/integration/anchor/package.json
@@ -7,7 +7,7 @@
     },
     "dependencies": {
         "@project-serum/anchor": "^0.25.0",
-        "@solana/solidity": "0.0.23",
+        "@solana/solidity": "0.0.24",
         "ts-node": "^10.9.1",
         "tsc-node": "^0.0.3"
     },

--- a/integration/solana/package.json
+++ b/integration/solana/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@dao-xyz/borsh": "3.3.0",
-    "@solana/solidity": "0.0.23",
+    "@solana/solidity": "0.0.24",
     "@solana/spl-token": "0.2.0",
     "@solana/web3.js": "^1.30.2 <1.40.0",
     "ethers": "^5.2.0",


### PR DESCRIPTION
#1089 introduced discriminators to replace selectors on Solana. This broke the integration tests and needed an updated version of our `@solana/solidity.js` Typescript library. This PR fix such an issue.