### PR TITLE
Only emit in codegen when needed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ funty = "2.0"
 itertools = "0.10"
 num-rational = "0.4"
 indexmap = "1.8"
-once_cell = "1.10"
+once_cell = "1.16"
 solang-parser = { path = "solang-parser", version = "0.2.0" }
 codespan-reporting = "0.11"
 phf = { version = "0.11", features = ["macros"] }
@@ -57,7 +57,6 @@ parse-display = "0.6.0"
 parity-scale-codec = "3.1"
 ink = "4.0.0-beta"
 scale-info = "2.3"
-
 
 [dev-dependencies]
 num-derive = "0.3"

--- a/src/codegen/cfg.rs
+++ b/src/codegen/cfg.rs
@@ -816,15 +816,6 @@ impl ControlFlowGraph {
             Expression::InternalFunctionCfg(cfg_no) => {
                 format!("function {}", contract.cfg[*cfg_no].name)
             }
-            Expression::CodeLiteral(_, contract_no, runtime) => format!(
-                "({} code contract {})",
-                if *runtime {
-                    "runtimeCode"
-                } else {
-                    "creationCode"
-                },
-                ns.contracts[*contract_no].name,
-            ),
             Expression::ReturnData(_) => "(external call return data)".to_string(),
             Expression::Cast(_, ty, e) => format!(
                 "{}({})",

--- a/src/codegen/constant_folding.rs
+++ b/src/codegen/constant_folding.rs
@@ -1166,7 +1166,6 @@ fn expression(
         | Expression::RationalNumberLiteral(..)
         | Expression::BoolLiteral(..)
         | Expression::BytesLiteral(..)
-        | Expression::CodeLiteral(..)
         | Expression::FunctionArg(..) => (expr.clone(), true),
 
         Expression::ReturnData(_)

--- a/src/codegen/expression.rs
+++ b/src/codegen/expression.rs
@@ -722,9 +722,7 @@ pub fn expression(
         ast::Expression::BytesLiteral(loc, ty, arr) => {
             Expression::BytesLiteral(*loc, ty.clone(), arr.clone())
         }
-        ast::Expression::CodeLiteral(loc, pos, boolean) => {
-            Expression::CodeLiteral(*loc, *pos, *boolean)
-        }
+        ast::Expression::CodeLiteral(loc, contract_no, _) => code(loc, *contract_no, ns, opt),
         ast::Expression::NumberLiteral(loc, ty, n) => {
             Expression::NumberLiteral(*loc, ty.clone(), n.clone())
         }
@@ -2926,4 +2924,15 @@ pub(super) fn assert_failure(
             encoded_args: Some(encoded_buffer),
         },
     )
+}
+
+/// Generate the binary code for a contract
+fn code(loc: &Loc, contract_no: usize, ns: &Namespace, opt: &Options) -> Expression {
+    let contract = &ns.contracts[contract_no];
+
+    let code = contract.emit(ns, opt);
+
+    let size = Expression::NumberLiteral(*loc, Type::Uint(32), code.len().into());
+
+    Expression::AllocDynamicBytes(*loc, Type::DynamicBytes, size.into(), Some(code))
 }

--- a/src/codegen/yul/tests/expression.rs
+++ b/src/codegen/yul/tests/expression.rs
@@ -12,6 +12,7 @@ use crate::sema::yul::ast;
 use crate::sema::yul::ast::YulSuffix;
 use crate::{sema, Target};
 use num_bigint::{BigInt, Sign};
+use once_cell::unsync::OnceCell;
 use solang_parser::pt::{ContractTy, Loc, StorageLocation, Visibility};
 
 #[test]
@@ -134,7 +135,7 @@ fn contract_constant_variable() {
         initializer: None,
         default_constructor: None,
         cfg: vec![],
-        code: vec![],
+        code: OnceCell::new(),
         instantiable: true,
         dispatch_no: 0,
         constructor_dispatch: None,
@@ -256,7 +257,7 @@ fn slot_suffix() {
         initializer: None,
         default_constructor: None,
         cfg: vec![],
-        code: vec![],
+        code: OnceCell::new(),
         instantiable: true,
         dispatch_no: 0,
         constructor_dispatch: None,

--- a/src/emit/cfg.rs
+++ b/src/emit/cfg.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::codegen::cfg::ControlFlowGraph;
-use crate::codegen::vartable::Storage;
+use crate::codegen::{cfg::ControlFlowGraph, vartable::Storage};
 use crate::emit::binary::Binary;
 use crate::emit::instructions::process_instruction;
 use crate::emit::{TargetRuntime, Variable};
@@ -39,7 +38,7 @@ pub(super) fn emit_cfg<'a, T: TargetRuntime<'a> + ?Sized>(
     let file = compile_unit.get_file();
     let mut di_func_scope: Option<DISubprogram<'_>> = None;
 
-    if bin.generate_debug_info {
+    if bin.options.generate_debug_information {
         let return_type = function.get_type().get_return_type();
         match return_type {
             None => {}
@@ -182,7 +181,7 @@ pub(super) fn emit_cfg<'a, T: TargetRuntime<'a> + ?Sized>(
         }
 
         for (_, ins) in &cfg.blocks[w.block_no].instr {
-            if bin.generate_debug_info {
+            if bin.options.generate_debug_information {
                 let debug_loc = ins.loc();
                 if let pt::Loc::File(file_offset, offset, _) = debug_loc {
                     let (line, col) = ns.files[file_offset].offset_to_line_column(offset);

--- a/src/emit/functions.rs
+++ b/src/emit/functions.rs
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::emit::binary::Binary;
-use crate::emit::cfg::emit_cfg;
-use crate::emit::TargetRuntime;
-use crate::sema::ast::{Contract, Namespace, Type};
-use inkwell::module::Linkage;
-use inkwell::values::FunctionValue;
-use inkwell::{AddressSpace, IntPredicate};
+use crate::{
+    emit::{binary::Binary, cfg::emit_cfg, TargetRuntime},
+    sema::ast::{Contract, Namespace, Type},
+};
+use inkwell::{
+    module::Linkage,
+    values::FunctionValue,
+    {AddressSpace, IntPredicate},
+};
 
 /// Emit all functions, constructors, fallback and receiver
 pub(super) fn emit_functions<'a, T: TargetRuntime<'a>>(

--- a/src/emit/instructions.rs
+++ b/src/emit/instructions.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::codegen::cfg::{ControlFlowGraph, Instr, InternalCallTy, ReturnCode};
-use crate::codegen::Expression;
+use crate::codegen::{
+    cfg::{ControlFlowGraph, Instr, InternalCallTy, ReturnCode},
+    Expression,
+};
 use crate::emit::binary::Binary;
 use crate::emit::cfg::{create_block, BasicBlock, Work};
 use crate::emit::expression::expression;

--- a/src/emit/math.rs
+++ b/src/emit/math.rs
@@ -311,7 +311,7 @@ pub(super) fn multiply<'a, T: TargetRuntime<'a> + ?Sized>(
                 .build_store(r, bin.builder.build_int_z_extend(right, mul_ty, ""));
         }
 
-        if bin.math_overflow_check && !unchecked {
+        if bin.options.math_overflow_check && !unchecked {
             if signed {
                 return signed_ovf_detect(
                     target, bin, mul_ty, mul_bits, left, right, bits, function,
@@ -420,7 +420,7 @@ pub(super) fn multiply<'a, T: TargetRuntime<'a> + ?Sized>(
         } else {
             return call_mul32_without_ovf(bin, l, r, o, mul_bits, left.get_type());
         }
-    } else if bin.math_overflow_check && !unchecked {
+    } else if bin.options.math_overflow_check && !unchecked {
         build_binary_op_with_overflow_check(
             target,
             bin,

--- a/src/emit/substrate/mod.rs
+++ b/src/emit/substrate/mod.rs
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::sema::ast;
+use crate::{codegen::Options, sema::ast};
 use inkwell::context::Context;
 use inkwell::module::{Linkage, Module};
 use inkwell::types::BasicType;
 use inkwell::values::{BasicValueEnum, FunctionValue, IntValue, PointerValue};
 use inkwell::AddressSpace;
 use inkwell::IntPredicate;
-use inkwell::OptimizationLevel;
 use num_traits::ToPrimitive;
 use solang_parser::pt;
 use std::collections::HashMap;
@@ -129,10 +128,7 @@ impl SubstrateTarget {
         contract: &'a ast::Contract,
         ns: &'a ast::Namespace,
         filename: &'a str,
-        opt: OptimizationLevel,
-        math_overflow_check: bool,
-        generate_debug_info: bool,
-        log_api_return_codes: bool,
+        opt: &'a Options,
     ) -> Binary<'a> {
         let mut binary = Binary::new(
             context,
@@ -140,11 +136,8 @@ impl SubstrateTarget {
             &contract.name,
             filename,
             opt,
-            math_overflow_check,
             std_lib,
             None,
-            generate_debug_info,
-            log_api_return_codes,
         );
 
         binary.set_early_value_aborts(contract, ns);
@@ -1870,7 +1863,7 @@ fn event_id<'b>(
 
 /// Print the return code of API calls to the debug buffer.
 fn log_return_code<'b>(binary: &Binary<'b>, api: &'static str, code: IntValue) {
-    if !binary.log_api_return_codes {
+    if !binary.options.log_api_return_codes {
         return;
     }
 

--- a/src/emit/substrate/target.rs
+++ b/src/emit/substrate/target.rs
@@ -1064,6 +1064,8 @@ impl<'a> TargetRuntime<'a> for SubstrateTarget {
 
         let created_contract = &ns.contracts[contract_no];
 
+        let code = created_contract.emit(ns, binary.options);
+
         let (scratch_buf, scratch_len) = scratch_buf!();
 
         // salt
@@ -1122,12 +1124,10 @@ impl<'a> TargetRuntime<'a> for SubstrateTarget {
             );
         }
 
-        assert!(!created_contract.code.is_empty());
-
         // code hash
         let codehash = binary.emit_global_string(
             &format!("binary_{}_codehash", created_contract.name),
-            blake2_rfc::blake2b::blake2b(32, &[], &created_contract.code).as_bytes(),
+            blake2_rfc::blake2b::blake2b(32, &[], &code).as_bytes(),
             true,
         );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,34 +129,38 @@ pub fn compile(
     log_api_return_codes: bool,
 ) -> (Vec<(Vec<u8>, String)>, sema::ast::Namespace) {
     let mut ns = parse_and_resolve(filename, resolver, target);
+    let opts = codegen::Options {
+        math_overflow_check,
+        log_api_return_codes,
+        opt_level: opt_level.into(),
+        ..Default::default()
+    };
 
     if ns.diagnostics.any_errors() {
         return (Vec::new(), ns);
     }
 
     // codegen all the contracts
-    codegen::codegen(
-        &mut ns,
-        &codegen::Options {
-            math_overflow_check,
-            log_api_return_codes,
-            opt_level: opt_level.into(),
-            ..Default::default()
-        },
-    );
+    codegen::codegen(&mut ns, &opts);
 
-    let results = (0..ns.contracts.len())
-        .filter(|c| ns.contracts[*c].instantiable)
-        .map(|c| {
-            // codegen has already happened
-            assert!(!ns.contracts[c].code.is_empty());
+    if ns.diagnostics.any_errors() {
+        return (Vec::new(), ns);
+    }
 
-            let code = &ns.contracts[c].code;
-            let (abistr, _) = abi::generate_abi(c, &ns, code, false);
+    // emit the contracts
+    let mut results = Vec::new();
 
-            (code.clone(), abistr)
-        })
-        .collect();
+    for contract_no in 0..ns.contracts.len() {
+        let contract = &ns.contracts[contract_no];
+
+        if contract.instantiable {
+            let code = contract.emit(&ns, &opts);
+
+            let (abistr, _) = abi::generate_abi(contract_no, &ns, &code, false);
+
+            results.push((code, abistr));
+        };
+    }
 
     (results, ns)
 }

--- a/src/sema/ast.rs
+++ b/src/sema/ast.rs
@@ -10,6 +10,7 @@ use crate::{codegen, Target};
 use indexmap::IndexMap;
 use num_bigint::BigInt;
 use num_rational::BigRational;
+use once_cell::unsync::OnceCell;
 pub use solang_parser::diagnostics::*;
 use solang_parser::pt;
 use solang_parser::pt::{CodeLocation, FunctionTy, OptionalCodeLocation};
@@ -649,7 +650,8 @@ pub struct Contract {
     pub initializer: Option<usize>,
     pub default_constructor: Option<(Function, usize)>,
     pub cfg: Vec<ControlFlowGraph>,
-    pub code: Vec<u8>,
+    /// Compiled program. Only available after emit.
+    pub code: OnceCell<Vec<u8>>,
     /// Can the contract be instantiated, i.e. not abstract, no errors, etc.
     pub instantiable: bool,
     /// CFG number of this contract's dispatch function

--- a/src/sema/contracts.rs
+++ b/src/sema/contracts.rs
@@ -1,14 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use num_bigint::BigInt;
-use num_traits::Zero;
-use solang_parser::diagnostics::Diagnostic;
-use solang_parser::pt::FunctionTy;
-use solang_parser::pt::{self, CodeLocation};
-use std::collections::{BTreeMap, HashMap, HashSet};
-use std::convert::TryInto;
-use tiny_keccak::{Hasher, Keccak};
-
 use super::{
     annotions_not_allowed, ast,
     diagnostics::Diagnostics,
@@ -17,10 +8,16 @@ use super::{
     symtable::Symtable,
     using, variables, ContractDefinition,
 };
-#[cfg(feature = "llvm")]
-use crate::emit;
-use crate::sema::ast::Namespace;
-use crate::sema::unused_variable::emit_warning_local_variable;
+use crate::{sema::ast::Namespace, sema::unused_variable::emit_warning_local_variable};
+use num_bigint::BigInt;
+use num_traits::Zero;
+use once_cell::unsync::OnceCell;
+use solang_parser::diagnostics::Diagnostic;
+use solang_parser::pt::FunctionTy;
+use solang_parser::pt::{self, CodeLocation};
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::convert::TryInto;
+use tiny_keccak::{Hasher, Keccak};
 
 impl ast::Contract {
     /// Create a new contract, abstract contract, interface or library
@@ -46,36 +43,12 @@ impl ast::Contract {
             initializer: None,
             default_constructor: None,
             cfg: Vec::new(),
-            code: Vec::new(),
+            code: OnceCell::new(),
             instantiable,
             dispatch_no: 0,
             constructor_dispatch: None,
             program_id: None,
         }
-    }
-
-    /// Generate contract code for this contract
-    #[cfg(feature = "llvm")]
-    pub fn emit<'a>(
-        &'a self,
-        ns: &'a ast::Namespace,
-        context: &'a inkwell::context::Context,
-        filename: &'a str,
-        opt: inkwell::OptimizationLevel,
-        math_overflow_check: bool,
-        generate_debug_info: bool,
-        log_api_return_codes: bool,
-    ) -> emit::binary::Binary {
-        emit::binary::Binary::build(
-            context,
-            self,
-            ns,
-            filename,
-            opt,
-            math_overflow_check,
-            generate_debug_info,
-            log_api_return_codes,
-        )
     }
 
     /// Selector for this contract. This is used by Solana contract bundle

--- a/tests/contract.rs
+++ b/tests/contract.rs
@@ -87,19 +87,8 @@ fn parse_file(path: PathBuf, target: Target) -> io::Result<()> {
         match ns.target {
             Target::Solana | Target::Substrate { .. } => {
                 for contract in &ns.contracts {
-                    let context = inkwell::context::Context::create();
-
                     if contract.instantiable {
-                        solang::emit::binary::Binary::build(
-                            &context,
-                            contract,
-                            &ns,
-                            &filename,
-                            Default::default(),
-                            false,
-                            false,
-                            false,
-                        );
+                        let _ = contract.emit(&ns, &Default::default());
                     }
                 }
             }

--- a/tests/solana.rs
+++ b/tests/solana.rs
@@ -146,11 +146,13 @@ fn build_solidity_with_overflow_check(src: &str, math_overflow_flag: bool) -> Vi
     for contract_no in 0..ns.contracts.len() {
         let contract = &ns.contracts[contract_no];
 
-        if contract.code.is_empty() {
+        if !contract.instantiable {
             continue;
         }
 
-        let (abistr, _) = solang::abi::generate_abi(contract_no, &ns, &contract.code, false);
+        let code = contract.code.get().unwrap();
+
+        let (abistr, _) = solang::abi::generate_abi(contract_no, &ns, code, false);
         let abi = ethabi::Contract::load(abistr.as_bytes()).unwrap();
 
         let program = if let Some(program_id) = &contract.program_id {
@@ -162,7 +164,7 @@ fn build_solidity_with_overflow_check(src: &str, math_overflow_flag: bool) -> Vi
         account_data.insert(
             program,
             AccountState {
-                data: contract.code.clone(),
+                data: code.clone(),
                 owner: None,
                 lamports: 0,
             },


### PR DESCRIPTION
The contract binary is always generated in codegen, but never used in codegen. We can replace `type(contract).runtimeCode` with the binary code in codegen, which removes the need  for 
 `Expression::CodeLiteral` in codegen. We only generate this if needed.

This has an added bonus for debugging issues: if there is an issue in emit, then `--emit cfg` will still 
work and not crash before emitting the cfg (unless `type(foo).runtimeCode` is present).

Signed-off-by: Sean Young <sean@mess.org>