### PR TITLE
Generate Anchor IDL from Solidity contracts ⚓

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ codespan-reporting = "0.11"
 phf = { version = "0.11", features = ["macros"] }
 rust-lapper = "1.0"
 bitflags = "1.3"
-anchor-syn = { version = "0.25", features = ["idl"] }
+anchor-syn = { version = "0.26", features = ["idl"] }
 convert_case = "0.6"
 parse-display = "0.6.0"
 parity-scale-codec = "3.1"

--- a/src/abi/anchor.rs
+++ b/src/abi/anchor.rs
@@ -1,5 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::sema::ast::{
+    ArrayLength, Contract, Function, Mutability, Namespace, StructDecl, StructType, Tag, Type,
+};
+use anchor_syn::idl::{
+    Idl, IdlAccount, IdlAccountItem, IdlEnumVariant, IdlEvent, IdlEventField, IdlField,
+    IdlInstruction, IdlType, IdlTypeDefinition, IdlTypeDefinitionTy,
+};
+use num_traits::ToPrimitive;
+use semver::Version;
+use std::collections::HashSet;
+
 use convert_case::{Boundary, Case, Casing};
 use sha2::{Digest, Sha256};
 
@@ -16,4 +27,376 @@ pub fn discriminator(namespace: &'static str, name: &str) -> Vec<u8> {
         .to_case(Case::Snake);
     hasher.update(format!("{}:{}", namespace, normalized));
     hasher.finalize()[..8].to_vec()
+}
+
+/// Generate an Anchor IDL for a Solidity contract.
+pub fn generate_anchor_idl(contract_no: usize, ns: &Namespace) -> Idl {
+    let contract = &ns.contracts[contract_no];
+    let docs = idl_docs(&contract.tags);
+    let mut type_manager = TypeManager::new(ns);
+
+    let instructions = idl_instructions(contract_no, contract, &mut type_manager, ns);
+
+    let events = idl_events(contract, &mut type_manager, ns);
+
+    Idl {
+        version: Version::parse(env!("CARGO_PKG_VERSION"))
+            .unwrap()
+            .to_string(),
+        name: ns.contracts[contract_no].name.clone(),
+        docs,
+        constants: vec![],
+        instructions,
+        state: None,
+        accounts: vec![],
+        types: type_manager.generate_custom_idl_types(),
+        events,
+        errors: None,
+        metadata: None,
+    }
+}
+
+/// Generate IDL events for a contract.
+fn idl_events(
+    contract: &Contract,
+    type_manager: &mut TypeManager,
+    ns: &Namespace,
+) -> Option<Vec<IdlEvent>> {
+    if contract.emits_events.is_empty() {
+        None
+    } else {
+        let mut events: Vec<IdlEvent> = Vec::with_capacity(contract.emits_events.len());
+        for event_no in &contract.emits_events {
+            let def = &ns.events[*event_no];
+            let mut fields: Vec<IdlEventField> = Vec::with_capacity(def.fields.len());
+            for (item_no, item) in def.fields.iter().enumerate() {
+                let name = if item.id.is_none() {
+                    format!("field_{}", item_no)
+                } else {
+                    item.name_as_str().to_string()
+                };
+
+                fields.push(IdlEventField {
+                    name,
+                    ty: type_manager.convert(&item.ty),
+                    index: item.indexed,
+                });
+            }
+
+            events.push(IdlEvent {
+                name: def.name.clone(),
+                fields,
+            });
+        }
+
+        Some(events)
+    }
+}
+
+/// Generate the IDL instructions for a contract.
+fn idl_instructions(
+    contract_no: usize,
+    contract: &Contract,
+    type_manager: &mut TypeManager,
+    ns: &Namespace,
+) -> Vec<IdlInstruction> {
+    let mut instructions: Vec<IdlInstruction> = Vec::new();
+
+    if !contract.have_constructor(ns) {
+        instructions.push(IdlInstruction {
+            name: "new".to_string(),
+            docs: None,
+            accounts: vec![IdlAccountItem::IdlAccount(IdlAccount {
+                name: "data_account".to_string(),
+                is_mut: true,
+                is_signer: false,
+                is_optional: Some(false),
+                docs: None,
+                pda: None,
+                relations: vec![],
+            })],
+            args: vec![],
+            returns: None,
+        })
+    }
+
+    for func_no in contract.all_functions.keys() {
+        if !ns.functions[*func_no].is_public() {
+            continue;
+        }
+
+        let func = &ns.functions[*func_no];
+        let tags = idl_docs(&func.tags);
+
+        let accounts = match &func.mutability {
+            Mutability::Pure(_) => {
+                vec![]
+            }
+            Mutability::View(_) => {
+                vec![IdlAccountItem::IdlAccount(IdlAccount {
+                    name: "data_account".to_string(),
+                    is_mut: false,
+                    is_signer: false,
+                    is_optional: Some(false),
+                    docs: None,
+                    pda: None,
+                    relations: vec![],
+                })]
+            }
+            _ => {
+                vec![IdlAccountItem::IdlAccount(IdlAccount {
+                    name: "data_account".to_string(),
+                    is_mut: true,
+                    is_signer: false,
+                    is_optional: Some(false),
+                    docs: None,
+                    pda: None,
+                    relations: vec![],
+                })]
+            }
+        };
+
+        let mut args: Vec<IdlField> = Vec::with_capacity(func.params.len());
+        for (item_no, item) in func.params.iter().enumerate() {
+            let name = if item.id.is_none() || item.id.as_ref().unwrap().name.is_empty() {
+                format!("arg_{}", item_no)
+            } else {
+                item.id.as_ref().unwrap().name.clone()
+            };
+            args.push(IdlField {
+                name,
+                docs: None,
+                ty: type_manager.convert(&item.ty),
+            });
+        }
+
+        let name = if func.is_constructor() {
+            "new".to_string()
+        } else if func.mangled_name_contracts.contains(&contract_no) {
+            func.mangled_name.clone()
+        } else {
+            func.name.clone()
+        };
+
+        let returns = if func.returns.is_empty() {
+            None
+        } else if func.returns.len() == 1 {
+            Some(type_manager.convert(&func.returns[0].ty))
+        } else {
+            Some(type_manager.build_struct_for_return(func, &name))
+        };
+
+        instructions.push(IdlInstruction {
+            name,
+            docs: tags,
+            accounts,
+            args,
+            returns,
+        });
+    }
+
+    instructions
+}
+
+/// This struct accounts all the user defined types used in the contract that need to be present
+/// in the IDL 'types' field.
+struct TypeManager<'a> {
+    namespace: &'a Namespace,
+    added_types: HashSet<Type>,
+    returns_structs: Vec<IdlTypeDefinition>,
+    types: Vec<IdlTypeDefinition>,
+}
+
+impl TypeManager<'_> {
+    fn new(ns: &Namespace) -> TypeManager {
+        TypeManager {
+            namespace: ns,
+            added_types: HashSet::new(),
+            types: Vec::new(),
+            returns_structs: Vec::new(),
+        }
+    }
+
+    /// Functions with multiple returns must return a struct in Anchor, so we build a return
+    /// struct containing all the returned types.
+    fn build_struct_for_return(&mut self, func: &Function, effective_name: &String) -> IdlType {
+        let mut fields: Vec<IdlField> = Vec::with_capacity(func.returns.len());
+        for (item_no, item) in func.returns.iter().enumerate() {
+            let name = if let Some(id) = &item.id {
+                id.name.clone()
+            } else {
+                format!("return_{}", item_no)
+            };
+
+            fields.push(IdlField {
+                name,
+                docs: None,
+                ty: self.convert(&item.ty),
+            });
+        }
+
+        let name = format!("{}_returns", effective_name);
+        self.returns_structs.push(IdlTypeDefinition {
+            name: name.clone(),
+            docs: Some(vec![format!(
+                "Data structure to hold the multiple returns of function {}",
+                func.name
+            )]),
+            ty: IdlTypeDefinitionTy::Struct { fields },
+        });
+
+        IdlType::Defined(name)
+    }
+
+    /// Add a struct definition to the TypeManager
+    fn add_struct_definition(&mut self, def: &StructDecl, ty: &Type) {
+        if self.added_types.contains(ty) {
+            return;
+        }
+        self.added_types.insert(ty.clone());
+
+        let docs = idl_docs(&def.tags);
+
+        let mut fields: Vec<IdlField> = Vec::with_capacity(def.fields.len());
+        for item in &def.fields {
+            fields.push(IdlField {
+                name: item.name_as_str().to_string(),
+                docs: None,
+                ty: self.convert(&item.ty),
+            });
+        }
+
+        self.types.push(IdlTypeDefinition {
+            name: def.name.clone(),
+            docs,
+            ty: IdlTypeDefinitionTy::Struct { fields },
+        });
+    }
+
+    /// This function ensures there are no name collisions on the structs created for the functions
+    /// with multiple returns, before returning all the custom types needed for the IDL file.
+    fn generate_custom_idl_types(self) -> Vec<IdlTypeDefinition> {
+        let mut custom_types = self.types;
+        let mut used_names: HashSet<String> = custom_types
+            .iter()
+            .map(|e| e.name.clone())
+            .collect::<HashSet<String>>();
+
+        for item in self.returns_structs {
+            let mut value = 0;
+            let mut name = item.name.clone();
+            while used_names.contains(&name) {
+                value += 1;
+                name = format!("{}_{}", item.name, value);
+            }
+            used_names.insert(name.clone());
+            custom_types.push(IdlTypeDefinition {
+                name,
+                docs: item.docs,
+                ty: item.ty,
+            });
+        }
+
+        custom_types
+    }
+
+    /// Add an enum definition to the TypeManager
+    fn add_enum_definition(&mut self, enum_no: usize, ty: &Type) {
+        if self.added_types.contains(ty) {
+            return;
+        }
+        self.added_types.insert(ty.clone());
+        let def = &self.namespace.enums[enum_no];
+
+        let docs = idl_docs(&def.tags);
+
+        let variants = def
+            .values
+            .iter()
+            .map(|(name, _)| IdlEnumVariant {
+                name: name.clone(),
+                fields: None,
+            })
+            .collect::<Vec<IdlEnumVariant>>();
+
+        self.types.push(IdlTypeDefinition {
+            name: def.name.clone(),
+            docs,
+            ty: IdlTypeDefinitionTy::Enum { variants },
+        });
+    }
+
+    /// Convert for AST Type to IDL Type
+    fn convert(&mut self, ast_type: &Type) -> IdlType {
+        match ast_type {
+            Type::Bool => IdlType::Bool,
+            Type::Int(n) => match *n {
+                0..=8 => IdlType::I8,
+                9..=16 => IdlType::I16,
+                17..=32 => IdlType::I32,
+                33..=64 => IdlType::I64,
+                65..=128 => IdlType::I128,
+                129..=256 => IdlType::I256,
+                _ => unreachable!("Integers wider than 256 bits are not supported"),
+            },
+            Type::Uint(n) => match *n {
+                0..=8 => IdlType::U8,
+                9..=16 => IdlType::U16,
+                17..=32 => IdlType::U32,
+                33..=64 => IdlType::U64,
+                65..=128 => IdlType::U128,
+                129..=256 => IdlType::U256,
+                _ => unreachable!("Unsigned integers wider than 256 bits are not supported"),
+            },
+            Type::DynamicBytes => IdlType::Bytes,
+            Type::String => IdlType::String,
+            Type::Address(_) | Type::Contract(_) => IdlType::PublicKey,
+            Type::Struct(struct_type) => {
+                let def = struct_type.definition(self.namespace);
+                self.add_struct_definition(def, ast_type);
+                IdlType::Defined(def.name.clone())
+            }
+            Type::Array(ty, dims) => {
+                let mut idl_type = self.convert(ty);
+                for item in dims {
+                    match item {
+                        ArrayLength::Fixed(number) => {
+                            idl_type =
+                                IdlType::Array(Box::new(idl_type), number.to_usize().unwrap());
+                        }
+                        ArrayLength::Dynamic => {
+                            idl_type = IdlType::Vec(Box::new(idl_type));
+                        }
+                        ArrayLength::AnyFixed => {
+                            unreachable!("A parameter cannot have an AnyFixed dimension")
+                        }
+                    }
+                }
+                idl_type
+            }
+            Type::Bytes(dim) => IdlType::Array(Box::new(IdlType::U8), *dim as usize),
+            Type::Enum(enum_no) => {
+                self.add_enum_definition(*enum_no, ast_type);
+                IdlType::Defined(self.namespace.enums[*enum_no].name.clone())
+            }
+            Type::ExternalFunction { .. } => {
+                self.convert(&Type::Struct(StructType::ExternalFunction))
+            }
+            Type::UserType(type_no) => self.convert(&self.namespace.user_types[*type_no].ty),
+            _ => unreachable!("Type should not be in the IDL"),
+        }
+    }
+}
+
+/// Prepare the docs from doc comments.
+fn idl_docs(tags: &[Tag]) -> Option<Vec<String>> {
+    if tags.is_empty() {
+        None
+    } else {
+        Some(
+            tags.iter()
+                .map(|tag| format!("{}: {}", tag.tag, tag.value))
+                .collect::<Vec<String>>(),
+        )
+    }
 }

--- a/src/abi/anchor.rs
+++ b/src/abi/anchor.rs
@@ -8,11 +8,13 @@ use anchor_syn::idl::{
     Idl, IdlAccount, IdlAccountItem, IdlEnumVariant, IdlEvent, IdlEventField, IdlField,
     IdlInstruction, IdlType, IdlTypeDefinition, IdlTypeDefinitionTy,
 };
+use base58::ToBase58;
 use num_traits::ToPrimitive;
 use semver::Version;
 use std::collections::{HashMap, HashSet};
 
 use convert_case::{Boundary, Case, Casing};
+use serde_json::json;
 use sha2::{Digest, Sha256};
 use solang_parser::pt::FunctionTy;
 
@@ -41,6 +43,11 @@ pub fn generate_anchor_idl(contract_no: usize, ns: &Namespace) -> Idl {
 
     let events = idl_events(contract, &mut type_manager, ns);
 
+    let metadata = contract
+        .program_id
+        .as_ref()
+        .map(|id| json!({"address": id.to_base58()}));
+
     Idl {
         version: Version::parse(env!("CARGO_PKG_VERSION"))
             .unwrap()
@@ -54,7 +61,7 @@ pub fn generate_anchor_idl(contract_no: usize, ns: &Namespace) -> Idl {
         types: type_manager.generate_custom_idl_types(),
         events,
         errors: None,
-        metadata: None,
+        metadata,
     }
 }
 

--- a/src/abi/mod.rs
+++ b/src/abi/mod.rs
@@ -6,6 +6,7 @@ use crate::Target;
 pub mod anchor;
 pub mod ethereum;
 pub mod substrate;
+mod tests;
 
 pub fn generate_abi(
     contract_no: usize,

--- a/src/abi/tests.rs
+++ b/src/abi/tests.rs
@@ -1,0 +1,1085 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(test)]
+
+use crate::abi::anchor::generate_anchor_idl;
+use crate::codegen::{OptimizationLevel, Options};
+use crate::file_resolver::FileResolver;
+use crate::sema::ast::Namespace;
+use crate::{codegen, parse_and_resolve, Target};
+use anchor_syn::idl::{
+    IdlAccount, IdlAccountItem, IdlEnumVariant, IdlEvent, IdlEventField, IdlField, IdlType,
+    IdlTypeDefinition, IdlTypeDefinitionTy,
+};
+use semver::Version;
+use std::ffi::OsStr;
+
+fn generate_namespace(src: &'static str) -> Namespace {
+    let mut cache = FileResolver::new();
+    cache.set_file_contents("test.sol", src.to_string());
+    parse_and_resolve(OsStr::new("test.sol"), &mut cache, Target::Solana)
+}
+
+#[test]
+fn version_name_and_docs() {
+    let src = r#"
+/// @title MyContract
+/// @author Lucas
+contract caller {
+    function doThis(int64 a) public pure returns (int64) {
+        return a + 2;
+    }
+
+    function doThat(int32 b) public pure returns (int32) {
+        return b + 3;
+    }
+
+    function do_call() pure public returns (int64, int32) {
+        return (this.doThis(5), this.doThat(3));
+    }
+}
+    "#;
+
+    let ns = generate_namespace(src);
+    let idl = generate_anchor_idl(0, &ns);
+    assert_eq!(
+        idl.version,
+        Version::parse(env!("CARGO_PKG_VERSION"))
+            .unwrap()
+            .to_string()
+    );
+    assert_eq!(idl.name, "caller");
+    assert!(idl.docs.is_some());
+    assert_eq!(idl.docs.as_ref().unwrap().len(), 2);
+    assert_eq!(idl.docs.as_ref().unwrap()[0], "title: MyContract");
+    assert_eq!(idl.docs.as_ref().unwrap()[1], "author: Lucas");
+}
+
+#[test]
+fn constants_and_types() {
+    let src = r#"
+    contract caller {
+    int32 public constant cte1 = -90;
+    uint64[3] public constant cte2 = [90, 875, 1044];
+    string public constant cte3 = "Rio";
+    string[4] public constant cte4 = ["Baku", "Paris", "Sao Paulo", "Auckland"];
+    MyStruct public constant cte5 = MyStruct(125, "ab");
+    Week public constant cte6 = Week.Tuesday;
+
+    struct MyStruct {
+        uint8 g;
+        bytes2 d;
+    }
+
+    enum Week {Monday, Tuesday, Wednesday}
+}
+    "#;
+    let ns = generate_namespace(src);
+    let idl = generate_anchor_idl(0, &ns);
+
+    assert!(idl.constants.is_empty());
+
+    assert_eq!(idl.types.len(), 2);
+
+    assert_eq!(idl.types[0].name, "MyStruct");
+    assert!(idl.types[0].docs.is_none());
+    assert_eq!(
+        idl.types[0].ty,
+        IdlTypeDefinitionTy::Struct {
+            fields: vec![
+                IdlField {
+                    name: "g".to_string(),
+                    docs: None,
+                    ty: IdlType::U8,
+                },
+                IdlField {
+                    name: "d".to_string(),
+                    docs: None,
+                    ty: IdlType::Array(IdlType::U8.into(), 2)
+                }
+            ]
+        }
+    );
+
+    assert_eq!(idl.types[1].name, "Week");
+    assert!(idl.types[1].docs.is_none());
+    assert_eq!(
+        idl.types[1].ty,
+        IdlTypeDefinitionTy::Enum {
+            variants: vec![
+                IdlEnumVariant {
+                    name: "Monday".to_string(),
+                    fields: None,
+                },
+                IdlEnumVariant {
+                    name: "Tuesday".to_string(),
+                    fields: None,
+                },
+                IdlEnumVariant {
+                    name: "Wednesday".to_string(),
+                    fields: None,
+                }
+            ]
+        }
+    );
+}
+
+#[test]
+fn instructions_and_types() {
+    let src = r#"
+    contract caller {
+
+    string private my_string;
+    uint64 public cte;
+    uint64[] public cte2;
+
+    struct MetaData {
+        bool b;
+        bool c;
+    }
+
+    function sum(uint256 a, int256 b) public pure returns (int256) {
+        MetaData d = MetaData(true, false);
+        return notInIdl(a, d) + b;
+    }
+
+    /// @param c input
+    function setString(string c) public {
+        my_string = c;
+    }
+
+    /// @return the string
+    function getString() public view returns (string) {
+        return my_string;
+    }
+
+    function notInIdl(uint256 c, MetaData dd) private pure returns (int256) {
+        if (dd.a && dd.b) {
+            return 0;
+        }
+        return int256(c);
+    }
+
+    function multipleReturns() public returns (uint64, string) {
+        cte += 1;
+        return (cte, my_string);
+    }
+}
+    "#;
+
+    let ns = generate_namespace(src);
+    let idl = generate_anchor_idl(0, &ns);
+
+    assert_eq!(idl.instructions.len(), 7);
+
+    // implicit constructor
+    assert_eq!(idl.instructions[0].name, "new");
+    assert!(idl.instructions[0].docs.is_none());
+    assert_eq!(
+        idl.instructions[0].accounts,
+        vec![IdlAccountItem::IdlAccount(IdlAccount {
+            name: "data_account".to_string(),
+            is_mut: true,
+            is_signer: false,
+            is_optional: Some(false),
+            docs: None,
+            pda: None,
+            relations: vec![],
+        })]
+    );
+    assert!(idl.instructions[0].args.is_empty());
+    assert!(idl.instructions[0].returns.is_none());
+
+    // cte accessor function
+    assert_eq!(idl.instructions[1].name, "cte");
+    assert!(idl.instructions[1].docs.is_none());
+    assert_eq!(
+        idl.instructions[1].accounts,
+        vec![IdlAccountItem::IdlAccount(IdlAccount {
+            name: "data_account".to_string(),
+            is_mut: false,
+            is_signer: false,
+            is_optional: Some(false),
+            docs: None,
+            pda: None,
+            relations: vec![],
+        })]
+    );
+    assert!(idl.instructions[1].args.is_empty());
+    assert_eq!(idl.instructions[1].returns, Some(IdlType::U64));
+
+    // cte2 accessor function
+    assert_eq!(idl.instructions[2].name, "cte2");
+    assert!(idl.instructions[2].docs.is_none());
+    assert_eq!(
+        idl.instructions[2].accounts,
+        vec![IdlAccountItem::IdlAccount(IdlAccount {
+            name: "data_account".to_string(),
+            is_mut: false,
+            is_signer: false,
+            is_optional: Some(false),
+            docs: None,
+            pda: None,
+            relations: vec![],
+        })]
+    );
+    assert_eq!(
+        idl.instructions[2].args,
+        vec![IdlField {
+            name: "arg_0".to_string(),
+            docs: None,
+            ty: IdlType::U256,
+        }]
+    );
+    assert_eq!(idl.instructions[2].returns, Some(IdlType::U64));
+
+    // sum function
+    assert_eq!(idl.instructions[3].name, "sum");
+    assert!(idl.instructions[3].docs.is_none());
+    assert!(idl.instructions[3].accounts.is_empty());
+    assert_eq!(
+        idl.instructions[3].args,
+        vec![
+            IdlField {
+                name: "a".to_string(),
+                docs: None,
+                ty: IdlType::U256
+            },
+            IdlField {
+                name: "b".to_string(),
+                docs: None,
+                ty: IdlType::I256
+            }
+        ]
+    );
+    assert_eq!(idl.instructions[3].returns, Some(IdlType::I256));
+
+    assert_eq!(idl.instructions[4].name, "setString");
+    assert_eq!(
+        idl.instructions[4].docs,
+        Some(vec!["param: input".to_string()])
+    );
+    assert_eq!(
+        idl.instructions[4].accounts,
+        vec![IdlAccountItem::IdlAccount(IdlAccount {
+            name: "data_account".to_string(),
+            is_mut: true,
+            is_signer: false,
+            is_optional: Some(false),
+            docs: None,
+            pda: None,
+            relations: vec![],
+        })]
+    );
+    assert_eq!(
+        idl.instructions[4].args,
+        vec![IdlField {
+            name: "c".to_string(),
+            docs: None,
+            ty: IdlType::String
+        }]
+    );
+    assert!(idl.instructions[4].returns.is_none());
+
+    assert_eq!(idl.instructions[5].name, "getString");
+    assert_eq!(
+        idl.instructions[5].docs,
+        Some(vec!["return: the string".to_string()])
+    );
+    assert_eq!(
+        idl.instructions[5].accounts,
+        vec![IdlAccountItem::IdlAccount(IdlAccount {
+            name: "data_account".to_string(),
+            is_mut: false,
+            is_signer: false,
+            is_optional: Some(false),
+            docs: None,
+            pda: None,
+            relations: vec![],
+        })]
+    );
+    assert!(idl.instructions[5].args.is_empty());
+    assert_eq!(idl.instructions[5].returns, Some(IdlType::String));
+
+    assert_eq!(idl.instructions[6].name, "multipleReturns");
+    assert!(idl.instructions[6].docs.is_none());
+    assert_eq!(
+        idl.instructions[6].accounts,
+        vec![IdlAccountItem::IdlAccount(IdlAccount {
+            name: "data_account".to_string(),
+            is_mut: true,
+            is_signer: false,
+            is_optional: Some(false),
+            docs: None,
+            pda: None,
+            relations: vec![],
+        })]
+    );
+    assert!(idl.instructions[6].args.is_empty());
+    assert_eq!(
+        idl.instructions[6].returns,
+        Some(IdlType::Defined("multipleReturns_returns".to_string()))
+    );
+
+    assert!(idl.state.is_none());
+    assert!(idl.accounts.is_empty());
+
+    assert_eq!(idl.types.len(), 1);
+
+    assert_eq!(
+        idl.types[0],
+        IdlTypeDefinition {
+            name: "multipleReturns_returns".to_string(),
+            docs: Some(vec![
+                "Data structure to hold the multiple returns of function multipleReturns"
+                    .to_string()
+            ]),
+            ty: IdlTypeDefinitionTy::Struct {
+                fields: vec![
+                    IdlField {
+                        name: "return_0".to_string(),
+                        docs: None,
+                        ty: IdlType::U64
+                    },
+                    IdlField {
+                        name: "return_1".to_string(),
+                        docs: None,
+                        ty: IdlType::String,
+                    }
+                ]
+            }
+        }
+    );
+
+    assert!(idl.events.is_none());
+    assert!(idl.events.is_none());
+    assert!(idl.metadata.is_none());
+}
+
+#[test]
+fn events() {
+    let src = r#"
+contract caller {
+    enum Color { Yellow, Blue, Green }
+
+    event Event1(bool, string indexed, int8, Color);
+    event Event2(bool a, uint128 indexed cc);
+
+    function emitAll(bool a, string b, int8 d, uint128 e) public {
+        emit Event1(a, b, d, Color.Blue);
+        emit Event2(a, e);
+    }
+}
+    "#;
+
+    let mut ns = generate_namespace(src);
+    // We need this to populate Contract.emit_events
+    codegen::codegen(
+        &mut ns,
+        &Options {
+            dead_storage: false,
+            constant_folding: false,
+            strength_reduce: false,
+            vector_to_slice: false,
+            math_overflow_check: false,
+            common_subexpression_elimination: false,
+            generate_debug_information: false,
+            opt_level: OptimizationLevel::None,
+            log_api_return_codes: false,
+        },
+    );
+
+    let idl = generate_anchor_idl(0, &ns);
+
+    assert_eq!(idl.instructions.len(), 2);
+
+    // implicit constructor
+    assert_eq!(idl.instructions[0].name, "new");
+    assert!(idl.instructions[0].docs.is_none());
+    assert_eq!(
+        idl.instructions[0].accounts,
+        vec![IdlAccountItem::IdlAccount(IdlAccount {
+            name: "data_account".to_string(),
+            is_mut: true,
+            is_signer: false,
+            is_optional: Some(false),
+            docs: None,
+            pda: None,
+            relations: vec![],
+        })]
+    );
+    assert!(idl.instructions[0].args.is_empty());
+    assert!(idl.instructions[0].returns.is_none());
+
+    assert_eq!(idl.instructions[1].name, "emitAll");
+    assert!(idl.instructions[1].docs.is_none());
+    assert_eq!(
+        idl.instructions[1].accounts,
+        vec![IdlAccountItem::IdlAccount(IdlAccount {
+            name: "data_account".to_string(),
+            is_mut: true,
+            is_signer: false,
+            is_optional: Some(false),
+            docs: None,
+            pda: None,
+            relations: vec![],
+        })]
+    );
+    assert_eq!(
+        idl.instructions[1].args,
+        vec![
+            IdlField {
+                name: "a".to_string(),
+                docs: None,
+                ty: IdlType::Bool,
+            },
+            IdlField {
+                name: "b".to_string(),
+                docs: None,
+                ty: IdlType::String,
+            },
+            IdlField {
+                name: "d".to_string(),
+                docs: None,
+                ty: IdlType::I8
+            },
+            IdlField {
+                name: "e".to_string(),
+                docs: None,
+                ty: IdlType::U128,
+            }
+        ]
+    );
+    assert!(idl.instructions[1].returns.is_none());
+
+    assert!(idl.state.is_none());
+    assert!(idl.accounts.is_empty());
+
+    assert_eq!(idl.types.len(), 1);
+
+    assert_eq!(
+        idl.types[0],
+        IdlTypeDefinition {
+            name: "Color".to_string(),
+            docs: None,
+            ty: IdlTypeDefinitionTy::Enum {
+                variants: vec![
+                    IdlEnumVariant {
+                        name: "Yellow".to_string(),
+                        fields: None,
+                    },
+                    IdlEnumVariant {
+                        name: "Blue".to_string(),
+                        fields: None,
+                    },
+                    IdlEnumVariant {
+                        name: "Green".to_string(),
+                        fields: None,
+                    }
+                ]
+            }
+        }
+    );
+
+    assert_eq!(
+        idl.events,
+        Some(vec![
+            IdlEvent {
+                name: "Event1".to_string(),
+                fields: vec![
+                    IdlEventField {
+                        name: "field_0".to_string(),
+                        ty: IdlType::Bool,
+                        index: false,
+                    },
+                    IdlEventField {
+                        name: "field_1".to_string(),
+                        ty: IdlType::String,
+                        index: true,
+                    },
+                    IdlEventField {
+                        name: "field_2".to_string(),
+                        ty: IdlType::I8,
+                        index: false,
+                    },
+                    IdlEventField {
+                        name: "field_3".to_string(),
+                        ty: IdlType::Defined("Color".to_string()),
+                        index: false,
+                    }
+                ],
+            },
+            IdlEvent {
+                name: "Event2".to_string(),
+                fields: vec![
+                    IdlEventField {
+                        name: "a".to_string(),
+                        ty: IdlType::Bool,
+                        index: false,
+                    },
+                    IdlEventField {
+                        name: "cc".to_string(),
+                        ty: IdlType::U128,
+                        index: true,
+                    }
+                ]
+            }
+        ])
+    );
+
+    assert!(idl.errors.is_none());
+    assert!(idl.metadata.is_none());
+}
+
+#[test]
+fn types() {
+    let src = r#"
+    contract caller {
+    event Event1(int24, uint32);
+
+    function myFunc(int24 a, uint32[2][] b, uint32[2][4] d, uint32[][2] e) public {
+        emit Event1(a, b[0][1] + d[1][2] - e[1][0]);
+    }
+}
+    "#;
+
+    let ns = generate_namespace(src);
+    let idl = generate_anchor_idl(0, &ns);
+
+    assert_eq!(idl.instructions.len(), 2);
+
+    // implicit constructor
+    assert_eq!(idl.instructions[0].name, "new");
+    assert!(idl.instructions[0].docs.is_none());
+    assert_eq!(
+        idl.instructions[0].accounts,
+        vec![IdlAccountItem::IdlAccount(IdlAccount {
+            name: "data_account".to_string(),
+            is_mut: true,
+            is_signer: false,
+            is_optional: Some(false),
+            docs: None,
+            pda: None,
+            relations: vec![],
+        })]
+    );
+    assert!(idl.instructions[0].args.is_empty());
+    assert!(idl.instructions[0].returns.is_none());
+
+    assert_eq!(idl.instructions[1].name, "myFunc");
+    assert_eq!(
+        idl.instructions[1].accounts,
+        vec![IdlAccountItem::IdlAccount(IdlAccount {
+            name: "data_account".to_string(),
+            is_mut: true,
+            is_signer: false,
+            is_optional: Some(false),
+            docs: None,
+            pda: None,
+            relations: vec![],
+        })]
+    );
+    assert_eq!(
+        idl.instructions[1].args,
+        vec![
+            IdlField {
+                name: "a".to_string(),
+                docs: None,
+                ty: IdlType::I32,
+            },
+            IdlField {
+                name: "b".to_string(),
+                docs: None,
+                ty: IdlType::Vec(IdlType::Array(IdlType::U32.into(), 2).into()),
+            },
+            IdlField {
+                name: "d".to_string(),
+                docs: None,
+                ty: IdlType::Array(IdlType::Array(IdlType::U32.into(), 2).into(), 4),
+            },
+            IdlField {
+                name: "e".to_string(),
+                docs: None,
+                ty: IdlType::Array(IdlType::Vec(IdlType::U32.into()).into(), 2)
+            }
+        ]
+    );
+    assert!(idl.instructions[1].returns.is_none());
+    assert!(idl.state.is_none());
+    assert!(idl.accounts.is_empty());
+    assert!(idl.types.is_empty());
+    assert!(idl.events.is_none());
+    assert!(idl.errors.is_none());
+    assert!(idl.metadata.is_none());
+}
+
+#[test]
+fn constructor() {
+    let src = r#"
+        contract caller {
+    uint64 b;
+    constructor(uint64 ff) {
+        b = ff;
+    }
+
+    function getNum() public view returns (uint64) {
+        return b;
+    }
+}
+    "#;
+    let ns = generate_namespace(src);
+    let idl = generate_anchor_idl(0, &ns);
+
+    assert_eq!(idl.name, "caller");
+    assert!(idl.docs.is_none());
+    assert!(idl.constants.is_empty());
+
+    assert_eq!(idl.instructions.len(), 2);
+    assert_eq!(idl.instructions[0].name, "new");
+    assert!(idl.instructions[0].docs.is_none());
+    assert_eq!(
+        idl.instructions[0].accounts,
+        vec![IdlAccountItem::IdlAccount(IdlAccount {
+            name: "data_account".to_string(),
+            is_mut: true,
+            is_signer: false,
+            is_optional: Some(false),
+            docs: None,
+            pda: None,
+            relations: vec![],
+        })]
+    );
+    assert_eq!(
+        idl.instructions[0].args,
+        vec![IdlField {
+            name: "ff".to_string(),
+            docs: None,
+            ty: IdlType::U64,
+        },]
+    );
+    assert!(idl.instructions[0].returns.is_none());
+
+    assert_eq!(idl.instructions[1].name, "getNum");
+    assert!(idl.instructions[1].docs.is_none());
+    assert_eq!(
+        idl.instructions[1].accounts,
+        vec![IdlAccountItem::IdlAccount(IdlAccount {
+            name: "data_account".to_string(),
+            is_mut: false,
+            is_signer: false,
+            is_optional: Some(false),
+            docs: None,
+            pda: None,
+            relations: vec![],
+        })]
+    );
+    assert!(idl.instructions[1].args.is_empty());
+    assert_eq!(idl.instructions[1].returns, Some(IdlType::U64));
+
+    assert!(idl.state.is_none());
+    assert!(idl.accounts.is_empty());
+    assert!(idl.types.is_empty());
+    assert!(idl.events.is_none());
+    assert!(idl.errors.is_none());
+    assert!(idl.metadata.is_none());
+}
+
+#[test]
+fn named_returns() {
+    let src = r#"
+contract Testing {
+    function getNum(uint64 a, uint64 b) public pure returns (uint64 ret1, uint64 ret2) {
+        ret1 = a + b;
+        ret2 = a/b;
+    }
+}    "#;
+
+    let ns = generate_namespace(src);
+    let idl = generate_anchor_idl(0, &ns);
+
+    assert_eq!(idl.instructions.len(), 2);
+
+    assert_eq!(idl.instructions[0].name, "new");
+    assert!(idl.instructions[0].returns.is_none());
+    assert!(idl.instructions[0].args.is_empty());
+    assert_eq!(
+        idl.instructions[0].accounts,
+        vec![IdlAccountItem::IdlAccount(IdlAccount {
+            name: "data_account".to_string(),
+            is_mut: true,
+            is_signer: false,
+            is_optional: Some(false),
+            docs: None,
+            pda: None,
+            relations: vec![],
+        })]
+    );
+
+    assert_eq!(idl.instructions[1].name, "getNum");
+    assert_eq!(
+        idl.instructions[1].returns,
+        Some(IdlType::Defined("getNum_returns".to_string()))
+    );
+    assert_eq!(
+        idl.instructions[1].args,
+        vec![
+            IdlField {
+                name: "a".to_string(),
+                docs: None,
+                ty: IdlType::U64
+            },
+            IdlField {
+                name: "b".to_string(),
+                docs: None,
+                ty: IdlType::U64
+            },
+        ]
+    );
+
+    assert_eq!(idl.types.len(), 1);
+    assert_eq!(
+        idl.types[0],
+        IdlTypeDefinition {
+            name: "getNum_returns".to_string(),
+            docs: Some(vec![
+                "Data structure to hold the multiple returns of function getNum".to_string()
+            ]),
+            ty: IdlTypeDefinitionTy::Struct {
+                fields: vec![
+                    IdlField {
+                        name: "ret1".to_string(),
+                        docs: None,
+                        ty: IdlType::U64,
+                    },
+                    IdlField {
+                        name: "ret2".to_string(),
+                        docs: None,
+                        ty: IdlType::U64,
+                    }
+                ],
+            },
+        }
+    );
+}
+
+#[test]
+fn mangled_names() {
+    let src = r#"
+contract Testing {
+    function getNum(uint64 a, uint64 b) public pure returns (uint64 ret1, uint64 ret2) {
+        ret1 = a + b;
+        ret2 = a/b;
+    }
+
+    function getNum(int32 a, int32 b) public pure returns (int32 ret3, int32 ret4) {
+        ret3 = a-b;
+        ret4 = b/a;
+    }
+}
+    "#;
+
+    let ns = generate_namespace(src);
+    let idl = generate_anchor_idl(0, &ns);
+
+    assert_eq!(idl.instructions.len(), 3);
+
+    assert_eq!(idl.instructions[0].name, "new");
+
+    assert_eq!(idl.instructions[1].name, "getNum_uint64_uint64");
+    assert!(idl.instructions[1].docs.is_none());
+    assert!(idl.instructions[1].accounts.is_empty());
+    assert_eq!(idl.instructions[1].args.len(), 2);
+    assert_eq!(
+        idl.instructions[1].args[0],
+        IdlField {
+            name: "a".to_string(),
+            docs: None,
+            ty: IdlType::U64
+        }
+    );
+    assert_eq!(
+        idl.instructions[1].args[1],
+        IdlField {
+            name: "b".to_string(),
+            docs: None,
+            ty: IdlType::U64
+        }
+    );
+    assert_eq!(
+        idl.instructions[1].returns,
+        Some(IdlType::Defined("getNum_uint64_uint64_returns".to_string()))
+    );
+
+    assert_eq!(idl.instructions[2].name, "getNum_int32_int32");
+    assert!(idl.instructions[2].docs.is_none());
+    assert!(idl.instructions[2].accounts.is_empty());
+
+    assert_eq!(idl.instructions[2].args.len(), 2);
+    assert_eq!(
+        idl.instructions[2].args[0],
+        IdlField {
+            name: "a".to_string(),
+            docs: None,
+            ty: IdlType::I32,
+        }
+    );
+    assert_eq!(
+        idl.instructions[2].args[1],
+        IdlField {
+            name: "b".to_string(),
+            docs: None,
+            ty: IdlType::I32
+        }
+    );
+    assert_eq!(
+        idl.instructions[2].returns,
+        Some(IdlType::Defined("getNum_int32_int32_returns".to_string()))
+    );
+
+    assert_eq!(idl.types.len(), 2);
+
+    assert_eq!(
+        idl.types[0],
+        IdlTypeDefinition {
+            name: "getNum_uint64_uint64_returns".to_string(),
+            docs: Some(vec![
+                "Data structure to hold the multiple returns of function getNum".to_string()
+            ]),
+            ty: IdlTypeDefinitionTy::Struct {
+                fields: vec![
+                    IdlField {
+                        name: "ret1".to_string(),
+                        docs: None,
+                        ty: IdlType::U64
+                    },
+                    IdlField {
+                        name: "ret2".to_string(),
+                        docs: None,
+                        ty: IdlType::U64
+                    }
+                ]
+            }
+        }
+    );
+
+    assert_eq!(
+        idl.types[1],
+        IdlTypeDefinition {
+            name: "getNum_int32_int32_returns".to_string(),
+            docs: Some(vec![
+                "Data structure to hold the multiple returns of function getNum".to_string()
+            ]),
+            ty: IdlTypeDefinitionTy::Struct {
+                fields: vec![
+                    IdlField {
+                        name: "ret3".to_string(),
+                        docs: None,
+                        ty: IdlType::I32
+                    },
+                    IdlField {
+                        name: "ret4".to_string(),
+                        docs: None,
+                        ty: IdlType::I32
+                    }
+                ]
+            }
+        }
+    );
+}
+
+#[test]
+fn name_collision() {
+    let str = r#"
+    contract Testing {
+    struct getNum_returns {
+        string str;
+    }
+
+    function getNum(uint64 a, uint64 b, getNum_returns c) public pure returns (uint64 ret1, uint64 ret2) {
+        ret1 = a + b;
+        ret2 = a/b;
+    }
+
+    function doNotGetNum(int32 a, int32 b) public pure returns (int32 ret3, int32 ret4) {
+        ret3 = a-b;
+        ret4 = b/a;
+    }
+}
+    "#;
+
+    let ns = generate_namespace(str);
+    let idl = generate_anchor_idl(0, &ns);
+
+    assert_eq!(idl.types.len(), 3);
+
+    assert_eq!(
+        idl.types[0],
+        IdlTypeDefinition {
+            name: "getNum_returns".to_string(),
+            docs: None,
+            ty: IdlTypeDefinitionTy::Struct {
+                fields: vec![IdlField {
+                    name: "str".to_string(),
+                    docs: None,
+                    ty: IdlType::String,
+                }]
+            },
+        }
+    );
+
+    assert_eq!(
+        idl.types[1],
+        IdlTypeDefinition {
+            name: "getNum_returns_1".to_string(),
+            docs: Some(vec![
+                "Data structure to hold the multiple returns of function getNum".to_string()
+            ]),
+            ty: IdlTypeDefinitionTy::Struct {
+                fields: vec![
+                    IdlField {
+                        name: "ret1".to_string(),
+                        docs: None,
+                        ty: IdlType::U64
+                    },
+                    IdlField {
+                        name: "ret2".to_string(),
+                        docs: None,
+                        ty: IdlType::U64
+                    }
+                ]
+            }
+        }
+    );
+
+    assert_eq!(
+        idl.types[2],
+        IdlTypeDefinition {
+            name: "doNotGetNum_returns".to_string(),
+            docs: Some(vec![
+                "Data structure to hold the multiple returns of function doNotGetNum".to_string()
+            ]),
+            ty: IdlTypeDefinitionTy::Struct {
+                fields: vec![
+                    IdlField {
+                        name: "ret3".to_string(),
+                        docs: None,
+                        ty: IdlType::I32
+                    },
+                    IdlField {
+                        name: "ret4".to_string(),
+                        docs: None,
+                        ty: IdlType::I32
+                    }
+                ]
+            }
+        }
+    );
+}
+
+#[test]
+fn double_name_collision() {
+    let str = r#"
+    contract Testing {
+    struct getNum_returns {
+        string str;
+    }
+
+    struct getNum_returns_1 {
+        bytes bt;
+    }
+
+    function getNum(uint64 a, uint64 b, getNum_returns c) public pure returns (uint64 ret1, uint64 ret2) {
+        ret1 = a + b;
+        ret2 = a/b;
+    }
+
+    function doNotGetNum(int32 a, int32 b, getNum_returns_1 c) public pure returns (int32 ret3, int32 ret4) {
+        ret3 = a-b;
+        ret4 = b/a;
+    }
+}
+    "#;
+
+    let ns = generate_namespace(str);
+    let idl = generate_anchor_idl(0, &ns);
+
+    assert_eq!(idl.types.len(), 4);
+
+    assert_eq!(
+        idl.types[0],
+        IdlTypeDefinition {
+            name: "getNum_returns".to_string(),
+            docs: None,
+            ty: IdlTypeDefinitionTy::Struct {
+                fields: vec![IdlField {
+                    name: "str".to_string(),
+                    docs: None,
+                    ty: IdlType::String,
+                }]
+            },
+        }
+    );
+
+    assert_eq!(
+        idl.types[1],
+        IdlTypeDefinition {
+            name: "getNum_returns_1".to_string(),
+            docs: None,
+            ty: IdlTypeDefinitionTy::Struct {
+                fields: vec![IdlField {
+                    name: "bt".to_string(),
+                    docs: None,
+                    ty: IdlType::Bytes
+                },]
+            }
+        }
+    );
+
+    assert_eq!(
+        idl.types[2],
+        IdlTypeDefinition {
+            name: "getNum_returns_2".to_string(),
+            docs: Some(vec![
+                "Data structure to hold the multiple returns of function getNum".to_string()
+            ]),
+            ty: IdlTypeDefinitionTy::Struct {
+                fields: vec![
+                    IdlField {
+                        name: "ret1".to_string(),
+                        docs: None,
+                        ty: IdlType::U64
+                    },
+                    IdlField {
+                        name: "ret2".to_string(),
+                        docs: None,
+                        ty: IdlType::U64
+                    }
+                ]
+            }
+        }
+    );
+
+    assert_eq!(
+        idl.types[3],
+        IdlTypeDefinition {
+            name: "doNotGetNum_returns".to_string(),
+            docs: Some(vec![
+                "Data structure to hold the multiple returns of function doNotGetNum".to_string()
+            ]),
+            ty: IdlTypeDefinitionTy::Struct {
+                fields: vec![
+                    IdlField {
+                        name: "ret3".to_string(),
+                        docs: None,
+                        ty: IdlType::I32
+                    },
+                    IdlField {
+                        name: "ret4".to_string(),
+                        docs: None,
+                        ty: IdlType::I32
+                    }
+                ]
+            }
+        }
+    );
+}

--- a/src/abi/tests.rs
+++ b/src/abi/tests.rs
@@ -12,6 +12,7 @@ use anchor_syn::idl::{
     IdlTypeDefinition, IdlTypeDefinitionTy,
 };
 use semver::Version;
+use serde_json::json;
 use std::ffi::OsStr;
 
 fn generate_namespace(src: &'static str) -> Namespace {
@@ -1475,4 +1476,31 @@ contract C {
     assert_eq!(idl.types[1].name, "Foo");
     assert_eq!(idl.types[2].name, "D_Foo_2");
     assert_eq!(idl.types[3].name, "D_Foo_1");
+}
+
+#[test]
+fn program_id() {
+    let src = r#"
+    @program_id("Foo5mMfYo5RhRcWa4NZ2bwFn4Kdhe8rNK5jchxsKrivA")
+contract C {
+    struct D_Foo {
+        int64 f2;
+    }
+
+    struct D_Foo_1 {
+       int64 f3;
+    }
+
+    function f(D_Foo_1 k, D_Foo z) public pure returns (int64) { return z.f2 + k.f3; }
+}
+    "#;
+
+    let ns = generate_namespace(src);
+    let idl = generate_anchor_idl(0, &ns);
+
+    assert!(idl.metadata.is_some());
+    assert_eq!(
+        idl.metadata.unwrap(),
+        json!({"address": "Foo5mMfYo5RhRcWa4NZ2bwFn4Kdhe8rNK5jchxsKrivA"})
+    );
 }

--- a/src/bin/idl/mod.rs
+++ b/src/bin/idl/mod.rs
@@ -358,6 +358,8 @@ fn idltype_to_solidity(ty: &IdlType, ty_names: &[(String, String)]) -> Result<St
         IdlType::I64 => Ok("int64".to_string()),
         IdlType::U128 => Ok("uint128".to_string()),
         IdlType::I128 => Ok("int128".to_string()),
+        IdlType::U256 => Ok("uint256".to_string()),
+        IdlType::I256 => Ok("int256".to_string()),
         IdlType::F32 => Err("f32".to_string()),
         IdlType::F64 => Err("f64".to_string()),
         IdlType::Bytes => Ok("bytes".to_string()),

--- a/src/sema/yul/tests/block.rs
+++ b/src/sema/yul/tests/block.rs
@@ -186,9 +186,6 @@ contract testTypes {
     "#;
 
     let ns = parse(file);
-    for item in ns.diagnostics.iter() {
-        std::println!("{}", item.message);
-    }
     assert!(ns.diagnostics.contains_message("unreachable yul statement"));
 
     let file = r#"

--- a/src/sema/yul/tests/switch.rs
+++ b/src/sema/yul/tests/switch.rs
@@ -100,9 +100,6 @@ contract testTypes {
     "#;
 
     let ns = parse(file);
-    for item in ns.diagnostics.iter() {
-        std::println!("{}", item.message);
-    }
     assert_eq!(ns.diagnostics.len(), 1);
     assert_eq!(
         ns.diagnostics.iter().next().unwrap().message,

--- a/tests/solana.rs
+++ b/tests/solana.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::borsh_encoding::{decode_output, encode_arguments, BorshToken};
+use crate::borsh_encoding::{decode_at_offset, encode_arguments, BorshToken};
 use base58::{FromBase58, ToBase58};
 use byteorder::{ByteOrder, LittleEndian, WriteBytesExt};
 use ethabi::RawLog;
@@ -23,7 +23,8 @@ use solana_rbpf::{
 };
 use solang::compile;
 
-use solang::abi::anchor::discriminator;
+use anchor_syn::idl::Idl;
+use solang::abi::anchor::{discriminator, generate_anchor_idl};
 use solang::{file_resolver::FileResolver, Target};
 use std::{
     cell::{RefCell, RefMut},
@@ -75,7 +76,7 @@ struct VirtualMachine {
 #[derive(Clone)]
 struct Contract {
     program: Account,
-    abi: Option<ethabi::Contract>,
+    idl: Option<Idl>,
     data: Account,
 }
 
@@ -151,9 +152,7 @@ fn build_solidity_with_overflow_check(src: &str, math_overflow_flag: bool) -> Vi
         }
 
         let code = contract.code.get().unwrap();
-
-        let (abistr, _) = solang::abi::generate_abi(contract_no, &ns, code, false);
-        let abi = ethabi::Contract::load(abistr.as_bytes()).unwrap();
+        let idl = generate_anchor_idl(contract_no, &ns);
 
         let program = if let Some(program_id) = &contract.program_id {
             program_id.clone().try_into().unwrap()
@@ -183,7 +182,7 @@ fn build_solidity_with_overflow_check(src: &str, math_overflow_flag: bool) -> Vi
 
         programs.push(Contract {
             program,
-            abi: Some(abi),
+            idl: Some(idl),
             data,
         });
     }
@@ -1384,7 +1383,7 @@ impl<'a> SyscallObject<UserError> for SyscallInvokeSignedC<'a> {
 
                         vm.programs.push(Contract {
                             program: create_account.program_id,
-                            abi: None,
+                            idl: None,
                             data: new_address,
                         });
                     }
@@ -1606,8 +1605,14 @@ impl VirtualMachine {
         println!("constructor for {}", hex::encode(program.data));
 
         let mut calldata = discriminator("global", "new");
-
-        if program.abi.as_ref().unwrap().constructor.is_some() {
+        if program
+            .idl
+            .as_ref()
+            .unwrap()
+            .instructions
+            .iter()
+            .any(|instr| instr.name == "new")
+        {
             let mut encoded_data = encode_arguments(args);
             calldata.append(&mut encoded_data);
         };
@@ -1623,7 +1628,7 @@ impl VirtualMachine {
         }
     }
 
-    fn function(&mut self, name: &str, args: &[BorshToken]) -> Vec<BorshToken> {
+    fn function(&mut self, name: &str, args: &[BorshToken]) -> Option<BorshToken> {
         let default_metas = self.default_metas();
 
         self.function_metas(&default_metas, name, args)
@@ -1634,14 +1639,30 @@ impl VirtualMachine {
         metas: &[AccountMeta],
         name: &str,
         args: &[BorshToken],
-    ) -> Vec<BorshToken> {
+    ) -> Option<BorshToken> {
         self.return_data = None;
-
         let program = &self.stack[0];
 
         println!("function {} for {}", name, hex::encode(program.data));
 
         let mut calldata = discriminator("global", name);
+        println!("input: {} ", hex::encode(&calldata));
+
+        let instruction = if let Some(instr) = self.stack[0]
+            .idl
+            .as_ref()
+            .unwrap()
+            .instructions
+            .iter()
+            .find(|item| item.name == name)
+        {
+            instr.clone()
+        } else {
+            panic!("Function '{}' not found", name);
+        };
+
+        let selector = discriminator("global", name);
+        calldata.extend_from_slice(&selector);
         let mut encoded_args = encode_arguments(args);
         calldata.append(&mut encoded_args);
 
@@ -1660,11 +1681,18 @@ impl VirtualMachine {
             &[]
         };
 
-        let func = &self.stack[0].abi.as_ref().unwrap().functions[name][0];
-        if func.outputs.is_empty() {
+        if let Some(ret) = &instruction.returns {
+            let mut offset: usize = 0;
+            Some(decode_at_offset(
+                return_data,
+                &mut offset,
+                ret,
+                &self.stack[0].idl.as_ref().unwrap().types,
+            ))
+        } else {
             assert_eq!(return_data.len(), 0);
+            None
         }
-        decode_output(&func.outputs, return_data)
     }
 
     fn function_must_fail(
@@ -1677,6 +1705,17 @@ impl VirtualMachine {
         println!("function for {}", hex::encode(program.data));
 
         let mut calldata = Vec::new();
+
+        if !self.stack[0]
+            .idl
+            .as_ref()
+            .unwrap()
+            .instructions
+            .iter()
+            .any(|item| item.name == name)
+        {
+            panic!("Function '{}' not found", name);
+        }
 
         let selector = discriminator("global", name);
         calldata.extend_from_slice(&selector);
@@ -1757,7 +1796,7 @@ impl VirtualMachine {
 
         self.programs.push(Contract {
             program: *program_id,
-            abi: None,
+            idl: None,
             data: *account,
         });
     }

--- a/tests/solana_tests/abi.rs
+++ b/tests/solana_tests/abi.rs
@@ -45,7 +45,7 @@ fn packed() {
         }"#,
     );
 
-    vm.constructor("bar", &[]);
+    vm.constructor(&[]);
 
     vm.function("test", &[]);
     vm.function("test2", &[]);
@@ -65,7 +65,7 @@ fn inherited() {
         contract bar is foo { }"#,
     );
 
-    vm.constructor("bar", &[]);
+    vm.constructor(&[]);
 
     vm.function("test", &[]);
 
@@ -78,7 +78,7 @@ fn inherited() {
             contract bar is foo { }"#,
     );
 
-    vm.constructor("bar", &[]);
+    vm.constructor(&[]);
 
     vm.function("test", &[]);
 }

--- a/tests/solana_tests/abi_decode.rs
+++ b/tests/solana_tests/abi_decode.rs
@@ -67,7 +67,7 @@ fn integers_bool_enum() {
         "#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     let input = Res1 {
         a: 45,
         b: 9965956609890,
@@ -110,7 +110,7 @@ fn decode_address() {
         "#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     let input = Data {
         address: vm.programs[0].data,
         this: vm.programs[0].data,
@@ -140,7 +140,7 @@ fn string_and_bytes() {
         "#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     let data = Data {
         a: "coffee".to_string(),
         b: b"tea".to_vec(),
@@ -194,7 +194,7 @@ fn primitive_struct() {
         "#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     let data = NoPadStruct { a: 1238, b: 87123 };
     let encoded = data.try_to_vec().unwrap();
     let _ = vm.function("testNoPadStruct", &[BorshToken::Bytes(encoded)]);
@@ -227,7 +227,7 @@ fn returned_string() {
     }
         "#,
     );
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     let data = Input {
         rr: "cortado".to_string(),
     };
@@ -257,7 +257,7 @@ fn test_string_array() {
         "#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     let data = Input {
         a: vec![
             "coffee".to_string(),
@@ -337,7 +337,7 @@ fn struct_within_struct() {
         "#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     let no_pad = NoPadStruct { a: 89123, b: 12354 };
     let mut tea_is_good = b"tea_is_good".to_vec();
     tea_is_good.append(&mut vec![0; 21]);
@@ -449,7 +449,7 @@ fn struct_in_array() {
         "#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     let mut bytes_string = b"there_is_padding_here".to_vec();
     bytes_string.append(&mut vec![0; 11]);
     let input = Input1 {
@@ -552,7 +552,7 @@ fn arrays() {
         "#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     let input = Input1 {
         complex_array: vec![
             NonConstantStruct {
@@ -687,7 +687,7 @@ fn multi_dimensional_arrays() {
     }
         "#,
     );
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     let mut response: Vec<u8> = vec![0; 32];
 
     let input = Input1 {
@@ -781,7 +781,7 @@ fn empty_arrays() {
     }
         "#,
     );
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
 
     let input = Input {
         vec_1: vec![],
@@ -810,7 +810,7 @@ fn external_function() {
         "#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     let input = Input {
         selector: [1, 2, 3, 4, 5, 6, 7, 8],
         address: [
@@ -857,7 +857,7 @@ fn bytes_arrays() {
         "#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     let input = Input {
         item_1: [b"abcd".to_owned(), b"efgh".to_owned()],
         item_2: vec![b"12345".to_owned(), b"67890".to_owned()],
@@ -892,7 +892,7 @@ fn different_types() {
         "#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     let input = Input1 { a: -789, b: 14234 };
     let encoded = input.try_to_vec().unwrap();
     let _ = vm.function("testByteArrays", &[BorshToken::Bytes(encoded)]);
@@ -918,7 +918,7 @@ fn more_elements() {
         "#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
 
     let input = Input { vec: [1, 4, 5, 6] };
     let encoded = input.try_to_vec().unwrap();
@@ -946,7 +946,7 @@ fn extra_element() {
         "#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     let input = Input {
         vec: vec![-90, 89, -2341],
     };
@@ -975,7 +975,7 @@ fn invalid_type() {
     "#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
 
     let input = Input { item: 5 };
     let encoded = input.try_to_vec().unwrap();
@@ -1003,7 +1003,7 @@ fn longer_buffer() {
         "#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
 
     let input = Input {
         item_1: 4,
@@ -1035,7 +1035,7 @@ fn longer_buffer_array() {
             }
         }        "#,
     );
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
 
     let input = Input {
         item_1: 23434,
@@ -1069,7 +1069,7 @@ fn dynamic_array_of_array() {
         "#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     let input = Input {
         vec: vec![[0, 1], [2, -3]],
     };
@@ -1114,7 +1114,7 @@ fn test_struct_validation() {
         "#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     let mut bytes_string = b"struct".to_vec();
     bytes_string.append(&mut vec![0; 26]);
 
@@ -1167,7 +1167,7 @@ fn test_struct_validation_invalid() {
         "#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     let mut bytes_string = b"struct".to_vec();
     bytes_string.append(&mut vec![0; 26]);
 
@@ -1197,7 +1197,7 @@ fn string_fixed_array() {
 }
         "#,
     );
-    vm.constructor("test", &[]);
+    vm.constructor(&[]);
 
     #[derive(Debug, BorshSerialize)]
     struct Input {

--- a/tests/solana_tests/abi_decode.rs
+++ b/tests/solana_tests/abi_decode.rs
@@ -232,8 +232,10 @@ fn returned_string() {
         rr: "cortado".to_string(),
     };
     let encoded = data.try_to_vec().unwrap();
-    let returns = vm.function("returnedString", &[BorshToken::Bytes(encoded)]);
-    let string = returns[0].clone().into_string().unwrap();
+    let returns = vm
+        .function("returnedString", &[BorshToken::Bytes(encoded)])
+        .unwrap();
+    let string = returns.into_string().unwrap();
     assert_eq!(string, "cortado");
 }
 
@@ -264,8 +266,11 @@ fn test_string_array() {
         ],
     };
     let encoded = data.try_to_vec().unwrap();
-    let returns = vm.function("testStringVector", &[BorshToken::Bytes(encoded)]);
-    let vec = returns[0].clone().into_array().unwrap();
+    let returns = vm
+        .function("testStringVector", &[BorshToken::Bytes(encoded)])
+        .unwrap();
+    let vec = returns.into_array().unwrap();
+
     assert_eq!(vec.len(), 3);
     assert_eq!(vec[0].clone().into_string().unwrap(), "coffee");
     assert_eq!(vec[1].clone().into_string().unwrap(), "tea");
@@ -814,7 +819,11 @@ fn external_function() {
         ],
     };
     let encoded = input.try_to_vec().unwrap();
-    let returns = vm.function("testExternalFunction", &[BorshToken::Bytes(encoded)]);
+
+    let returns = vm
+        .function("testExternalFunction", &[BorshToken::Bytes(encoded)])
+        .unwrap()
+        .unwrap_tuple();
 
     let selector = returns[0].clone().into_fixed_bytes().unwrap();
     assert_eq!(selector, input.selector);

--- a/tests/solana_tests/abi_encode.rs
+++ b/tests/solana_tests/abi_encode.rs
@@ -68,8 +68,8 @@ contract Testing {
     );
 
     vm.constructor("Testing", &[]);
-    let returns = vm.function("getThis", &[]);
-    let encoded = returns[0].clone().into_bytes().unwrap();
+    let returns = vm.function("getThis", &[]).unwrap();
+    let encoded = returns.into_bytes().unwrap();
     let decoded = Res1::try_from_slice(&encoded).unwrap();
 
     assert_eq!(decoded.a, 45);
@@ -80,8 +80,8 @@ contract Testing {
     assert_eq!(decoded.day, WeekDay::Wednesday);
     assert!(!decoded.h);
 
-    let returns = vm.function("encodeEnum", &[]);
-    let encoded = returns[0].clone().into_bytes().unwrap();
+    let returns = vm.function("encodeEnum", &[]).unwrap();
+    let encoded = returns.into_bytes().unwrap();
     let decoded = Res2::try_from_slice(&encoded).unwrap();
 
     assert_eq!(decoded.sunday, WeekDay::Sunday);
@@ -109,8 +109,8 @@ contract Testing {
         "#,
     );
     vm.constructor("Testing", &[]);
-    let returns = vm.function("getThis", &[]);
-    let encoded = returns[0].clone().into_bytes().unwrap();
+    let returns = vm.function("getThis", &[]).unwrap();
+    let encoded = returns.into_bytes().unwrap();
     let decoded = Response::try_from_slice(&encoded).unwrap();
     assert_eq!(decoded.address, vm.programs[0].data);
     assert_eq!(decoded.this, vm.programs[0].data);
@@ -139,8 +139,8 @@ contract Testing {
     );
 
     vm.constructor("Testing", &[]);
-    let returns = vm.function("getThis", &[]);
-    let encoded = returns[0].clone().into_bytes().unwrap();
+    let returns = vm.function("getThis", &[]).unwrap();
+    let encoded = returns.into_bytes().unwrap();
     let decoded = MyStruct::try_from_slice(&encoded).unwrap();
     assert_eq!(decoded.a, "coffe");
     assert_eq!(decoded.b, b"tea");
@@ -191,14 +191,15 @@ fn primitive_structs() {
         "#,
     );
     vm.constructor("Testing", &[]);
-    let returns = vm.function("getThis", &[]);
-    let encoded = returns[0].clone().into_bytes().unwrap();
+    let returns = vm.function("getThis", &[]).unwrap();
+    let encoded = returns.into_bytes().unwrap();
+
     let decoded = NoPadStruct::try_from_slice(&encoded).unwrap();
     assert_eq!(decoded.a, 1238);
     assert_eq!(decoded.b, 87123);
 
-    let returns = vm.function("getThat", &[]);
-    let encoded = returns[0].clone().into_bytes().unwrap();
+    let returns = vm.function("getThat", &[]).unwrap();
+    let encoded = returns.into_bytes().unwrap();
     let decoded = PaddedStruct::try_from_slice(&encoded).unwrap();
     assert_eq!(decoded.a, 12998);
     assert_eq!(decoded.b, 240);
@@ -226,8 +227,11 @@ contract Testing {
     );
 
     vm.constructor("Testing", &[]);
-    let returns = vm.function("testStruct", &[BorshToken::String("nihao".to_string())]);
-    let encoded = returns[0].clone().into_bytes().unwrap();
+
+    let returns = vm
+        .function("testStruct", &[BorshToken::String("nihao".to_string())])
+        .unwrap();
+    let encoded = returns.into_bytes().unwrap();
     let decoded = Response::try_from_slice(&encoded).unwrap();
     assert_eq!(decoded.rr, "nihao");
 }
@@ -258,14 +262,14 @@ fn test_string_array() {
     );
 
     vm.constructor("Testing", &[]);
-    let returns = vm.function("encode", &[]);
-    let encoded = returns[0].clone().into_bytes().unwrap();
+    let returns = vm.function("encode", &[]).unwrap();
+    let encoded = returns.into_bytes().unwrap();
     let decoded = Response::try_from_slice(&encoded).unwrap();
     assert_eq!(decoded.a.len(), 0);
 
     let _ = vm.function("insertStrings", &[]);
-    let returns = vm.function("encode", &[]);
-    let encoded = returns[0].clone().into_bytes().unwrap();
+    let returns = vm.function("encode", &[]).unwrap();
+    let encoded = returns.into_bytes().unwrap();
     let decoded = Response::try_from_slice(&encoded).unwrap();
     assert_eq!(decoded.a.len(), 2);
     assert_eq!(decoded.a[0], "tea");
@@ -335,8 +339,8 @@ contract Testing {
     );
 
     vm.constructor("Testing", &[]);
-    let returns = vm.function("testStruct", &[]);
-    let encoded = returns[0].clone().into_bytes().unwrap();
+    let returns = vm.function("testStruct", &[]).unwrap();
+    let encoded = returns.into_bytes().unwrap();
     let decoded = NonConstantStruct::try_from_slice(&encoded).unwrap();
 
     assert_eq!(decoded.a, 890234);
@@ -439,8 +443,8 @@ fn struct_in_array() {
 
     vm.constructor("Testing", &[]);
     let _ = vm.function("addData", &[]);
-    let returns = vm.function("encodeStruct", &[]);
-    let encoded = returns[0].clone().into_bytes().unwrap();
+    let returns = vm.function("encodeStruct", &[]).unwrap();
+    let encoded = returns.into_bytes().unwrap();
     let decoded = Res1::try_from_slice(&encoded).unwrap();
 
     assert_eq!(decoded.item_1.a, 945);
@@ -450,8 +454,8 @@ fn struct_in_array() {
     let b: [u8; 21] = b"there_is_padding_here".to_owned();
     assert_eq!(&decoded.item_2.c[0..21], b);
 
-    let returns = vm.function("primitiveStruct", &[]);
-    let encoded = returns[0].clone().into_bytes().unwrap();
+    let returns = vm.function("primitiveStruct", &[]).unwrap();
+    let encoded = returns.into_bytes().unwrap();
     let decoded = Res2::try_from_slice(&encoded).unwrap();
 
     assert_eq!(decoded.item_1.len(), 3);
@@ -462,8 +466,8 @@ fn struct_in_array() {
     assert_eq!(decoded.item_3[0], NoPadStruct { a: 1, b: 2 });
     assert_eq!(decoded.item_3[1], NoPadStruct { a: 3, b: 4 });
 
-    let returns = vm.function("primitiveDynamicArray", &[]);
-    let encoded = returns[0].clone().into_bytes().unwrap();
+    let returns = vm.function("primitiveDynamicArray", &[]).unwrap();
+    let encoded = returns.into_bytes().unwrap();
     let decoded = Res3::try_from_slice(&encoded).unwrap();
 
     assert_eq!(decoded.item_1.len(), 2);
@@ -539,8 +543,8 @@ fn arrays() {
 
     vm.constructor("Testing", &[]);
     let _ = vm.function("addData", &[]);
-    let returns = vm.function("encodeArray", &[]);
-    let encoded = returns[0].clone().into_bytes().unwrap();
+    let returns = vm.function("encodeArray", &[]).unwrap();
+    let encoded = returns.into_bytes().unwrap();
     let decoded = Res1::try_from_slice(&encoded).unwrap();
 
     assert_eq!(decoded.vec_1.len(), 3);
@@ -548,8 +552,8 @@ fn arrays() {
     assert_eq!(decoded.vec_1[1], 5523);
     assert_eq!(decoded.vec_1[2], -89);
 
-    let returns = vm.function("encodeComplex", &[]);
-    let encoded = returns[0].clone().into_bytes().unwrap();
+    let returns = vm.function("encodeComplex", &[]).unwrap();
+    let encoded = returns.into_bytes().unwrap();
     let decoded = Res2::try_from_slice(&encoded).unwrap();
 
     assert_eq!(decoded.complex_array.len(), 2);
@@ -564,8 +568,8 @@ fn arrays() {
         vec!["cortado".to_string(), "cappuccino".to_string()]
     );
 
-    let returns = vm.function("multiDimArrays", &[]);
-    let encoded = returns[0].clone().into_bytes().unwrap();
+    let returns = vm.function("multiDimArrays", &[]).unwrap();
+    let encoded = returns.into_bytes().unwrap();
     let decoded = Res3::try_from_slice(&encoded).unwrap();
 
     assert_eq!(decoded.multi_dim[0], [1, 2]);
@@ -651,8 +655,8 @@ contract Testing {
     );
 
     vm.constructor("Testing", &[]);
-    let returns = vm.function("getThis", &[]);
-    let encoded = returns[0].clone().into_bytes().unwrap();
+    let returns = vm.function("getThis", &[]).unwrap();
+    let encoded = returns.into_bytes().unwrap();
     let decoded = Res1::try_from_slice(&encoded).unwrap();
 
     assert_eq!(decoded.item_1.len(), 1);
@@ -709,16 +713,16 @@ contract Testing {
     );
     assert_eq!(decoded.item_2, 5);
 
-    let returns = vm.function("multiDim", &[]);
-    let encoded = returns[0].clone().into_bytes().unwrap();
+    let returns = vm.function("multiDim", &[]).unwrap();
+    let encoded = returns.into_bytes().unwrap();
     let decoded = Res2::try_from_slice(&encoded).unwrap();
 
     assert_eq!(decoded.item.len(), 1);
     assert_eq!(decoded.item[0][0], [1, 2, 3, 4]);
     assert_eq!(decoded.item[0][1], [5, 6, 7, 8]);
 
-    let returns = vm.function("uniqueDim", &[]);
-    let encoded = returns[0].clone().into_bytes().unwrap();
+    let returns = vm.function("uniqueDim", &[]).unwrap();
+    let encoded = returns.into_bytes().unwrap();
     let decoded = Res3::try_from_slice(&encoded).unwrap();
 
     assert_eq!(decoded.item.len(), 5);
@@ -772,8 +776,8 @@ fn null_pointer() {
     );
 
     vm.constructor("Testing", &[]);
-    let returns = vm.function("test1", &[]);
-    let encoded = returns[0].clone().into_bytes().unwrap();
+    let returns = vm.function("test1", &[]).unwrap();
+    let encoded = returns.into_bytes().unwrap();
     let decoded = Res1::try_from_slice(&encoded).unwrap();
 
     assert_eq!(decoded.item.len(), 5);
@@ -782,8 +786,8 @@ fn null_pointer() {
         assert!(decoded.item[i].f2.is_empty())
     }
 
-    let returns = vm.function("test2", &[]);
-    let encoded = returns[0].clone().into_bytes().unwrap();
+    let returns = vm.function("test2", &[]).unwrap();
+    let encoded = returns.into_bytes().unwrap();
     let decoded = Res2::try_from_slice(&encoded).unwrap();
 
     assert_eq!(decoded.item.len(), 5);
@@ -820,7 +824,7 @@ fn external_function() {
 
     vm.constructor("Testing", &[]);
 
-    let returns = vm.function("doThat", &[]);
+    let returns = vm.function("doThat", &[]).unwrap().unwrap_tuple();
     let encoded = returns[2].clone().into_bytes().unwrap();
     let decoded = Res::try_from_slice(&encoded).unwrap();
 
@@ -854,8 +858,8 @@ fn bytes_arrays() {
         "#,
     );
     vm.constructor("Testing", &[]);
-    let returns = vm.function("testBytesArray", &[]);
-    let encoded = returns[0].clone().into_bytes().unwrap();
+    let returns = vm.function("testBytesArray", &[]).unwrap();
+    let encoded = returns.into_bytes().unwrap();
     let decoded = Res::try_from_slice(&encoded).unwrap();
 
     assert_eq!(&decoded.item_1[0], b"abcd");
@@ -893,8 +897,8 @@ fn uint8_arrays() {
     );
 
     vm.constructor("Testing", &[]);
-    let returns = vm.function("testBytesArray", &[]);
-    let encoded = returns[0].clone().into_bytes().unwrap();
+    let returns = vm.function("testBytesArray", &[]).unwrap();
+    let encoded = returns.into_bytes().unwrap();
     let decoded = Res::try_from_slice(&encoded).unwrap();
 
     assert!(decoded.item_2.is_empty());
@@ -925,7 +929,7 @@ contract caller {
 
     vm.constructor("caller", &[]);
 
-    let returns = vm.function("do_call", &[]);
+    let returns = vm.function("do_call", &[]).unwrap().unwrap_tuple();
     assert_eq!(returns.len(), 2);
     assert_eq!(
         returns[0],

--- a/tests/solana_tests/abi_encode.rs
+++ b/tests/solana_tests/abi_encode.rs
@@ -67,7 +67,7 @@ contract Testing {
         "#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     let returns = vm.function("getThis", &[]).unwrap();
     let encoded = returns.into_bytes().unwrap();
     let decoded = Res1::try_from_slice(&encoded).unwrap();
@@ -108,7 +108,7 @@ contract Testing {
 }
         "#,
     );
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     let returns = vm.function("getThis", &[]).unwrap();
     let encoded = returns.into_bytes().unwrap();
     let decoded = Response::try_from_slice(&encoded).unwrap();
@@ -138,7 +138,7 @@ contract Testing {
       "#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     let returns = vm.function("getThis", &[]).unwrap();
     let encoded = returns.into_bytes().unwrap();
     let decoded = MyStruct::try_from_slice(&encoded).unwrap();
@@ -190,7 +190,7 @@ fn primitive_structs() {
 }
         "#,
     );
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     let returns = vm.function("getThis", &[]).unwrap();
     let encoded = returns.into_bytes().unwrap();
 
@@ -226,7 +226,7 @@ contract Testing {
       "#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
 
     let returns = vm
         .function("testStruct", &[BorshToken::String("nihao".to_string())])
@@ -261,7 +261,7 @@ fn test_string_array() {
         "#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     let returns = vm.function("encode", &[]).unwrap();
     let encoded = returns.into_bytes().unwrap();
     let decoded = Response::try_from_slice(&encoded).unwrap();
@@ -338,7 +338,7 @@ contract Testing {
         "#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     let returns = vm.function("testStruct", &[]).unwrap();
     let encoded = returns.into_bytes().unwrap();
     let decoded = NonConstantStruct::try_from_slice(&encoded).unwrap();
@@ -441,7 +441,7 @@ fn struct_in_array() {
         "#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     let _ = vm.function("addData", &[]);
     let returns = vm.function("encodeStruct", &[]).unwrap();
     let encoded = returns.into_bytes().unwrap();
@@ -541,7 +541,7 @@ fn arrays() {
       "#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     let _ = vm.function("addData", &[]);
     let returns = vm.function("encodeArray", &[]).unwrap();
     let encoded = returns.into_bytes().unwrap();
@@ -654,7 +654,7 @@ contract Testing {
         "#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     let returns = vm.function("getThis", &[]).unwrap();
     let encoded = returns.into_bytes().unwrap();
     let decoded = Res1::try_from_slice(&encoded).unwrap();
@@ -775,7 +775,7 @@ fn null_pointer() {
         "#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     let returns = vm.function("test1", &[]).unwrap();
     let encoded = returns.into_bytes().unwrap();
     let decoded = Res1::try_from_slice(&encoded).unwrap();
@@ -822,7 +822,7 @@ fn external_function() {
         "#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("doThat", &[]).unwrap().unwrap_tuple();
     let encoded = returns[2].clone().into_bytes().unwrap();
@@ -857,7 +857,7 @@ fn bytes_arrays() {
     }
         "#,
     );
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     let returns = vm.function("testBytesArray", &[]).unwrap();
     let encoded = returns.into_bytes().unwrap();
     let decoded = Res::try_from_slice(&encoded).unwrap();
@@ -896,7 +896,7 @@ fn uint8_arrays() {
     }"#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     let returns = vm.function("testBytesArray", &[]).unwrap();
     let encoded = returns.into_bytes().unwrap();
     let decoded = Res::try_from_slice(&encoded).unwrap();
@@ -927,7 +927,7 @@ contract caller {
 }"#,
     );
 
-    vm.constructor("caller", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("do_call", &[]).unwrap().unwrap_tuple();
     assert_eq!(returns.len(), 2);

--- a/tests/solana_tests/accessor.rs
+++ b/tests/solana_tests/accessor.rs
@@ -15,14 +15,14 @@ fn types() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function("f1", &[]);
+    let returns = vm.function("f1", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Int {
+        BorshToken::Int {
             width: 64,
             value: BigInt::from(102u8),
-        }]
+        }
     );
 
     let mut vm = build_solidity(
@@ -34,20 +34,22 @@ fn types() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function(
-        "f1",
-        &[BorshToken::Uint {
-            width: 256,
-            value: BigInt::from(2u8),
-        }],
-    );
+    let returns = vm
+        .function(
+            "f1",
+            &[BorshToken::Uint {
+                width: 256,
+                value: BigInt::from(2u8),
+            }],
+        )
+        .unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Int {
+        BorshToken::Int {
             width: 64,
             value: BigInt::from(5u8)
-        }]
+        }
     );
 
     let mut vm = build_solidity(
@@ -66,26 +68,28 @@ fn types() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function(
-        "f1",
-        &[
-            BorshToken::Uint {
-                width: 256,
-                value: BigInt::one(),
-            },
-            BorshToken::Uint {
-                width: 256,
-                value: BigInt::from(2u8),
-            },
-        ],
-    );
+    let returns = vm
+        .function(
+            "f1",
+            &[
+                BorshToken::Uint {
+                    width: 256,
+                    value: BigInt::one(),
+                },
+                BorshToken::Uint {
+                    width: 256,
+                    value: BigInt::from(2u8),
+                },
+            ],
+        )
+        .unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Int {
+        BorshToken::Int {
             width: 64,
             value: BigInt::from(2u8),
-        }]
+        }
     );
 
     let mut vm = build_solidity(
@@ -102,20 +106,22 @@ fn types() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function(
-        "f1",
-        &[BorshToken::Int {
-            width: 64,
-            value: BigInt::from(4000u16),
-        }],
-    );
+    let returns = vm
+        .function(
+            "f1",
+            &[BorshToken::Int {
+                width: 64,
+                value: BigInt::from(4000u16),
+            }],
+        )
+        .unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 64,
             value: BigInt::from(2u8)
-        }]
+        }
     );
 }
 
@@ -135,9 +141,9 @@ fn interfaces() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function("f1", &[]);
+    let returns = vm.function("f1", &[]).unwrap();
 
-    assert_eq!(returns, vec![BorshToken::FixedBytes(b"ab".to_vec())]);
+    assert_eq!(returns, BorshToken::uint8_fixed_array(b"ab".to_vec()));
 }
 
 #[test]
@@ -151,14 +157,14 @@ fn constant() {
 
     vm.constructor("x", &[]);
 
-    let returns = vm.function("z", &[]);
+    let returns = vm.function("z", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::FixedBytes(vec![
+        BorshToken::uint8_fixed_array(vec![
             0, 91, 121, 69, 17, 39, 209, 87, 169, 94, 81, 10, 68, 17, 183, 52, 82, 28, 128, 159,
             31, 73, 168, 235, 90, 61, 46, 198, 102, 241, 168, 79
-        ])]
+        ])
     );
 
     let mut vm = build_solidity(
@@ -170,14 +176,14 @@ fn constant() {
 
     vm.constructor("x", &[]);
 
-    let returns = vm.function("z", &[]);
+    let returns = vm.function("z", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::FixedBytes(vec![
+        BorshToken::uint8_fixed_array(vec![
             190, 212, 99, 127, 110, 196, 102, 135, 47, 156, 116, 193, 201, 43, 100, 230, 152, 184,
             58, 103, 63, 106, 217, 142, 143, 211, 220, 125, 255, 210, 48, 89
-        ])]
+        ])
     );
 
     let mut vm = build_solidity(
@@ -189,13 +195,13 @@ fn constant() {
 
     vm.constructor("x", &[]);
 
-    let returns = vm.function("z", &[]);
+    let returns = vm.function("z", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::FixedBytes(vec![
+        BorshToken::uint8_fixed_array(vec![
             255, 206, 178, 91, 165, 156, 178, 193, 7, 94, 233, 48, 117, 76, 48, 215, 255, 45, 61,
             225
-        ])]
+        ])
     );
 }

--- a/tests/solana_tests/accessor.rs
+++ b/tests/solana_tests/accessor.rs
@@ -13,7 +13,7 @@ fn types() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("f1", &[]).unwrap();
 
@@ -32,7 +32,7 @@ fn types() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm
         .function(
@@ -66,7 +66,7 @@ fn types() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm
         .function(
@@ -104,7 +104,7 @@ fn types() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm
         .function(
@@ -139,7 +139,7 @@ fn interfaces() {
         "#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("f1", &[]).unwrap();
 
@@ -155,7 +155,7 @@ fn constant() {
         }"#,
     );
 
-    vm.constructor("x", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("z", &[]).unwrap();
 
@@ -174,7 +174,7 @@ fn constant() {
         }"#,
     );
 
-    vm.constructor("x", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("z", &[]).unwrap();
 
@@ -193,7 +193,7 @@ fn constant() {
         }"#,
     );
 
-    vm.constructor("x", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("z", &[]).unwrap();
 

--- a/tests/solana_tests/account_info.rs
+++ b/tests/solana_tests/account_info.rs
@@ -27,7 +27,7 @@ fn lamports() {
         }"#,
     );
 
-    vm.constructor("c", &[]);
+    vm.constructor(&[]);
 
     vm.account_data.get_mut(&vm.origin).unwrap().lamports = 17672630920854456917u64;
 
@@ -64,7 +64,7 @@ fn owner() {
         }"#,
     );
 
-    vm.constructor("c", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("test", &[]).unwrap();
 
@@ -105,7 +105,7 @@ fn data() {
         }"#,
     );
 
-    vm.constructor("c", &[]);
+    vm.constructor(&[]);
 
     for i in 0..10 {
         let returns = vm

--- a/tests/solana_tests/account_info.rs
+++ b/tests/solana_tests/account_info.rs
@@ -31,10 +31,12 @@ fn lamports() {
 
     vm.account_data.get_mut(&vm.origin).unwrap().lamports = 17672630920854456917u64;
 
-    let returns = vm.function("test", &[BorshToken::Address(vm.origin)]);
+    let returns = vm
+        .function("test", &[BorshToken::Address(vm.origin)])
+        .unwrap();
 
     assert_eq!(
-        returns[0],
+        returns,
         BorshToken::Uint {
             width: 64,
             value: BigInt::from(17672630920854456917u64),
@@ -64,11 +66,11 @@ fn owner() {
 
     vm.constructor("c", &[]);
 
-    let returns = vm.function("test", &[]);
+    let returns = vm.function("test", &[]).unwrap();
 
-    let owner = vm.stack[0].program.to_vec();
+    let owner = vm.stack[0].program;
 
-    assert_eq!(returns[0], BorshToken::FixedBytes(owner));
+    assert_eq!(returns, BorshToken::Address(owner));
 }
 
 #[test]
@@ -106,20 +108,22 @@ fn data() {
     vm.constructor("c", &[]);
 
     for i in 0..10 {
-        let returns = vm.function(
-            "test",
-            &[BorshToken::Uint {
-                width: 32,
-                value: BigInt::from(i),
-            }],
-        );
+        let returns = vm
+            .function(
+                "test",
+                &[BorshToken::Uint {
+                    width: 32,
+                    value: BigInt::from(i),
+                }],
+            )
+            .unwrap();
 
         let this = &vm.stack[0].data;
 
         let val = vm.account_data[this].data[i];
 
         assert_eq!(
-            returns[0],
+            returns,
             BorshToken::Uint {
                 width: 8,
                 value: BigInt::from(val),
@@ -127,14 +131,14 @@ fn data() {
         );
     }
 
-    let returns = vm.function("test2", &[]);
+    let returns = vm.function("test2", &[]).unwrap();
 
     let this = &vm.stack[0].data;
 
     let val = u32::from_le_bytes(vm.account_data[this].data[1..5].try_into().unwrap());
 
     assert_eq!(
-        returns[0],
+        returns,
         BorshToken::Uint {
             width: 32,
             value: BigInt::from(val),

--- a/tests/solana_tests/arrays.rs
+++ b/tests/solana_tests/arrays.rs
@@ -20,7 +20,7 @@ fn fixed_array() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("get", &[]).unwrap().unwrap_tuple();
 
@@ -66,7 +66,7 @@ fn fixed_array() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("get", &[]).unwrap();
 
@@ -135,7 +135,7 @@ fn fixed_array() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("get", &[]).unwrap();
 
@@ -230,7 +230,7 @@ fn dynamic_array_fixed_elements() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm
         .function(
@@ -338,7 +338,7 @@ fn fixed_array_dynamic_elements() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm
         .function(
@@ -425,7 +425,7 @@ fn dynamic_array_dynamic_elements() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm
         .function(
@@ -506,7 +506,7 @@ fn fixed_array_fixed_elements_storage() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     vm.function(
         "set_elem",
@@ -680,7 +680,7 @@ fn fixed_array_dynamic_elements_storage() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     vm.function(
         "set_elem",
@@ -810,7 +810,7 @@ fn storage_simple_dynamic_array() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("len", &[]).unwrap();
 
@@ -1031,7 +1031,7 @@ fn storage_pop_running_on_empty() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     vm.function("pop", &[]);
 }
@@ -1088,7 +1088,7 @@ fn storage_dynamic_array_of_structs() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("len", &[]).unwrap();
 
@@ -1364,7 +1364,7 @@ fn array_literal() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("list", &[]).unwrap();
 
@@ -1440,7 +1440,7 @@ fn storage_pop_push() {
     }"#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     vm.function("fn1", &[]);
     vm.function("fn2", &[]);
     vm.function("fn3", &[]);
@@ -1479,7 +1479,7 @@ fn initialization_with_literal() {
         "#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
 
     let mut addr1: Vec<u8> = Vec::new();
     addr1.resize(32, 0);
@@ -1569,7 +1569,7 @@ fn dynamic_array_push() {
         "#,
     );
 
-    runtime.constructor("foo", &[]);
+    runtime.constructor(&[]);
     runtime.function("test", &[]);
 
     let mut runtime = build_solidity(
@@ -1590,7 +1590,7 @@ fn dynamic_array_push() {
         "#,
     );
 
-    runtime.constructor("foo", &[]);
+    runtime.constructor(&[]);
     runtime.function("test", &[]);
 
     let mut runtime = build_solidity(
@@ -1616,7 +1616,7 @@ fn dynamic_array_push() {
         "#,
     );
 
-    runtime.constructor("foo", &[]);
+    runtime.constructor(&[]);
     runtime.function("test", &[]);
 
     let mut runtime = build_solidity(
@@ -1638,7 +1638,7 @@ fn dynamic_array_push() {
         "#,
     );
 
-    runtime.constructor("foo", &[]);
+    runtime.constructor(&[]);
     runtime.function("test", &[]);
 
     // push() returns a reference to the thing
@@ -1664,7 +1664,7 @@ fn dynamic_array_push() {
         }"#,
     );
 
-    runtime.constructor("foo", &[]);
+    runtime.constructor(&[]);
     runtime.function("test", &[]);
 }
 
@@ -1688,7 +1688,7 @@ fn dynamic_array_pop() {
         "#,
     );
 
-    runtime.constructor("foo", &[]);
+    runtime.constructor(&[]);
     runtime.function("test", &[]);
 
     let mut runtime = build_solidity(
@@ -1709,7 +1709,7 @@ fn dynamic_array_pop() {
         "#,
     );
 
-    runtime.constructor("foo", &[]);
+    runtime.constructor(&[]);
     runtime.function("test", &[]);
 
     let mut runtime = build_solidity(
@@ -1737,7 +1737,7 @@ fn dynamic_array_pop() {
         "#,
     );
 
-    runtime.constructor("foo", &[]);
+    runtime.constructor(&[]);
     runtime.function("test", &[]);
 
     let mut runtime = build_solidity(
@@ -1759,7 +1759,7 @@ fn dynamic_array_pop() {
         "#,
     );
 
-    runtime.constructor("foo", &[]);
+    runtime.constructor(&[]);
     runtime.function("test", &[]);
 }
 
@@ -1778,7 +1778,7 @@ fn dynamic_array_pop_empty_array() {
         }"#,
     );
 
-    runtime.constructor("foo", &[]);
+    runtime.constructor(&[]);
     runtime.function("test", &[]);
 }
 
@@ -1800,7 +1800,7 @@ fn dynamic_array_pop_bounds() {
         }"#,
     );
 
-    runtime.constructor("foo", &[]);
+    runtime.constructor(&[]);
     runtime.function("test", &[]);
 }
 
@@ -1840,7 +1840,7 @@ fn dynamic_array_push_pop_loop() {
         }"#,
     );
 
-    runtime.constructor("foo", &[]);
+    runtime.constructor(&[]);
     runtime.function("test", &[]);
 
     let mut runtime = build_solidity(
@@ -1879,6 +1879,6 @@ fn dynamic_array_push_pop_loop() {
         }"#,
     );
 
-    runtime.constructor("foo", &[]);
+    runtime.constructor(&[]);
     runtime.function("test", &[]);
 }

--- a/tests/solana_tests/arrays.rs
+++ b/tests/solana_tests/arrays.rs
@@ -22,7 +22,7 @@ fn fixed_array() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function("get", &[]);
+    let returns = vm.function("get", &[]).unwrap().unwrap_tuple();
 
     assert_eq!(
         returns,
@@ -45,7 +45,7 @@ fn fixed_array() {
                     value: BigInt::from(12313231u32),
                 },
             ]),
-            BorshToken::FixedBytes(vec!(0xfe))
+            BorshToken::uint8_fixed_array(vec!(0xfe))
         ]
     );
 
@@ -68,11 +68,11 @@ fn fixed_array() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function("get", &[]);
+    let returns = vm.function("get", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::FixedArray(vec![
+        BorshToken::FixedArray(vec![
             BorshToken::Tuple(vec![
                 BorshToken::Uint {
                     width: 32,
@@ -101,7 +101,7 @@ fn fixed_array() {
                 },
                 BorshToken::Bool(false)
             ]),
-        ])]
+        ])
     );
 
     // Now let's try it the other way round; an struct with an array in it
@@ -137,11 +137,11 @@ fn fixed_array() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function("get", &[]);
+    let returns = vm.function("get", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Tuple(vec![
+        BorshToken::Tuple(vec![
             BorshToken::Bool(true),
             BorshToken::FixedArray(vec![
                 BorshToken::Uint {
@@ -162,41 +162,43 @@ fn fixed_array() {
                 },
             ]),
             BorshToken::Bool(true)
-        ])],
+        ]),
     );
 
-    let returns = vm.function(
-        "set",
-        &[BorshToken::Tuple(vec![
-            BorshToken::Bool(true),
-            BorshToken::FixedArray(vec![
-                BorshToken::Uint {
-                    width: 32,
-                    value: BigInt::from(3u8),
-                },
-                BorshToken::Uint {
-                    width: 32,
-                    value: BigInt::from(5u8),
-                },
-                BorshToken::Uint {
-                    width: 32,
-                    value: BigInt::from(7u8),
-                },
-                BorshToken::Uint {
-                    width: 32,
-                    value: BigInt::from(11u8),
-                },
-            ]),
-            BorshToken::Bool(true),
-        ])],
-    );
+    let returns = vm
+        .function(
+            "set",
+            &[BorshToken::Tuple(vec![
+                BorshToken::Bool(true),
+                BorshToken::FixedArray(vec![
+                    BorshToken::Uint {
+                        width: 32,
+                        value: BigInt::from(3u8),
+                    },
+                    BorshToken::Uint {
+                        width: 32,
+                        value: BigInt::from(5u8),
+                    },
+                    BorshToken::Uint {
+                        width: 32,
+                        value: BigInt::from(7u8),
+                    },
+                    BorshToken::Uint {
+                        width: 32,
+                        value: BigInt::from(11u8),
+                    },
+                ]),
+                BorshToken::Bool(true),
+            ])],
+        )
+        .unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 32,
             value: BigInt::from(26u8),
-        }]
+        }
     );
 }
 
@@ -230,48 +232,50 @@ fn dynamic_array_fixed_elements() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function(
-        "get",
-        &[
-            BorshToken::Uint {
-                width: 256,
-                value: BigInt::from(12123123u32),
-            },
-            BorshToken::Array(vec![
+    let returns = vm
+        .function(
+            "get",
+            &[
                 BorshToken::Uint {
-                    width: 32,
-                    value: BigInt::from(3u8),
+                    width: 256,
+                    value: BigInt::from(12123123u32),
                 },
+                BorshToken::Array(vec![
+                    BorshToken::Uint {
+                        width: 32,
+                        value: BigInt::from(3u8),
+                    },
+                    BorshToken::Uint {
+                        width: 32,
+                        value: BigInt::from(5u8),
+                    },
+                    BorshToken::Uint {
+                        width: 32,
+                        value: BigInt::from(7u8),
+                    },
+                    BorshToken::Uint {
+                        width: 32,
+                        value: BigInt::from(11u8),
+                    },
+                ]),
                 BorshToken::Uint {
-                    width: 32,
-                    value: BigInt::from(5u8),
+                    width: 256,
+                    value: BigInt::from(102u8),
                 },
-                BorshToken::Uint {
-                    width: 32,
-                    value: BigInt::from(7u8),
-                },
-                BorshToken::Uint {
-                    width: 32,
-                    value: BigInt::from(11u8),
-                },
-            ]),
-            BorshToken::Uint {
-                width: 256,
-                value: BigInt::from(102u8),
-            },
-        ],
-    );
+            ],
+        )
+        .unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 32,
             value: BigInt::from(26u8),
-        }]
+        }
     );
 
     // test that the abi encoder can handle fixed arrays
-    let returns = vm.function("set", &[]);
+    let returns = vm.function("set", &[]).unwrap().unwrap_tuple();
 
     assert_eq!(
         returns,
@@ -336,35 +340,37 @@ fn fixed_array_dynamic_elements() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function(
-        "get",
-        &[
-            BorshToken::Uint {
-                width: 256,
-                value: BigInt::from(12123123u32),
-            },
-            BorshToken::FixedArray(vec![
-                BorshToken::Bytes(vec![3, 5, 7]),
-                BorshToken::Bytes(vec![11, 13, 17]),
-                BorshToken::Bytes(vec![19, 23]),
-                BorshToken::Bytes(vec![29]),
-            ]),
-            BorshToken::Uint {
-                width: 256,
-                value: BigInt::from(102u8),
-            },
-        ],
-    );
+    let returns = vm
+        .function(
+            "get",
+            &[
+                BorshToken::Uint {
+                    width: 256,
+                    value: BigInt::from(12123123u32),
+                },
+                BorshToken::FixedArray(vec![
+                    BorshToken::Bytes(vec![3, 5, 7]),
+                    BorshToken::Bytes(vec![11, 13, 17]),
+                    BorshToken::Bytes(vec![19, 23]),
+                    BorshToken::Bytes(vec![29]),
+                ]),
+                BorshToken::Uint {
+                    width: 256,
+                    value: BigInt::from(102u8),
+                },
+            ],
+        )
+        .unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 32,
             value: BigInt::from(127),
-        }]
+        }
     );
 
-    let returns = vm.function("set", &[]);
+    let returns = vm.function("set", &[]).unwrap().unwrap_tuple();
 
     assert_eq!(
         returns,
@@ -421,35 +427,37 @@ fn dynamic_array_dynamic_elements() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function(
-        "get",
-        &[
-            BorshToken::Uint {
-                width: 256,
-                value: BigInt::from(12123123u32),
-            },
-            BorshToken::Array(vec![
-                BorshToken::Bytes(vec![3, 5, 7]),
-                BorshToken::Bytes(vec![11, 13, 17]),
-                BorshToken::Bytes(vec![19, 23]),
-                BorshToken::Bytes(vec![29]),
-            ]),
-            BorshToken::Uint {
-                width: 256,
-                value: BigInt::from(102u8),
-            },
-        ],
-    );
+    let returns = vm
+        .function(
+            "get",
+            &[
+                BorshToken::Uint {
+                    width: 256,
+                    value: BigInt::from(12123123u32),
+                },
+                BorshToken::Array(vec![
+                    BorshToken::Bytes(vec![3, 5, 7]),
+                    BorshToken::Bytes(vec![11, 13, 17]),
+                    BorshToken::Bytes(vec![19, 23]),
+                    BorshToken::Bytes(vec![29]),
+                ]),
+                BorshToken::Uint {
+                    width: 256,
+                    value: BigInt::from(102u8),
+                },
+            ],
+        )
+        .unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 32,
             value: BigInt::from(127),
-        }]
+        }
     );
 
-    let returns = vm.function("set", &[]);
+    let returns = vm.function("set", &[]).unwrap().unwrap_tuple();
 
     assert_eq!(
         returns,
@@ -528,27 +536,29 @@ fn fixed_array_fixed_elements_storage() {
         ],
     );
 
-    let returns = vm.function(
-        "get_elem",
-        &[BorshToken::Uint {
-            width: 256,
-            value: BigInt::from(2u8),
-        }],
-    );
+    let returns = vm
+        .function(
+            "get_elem",
+            &[BorshToken::Uint {
+                width: 256,
+                value: BigInt::from(2u8),
+            }],
+        )
+        .unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Int {
+        BorshToken::Int {
             width: 64,
             value: BigInt::from(12123123u64)
-        },]
+        },
     );
 
-    let returns = vm.function("get", &[]);
+    let returns = vm.function("get", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::FixedArray(vec![
+        BorshToken::FixedArray(vec![
             BorshToken::Int {
                 width: 64,
                 value: BigInt::zero()
@@ -565,7 +575,7 @@ fn fixed_array_fixed_elements_storage() {
                 width: 64,
                 value: BigInt::from(123456789u32),
             },
-        ])],
+        ]),
     );
 
     vm.function(
@@ -590,11 +600,11 @@ fn fixed_array_fixed_elements_storage() {
         ])],
     );
 
-    let returns = vm.function("get", &[]);
+    let returns = vm.function("get", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::FixedArray(vec![
+        BorshToken::FixedArray(vec![
             BorshToken::Int {
                 width: 64,
                 value: BigInt::one(),
@@ -611,16 +621,16 @@ fn fixed_array_fixed_elements_storage() {
                 width: 64,
                 value: BigInt::from(4u8),
             },
-        ])],
+        ]),
     );
 
     vm.function("del", &[]);
 
-    let returns = vm.function("get", &[]);
+    let returns = vm.function("get", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::FixedArray(vec![
+        BorshToken::FixedArray(vec![
             BorshToken::Int {
                 width: 64,
                 value: BigInt::zero(),
@@ -637,7 +647,7 @@ fn fixed_array_fixed_elements_storage() {
                 width: 64,
                 value: BigInt::zero(),
             },
-        ])],
+        ]),
     );
 }
 
@@ -696,28 +706,30 @@ fn fixed_array_dynamic_elements_storage() {
         ],
     );
 
-    let returns = vm.function(
-        "get_elem",
-        &[BorshToken::Uint {
-            width: 256,
-            value: BigInt::from(2u8),
-        }],
-    );
+    let returns = vm
+        .function(
+            "get_elem",
+            &[BorshToken::Uint {
+                width: 256,
+                value: BigInt::from(2u8),
+            }],
+        )
+        .unwrap();
 
-    assert_eq!(returns, vec![BorshToken::String(String::from("abcd"))]);
+    assert_eq!(returns, BorshToken::String(String::from("abcd")));
 
-    let returns = vm.function("get", &[]);
+    let returns = vm.function("get", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::FixedArray(vec![
+        BorshToken::FixedArray(vec![
             BorshToken::String(String::from("")),
             BorshToken::String(String::from("")),
             BorshToken::String(String::from("abcd")),
             BorshToken::String(String::from(
                 "you can lead a horse to water but you can’t make him drink"
             )),
-        ])],
+        ]),
     );
 
     vm.function(
@@ -730,30 +742,30 @@ fn fixed_array_dynamic_elements_storage() {
         ])],
     );
 
-    let returns = vm.function("get", &[]);
+    let returns = vm.function("get", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::FixedArray(vec![
+        BorshToken::FixedArray(vec![
             BorshToken::String(String::from("a")),
             BorshToken::String(String::from("b")),
             BorshToken::String(String::from("c")),
             BorshToken::String(String::from("d")),
-        ])],
+        ]),
     );
 
     vm.function("del", &[]);
 
-    let returns = vm.function("get", &[]);
+    let returns = vm.function("get", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::FixedArray(vec![
+        BorshToken::FixedArray(vec![
             BorshToken::String(String::from("")),
             BorshToken::String(String::from("")),
             BorshToken::String(String::from("")),
             BorshToken::String(String::from("")),
-        ])],
+        ]),
     );
 }
 
@@ -800,14 +812,14 @@ fn storage_simple_dynamic_array() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function("len", &[]);
+    let returns = vm.function("len", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::zero(),
-        }]
+        }
     );
 
     vm.function(
@@ -828,59 +840,65 @@ fn storage_simple_dynamic_array() {
         }],
     );
 
-    let returns = vm.function(
-        "subscript",
-        &[BorshToken::Uint {
-            width: 32,
-            value: BigInt::zero(),
-        }],
-    );
+    let returns = vm
+        .function(
+            "subscript",
+            &[BorshToken::Uint {
+                width: 32,
+                value: BigInt::zero(),
+            }],
+        )
+        .unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Int {
+        BorshToken::Int {
             width: 64,
             value: BigInt::from(102u8),
-        }]
+        }
     );
 
-    let returns = vm.function(
-        "subscript",
-        &[BorshToken::Uint {
-            width: 32,
-            value: BigInt::one(),
-        }],
-    );
+    let returns = vm
+        .function(
+            "subscript",
+            &[BorshToken::Uint {
+                width: 32,
+                value: BigInt::one(),
+            }],
+        )
+        .unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Int {
+        BorshToken::Int {
             width: 64,
             value: BigInt::zero()
-        }]
+        }
     );
 
-    let returns = vm.function(
-        "subscript",
-        &[BorshToken::Uint {
-            width: 32,
-            value: BigInt::from(2u8),
-        }],
-    );
+    let returns = vm
+        .function(
+            "subscript",
+            &[BorshToken::Uint {
+                width: 32,
+                value: BigInt::from(2u8),
+            }],
+        )
+        .unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Int {
+        BorshToken::Int {
             width: 64,
             value: BigInt::from(12345678901u64),
-        },]
+        },
     );
 
-    let returns = vm.function("copy", &[]);
+    let returns = vm.function("copy", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Array(vec![
+        BorshToken::Array(vec![
             BorshToken::Int {
                 width: 64,
                 value: BigInt::from(102u8),
@@ -893,27 +911,27 @@ fn storage_simple_dynamic_array() {
                 width: 64,
                 value: BigInt::from(12345678901u64),
             },
-        ])],
+        ]),
     );
 
-    let returns = vm.function("pop", &[]);
+    let returns = vm.function("pop", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Int {
+        BorshToken::Int {
             width: 64,
             value: BigInt::from(12345678901u64),
-        },]
+        },
     );
 
-    let returns = vm.function("len", &[]);
+    let returns = vm.function("len", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::from(2u8),
-        }]
+        }
     );
 
     vm.function(
@@ -950,11 +968,11 @@ fn storage_simple_dynamic_array() {
         ])],
     );
 
-    let returns = vm.function("copy", &[]);
+    let returns = vm.function("copy", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Array(vec![
+        BorshToken::Array(vec![
             BorshToken::Int {
                 width: 64,
                 value: BigInt::from(1u8)
@@ -983,19 +1001,19 @@ fn storage_simple_dynamic_array() {
                 width: 64,
                 value: BigInt::from(7u8)
             },
-        ])],
+        ]),
     );
 
     vm.function("rm", &[]);
 
-    let returns = vm.function("len", &[]);
+    let returns = vm.function("len", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::zero(),
-        }]
+        }
     );
 }
 
@@ -1072,14 +1090,14 @@ fn storage_dynamic_array_of_structs() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function("len", &[]);
+    let returns = vm.function("len", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::zero(),
-        }]
+        }
     );
 
     vm.function(
@@ -1106,68 +1124,74 @@ fn storage_dynamic_array_of_structs() {
         ])],
     );
 
-    let returns = vm.function(
-        "subscript",
-        &[BorshToken::Uint {
-            width: 32,
-            value: BigInt::zero(),
-        }],
-    );
+    let returns = vm
+        .function(
+            "subscript",
+            &[BorshToken::Uint {
+                width: 32,
+                value: BigInt::zero(),
+            }],
+        )
+        .unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Tuple(vec![
+        BorshToken::Tuple(vec![
             BorshToken::Uint {
                 width: 64,
                 value: BigInt::from(13819038012u64)
             },
             BorshToken::Bool(true),
-        ])]
+        ])
     );
 
-    let returns = vm.function(
-        "subscript",
-        &[BorshToken::Uint {
-            width: 32,
-            value: BigInt::one(),
-        }],
-    );
+    let returns = vm
+        .function(
+            "subscript",
+            &[BorshToken::Uint {
+                width: 32,
+                value: BigInt::one(),
+            }],
+        )
+        .unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Tuple(vec![
+        BorshToken::Tuple(vec![
             BorshToken::Uint {
                 width: 64,
                 value: BigInt::zero(),
             },
             BorshToken::Bool(false),
-        ])]
+        ])
     );
 
-    let returns = vm.function(
-        "subscript",
-        &[BorshToken::Uint {
-            width: 32,
-            value: BigInt::from(2u8),
-        }],
-    );
+    let returns = vm
+        .function(
+            "subscript",
+            &[BorshToken::Uint {
+                width: 32,
+                value: BigInt::from(2u8),
+            }],
+        )
+        .unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Tuple(vec![
+        BorshToken::Tuple(vec![
             BorshToken::Uint {
                 width: 64,
                 value: BigInt::from(12313123141123213u64),
             },
             BorshToken::Bool(true),
-        ]),]
+        ]),
     );
 
-    let returns = vm.function("copy", &[]);
+    let returns = vm.function("copy", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Array(vec![
+        BorshToken::Array(vec![
             BorshToken::Tuple(vec![
                 BorshToken::Uint {
                     width: 64,
@@ -1189,30 +1213,30 @@ fn storage_dynamic_array_of_structs() {
                 },
                 BorshToken::Bool(true),
             ]),
-        ])]
+        ])
     );
 
-    let returns = vm.function("pop", &[]);
+    let returns = vm.function("pop", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Tuple(vec![
+        BorshToken::Tuple(vec![
             BorshToken::Uint {
                 width: 64,
                 value: BigInt::from(12313123141123213u64),
             },
             BorshToken::Bool(true),
-        ])]
+        ])
     );
 
-    let returns = vm.function("len", &[]);
+    let returns = vm.function("len", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::from(2u8),
-        }]
+        }
     );
 
     vm.function(
@@ -1263,11 +1287,11 @@ fn storage_dynamic_array_of_structs() {
         ])],
     );
 
-    let returns = vm.function("copy", &[]);
+    let returns = vm.function("copy", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Array(vec![
+        BorshToken::Array(vec![
             BorshToken::Tuple(vec![
                 BorshToken::Uint {
                     width: 64,
@@ -1310,19 +1334,19 @@ fn storage_dynamic_array_of_structs() {
                 },
                 BorshToken::Bool(true)
             ]),
-        ]),]
+        ]),
     );
 
     vm.function("rm", &[]);
 
-    let returns = vm.function("len", &[]);
+    let returns = vm.function("len", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::zero(),
-        }]
+        }
     );
 }
 
@@ -1342,11 +1366,11 @@ fn array_literal() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function("list", &[]);
+    let returns = vm.function("list", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::FixedArray(vec![
+        BorshToken::FixedArray(vec![
             BorshToken::Int {
                 width: 64,
                 value: BigInt::one(),
@@ -1359,7 +1383,7 @@ fn array_literal() {
                 width: 64,
                 value: BigInt::from(3u8),
             },
-        ])]
+        ])
     );
 }
 
@@ -1470,40 +1494,46 @@ fn initialization_with_literal() {
             BorshToken::FixedBytes(addr2[..].to_vec()),
         ],
     );
-    let returns = vm.function(
-        "getIdx",
-        &[BorshToken::Uint {
-            width: 32,
-            value: BigInt::zero(),
-        }],
-    );
-    let returned_addr1 = returns[0].clone().into_fixed_bytes().unwrap();
+    let returns = vm
+        .function(
+            "getIdx",
+            &[BorshToken::Uint {
+                width: 32,
+                value: BigInt::zero(),
+            }],
+        )
+        .unwrap();
+    let returned_addr1 = returns.into_fixed_bytes().unwrap();
     assert_eq!(addr1, returned_addr1);
 
-    let returns = vm.function(
-        "getIdx",
-        &[BorshToken::Uint {
-            width: 32,
-            value: BigInt::one(),
-        }],
-    );
-    let returned_addr2 = returns[0].clone().into_fixed_bytes().unwrap();
+    let returns = vm
+        .function(
+            "getIdx",
+            &[BorshToken::Uint {
+                width: 32,
+                value: BigInt::one(),
+            }],
+        )
+        .unwrap();
+    let returned_addr2 = returns.into_fixed_bytes().unwrap();
     assert_eq!(addr2, returned_addr2);
 
-    let returns = vm.function(
-        "getVec",
-        &[
-            BorshToken::Uint {
-                width: 32,
-                value: BigInt::from(563u16),
-            },
-            BorshToken::Uint {
-                width: 32,
-                value: BigInt::from(895u16),
-            },
-        ],
-    );
-    let array = returns[0].clone().into_array().unwrap();
+    let returns = vm
+        .function(
+            "getVec",
+            &[
+                BorshToken::Uint {
+                    width: 32,
+                    value: BigInt::from(563u16),
+                },
+                BorshToken::Uint {
+                    width: 32,
+                    value: BigInt::from(895u16),
+                },
+            ],
+        )
+        .unwrap();
+    let array = returns.into_array().unwrap();
     assert_eq!(
         array,
         vec![

--- a/tests/solana_tests/balance.rs
+++ b/tests/solana_tests/balance.rs
@@ -15,7 +15,7 @@ fn get_balance() {
         }"#,
     );
 
-    vm.constructor("c", &[]);
+    vm.constructor(&[]);
 
     let new = account_new();
 
@@ -50,7 +50,7 @@ fn send_fails() {
         }"#,
     );
 
-    vm.constructor("c", &[]);
+    vm.constructor(&[]);
 
     let new = account_new();
 
@@ -94,7 +94,7 @@ fn send_succeeds() {
 
     vm.account_data.get_mut(&vm.stack[0].data).unwrap().lamports = 103;
 
-    vm.constructor("c", &[]);
+    vm.constructor(&[]);
 
     let new = account_new();
 
@@ -143,7 +143,7 @@ fn send_overflows() {
 
     vm.account_data.get_mut(&vm.stack[0].data).unwrap().lamports = 103;
 
-    vm.constructor("c", &[]);
+    vm.constructor(&[]);
 
     let new = account_new();
 
@@ -195,7 +195,7 @@ fn transfer_succeeds() {
 
     vm.account_data.get_mut(&vm.stack[0].data).unwrap().lamports = 103;
 
-    vm.constructor("c", &[]);
+    vm.constructor(&[]);
 
     let new = account_new();
 
@@ -240,7 +240,7 @@ fn transfer_fails_not_enough() {
 
     vm.account_data.get_mut(&vm.stack[0].data).unwrap().lamports = 103;
 
-    vm.constructor("c", &[]);
+    vm.constructor(&[]);
 
     let new = account_new();
 
@@ -281,7 +281,7 @@ fn transfer_fails_overflow() {
 
     vm.account_data.get_mut(&vm.stack[0].data).unwrap().lamports = 103;
 
-    vm.constructor("c", &[]);
+    vm.constructor(&[]);
 
     let new = account_new();
 
@@ -320,7 +320,7 @@ fn fallback() {
 
     vm.account_data.get_mut(&vm.origin).unwrap().lamports = 312;
 
-    vm.constructor("c", &[]);
+    vm.constructor(&[]);
 
     if let Some(idl) = &vm.stack[0].idl {
         let mut idl = idl.clone();
@@ -356,7 +356,7 @@ fn value_overflows() {
 
     vm.account_data.get_mut(&vm.stack[0].data).unwrap().lamports = 103;
 
-    vm.constructor("c", &[]);
+    vm.constructor(&[]);
 
     let new = account_new();
 

--- a/tests/solana_tests/builtin.rs
+++ b/tests/solana_tests/builtin.rs
@@ -30,7 +30,7 @@ fn builtins() {
         }"#,
     );
 
-    vm.constructor("timestamp", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("mr_now", &[]).unwrap();
 
@@ -133,7 +133,7 @@ fn pda() {
         }"#,
     );
 
-    vm.constructor("pda", &[]);
+    vm.constructor(&[]);
 
     let returns = vm
         .function("create_pda", &[BorshToken::Bool(true)])
@@ -229,7 +229,7 @@ fn test_string_bytes_buffer_write() {
     }
         "#,
     );
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     let returns = vm.function("testStringAndBytes", &[]).unwrap();
     let bytes = returns.into_bytes().unwrap();
 
@@ -254,7 +254,7 @@ fn out_of_bounds_bytes_write() {
         "#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     let _ = vm.function("testBytesOut", &[]);
 }
 
@@ -274,6 +274,6 @@ fn out_of_bounds_string_write() {
         "#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     let _ = vm.function("testStringOut", &[]);
 }

--- a/tests/solana_tests/builtin.rs
+++ b/tests/solana_tests/builtin.rs
@@ -32,74 +32,69 @@ fn builtins() {
 
     vm.constructor("timestamp", &[]);
 
-    let returns = vm.function("mr_now", &[]);
+    let returns = vm.function("mr_now", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 64,
             value: BigInt::from(1620656423u64)
-        }]
+        }
     );
 
-    let returns = vm.function("mr_slot", &[]);
+    let returns = vm.function("mr_slot", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 64,
             value: BigInt::from(70818331u64),
-        }]
+        }
     );
 
-    let returns = vm.function("mr_blocknumber", &[]);
+    let returns = vm.function("mr_blocknumber", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 64,
             value: BigInt::from(70818331u64)
-        },]
+        },
     );
 
-    let returns = vm.function(
-        "msg_data",
-        &[BorshToken::Uint {
-            width: 32,
-            value: BigInt::from(0xdeadcafeu32),
-        }],
-    );
+    let returns = vm
+        .function(
+            "msg_data",
+            &[BorshToken::Uint {
+                width: 32,
+                value: BigInt::from(0xdeadcafeu32),
+            }],
+        )
+        .unwrap();
 
-    if let BorshToken::Bytes(v) = &returns[0] {
+    if let BorshToken::Bytes(v) = &returns {
         println!("{}", hex::encode(v));
     }
 
     assert_eq!(
         returns,
-        vec![BorshToken::Bytes(
-            hex::decode("a73fcaa3b216e85afecaadde").unwrap()
-        )]
+        BorshToken::Bytes(hex::decode("a73fcaa3b216e85afecaadde").unwrap())
     );
 
-    let returns = vm.function("sig", &[]);
+    let returns = vm.function("sig", &[]).unwrap();
 
-    if let BorshToken::FixedBytes(v) = &returns[0] {
+    if let Some(v) = returns.clone().into_fixed_bytes() {
         println!("{}", hex::encode(v));
     }
 
     assert_eq!(
         returns,
-        vec![BorshToken::FixedBytes(
-            hex::decode("4b22101a3c98d6cb").unwrap()
-        )]
+        BorshToken::uint8_fixed_array(hex::decode("4b22101a3c98d6cb").unwrap())
     );
 
-    let returns = vm.function("prog", &[]);
+    let returns = vm.function("prog", &[]).unwrap();
 
-    assert_eq!(
-        returns,
-        vec![BorshToken::FixedBytes(vm.stack[0].program.to_vec())]
-    );
+    assert_eq!(returns, BorshToken::Address(vm.stack[0].program));
 }
 
 #[test]
@@ -140,9 +135,11 @@ fn pda() {
 
     vm.constructor("pda", &[]);
 
-    let returns = vm.function("create_pda", &[BorshToken::Bool(true)]);
+    let returns = vm
+        .function("create_pda", &[BorshToken::Bool(true)])
+        .unwrap();
 
-    if let BorshToken::FixedBytes(bs) = &returns[0] {
+    if let Some(bs) = returns.clone().into_fixed_bytes() {
         assert_eq!(
             bs.to_base58(),
             "2fnQrngrQT4SeLcdToJAD96phoEjNL2man2kfRLCASVk"
@@ -151,9 +148,11 @@ fn pda() {
         panic!("{:?} not expected", returns);
     }
 
-    let returns = vm.function("create_pda", &[BorshToken::Bool(false)]);
+    let returns = vm
+        .function("create_pda", &[BorshToken::Bool(false)])
+        .unwrap();
 
-    if let BorshToken::FixedBytes(bs) = &returns[0] {
+    if let Some(bs) = returns.clone().into_fixed_bytes() {
         assert_eq!(
             bs.to_base58(),
             "7YgSsrAiAEJFqBNujFBRsEossqdpV31byeJLBsZ5QSJE"
@@ -162,15 +161,17 @@ fn pda() {
         panic!("{:?} not expected", returns);
     }
 
-    let returns = vm.function(
-        "create_pda2",
-        &[
-            BorshToken::Bytes(b"Talking".to_vec()),
-            BorshToken::Bytes(b"Squirrels".to_vec()),
-        ],
-    );
+    let returns = vm
+        .function(
+            "create_pda2",
+            &[
+                BorshToken::Bytes(b"Talking".to_vec()),
+                BorshToken::Bytes(b"Squirrels".to_vec()),
+            ],
+        )
+        .unwrap();
 
-    if let BorshToken::FixedBytes(bs) = &returns[0] {
+    if let Some(bs) = returns.clone().into_fixed_bytes() {
         assert_eq!(
             bs.to_base58(),
             "2fnQrngrQT4SeLcdToJAD96phoEjNL2man2kfRLCASVk"
@@ -179,11 +180,14 @@ fn pda() {
         panic!("{:?} not expected", returns);
     }
 
-    let returns = vm.function("create_pda2_bump", &[BorshToken::Bool(true)]);
+    let returns = vm
+        .function("create_pda2_bump", &[BorshToken::Bool(true)])
+        .unwrap()
+        .unwrap_tuple();
 
-    assert_eq!(returns[1], BorshToken::FixedBytes(vec![255]));
+    assert_eq!(returns[1], BorshToken::uint8_fixed_array(vec![255]));
 
-    if let BorshToken::FixedBytes(bs) = &returns[0] {
+    if let Some(bs) = returns[0].clone().into_fixed_bytes() {
         assert_eq!(
             bs.to_base58(),
             "DZpR2BwsPVtbXxUUbMx5tK58Ln2T9RUtAshtR2ePqDcu"
@@ -192,11 +196,14 @@ fn pda() {
         panic!("{:?} not expected", returns);
     }
 
-    let returns = vm.function("create_pda2_bump", &[BorshToken::Bool(false)]);
+    let returns = vm
+        .function("create_pda2_bump", &[BorshToken::Bool(false)])
+        .unwrap()
+        .unwrap_tuple();
 
-    assert_eq!(returns[1], BorshToken::FixedBytes(vec![255]));
+    assert_eq!(returns[1], BorshToken::uint8_fixed_array(vec![255]));
 
-    if let BorshToken::FixedBytes(bs) = &returns[0] {
+    if let Some(bs) = returns[0].clone().into_fixed_bytes() {
         assert_eq!(
             bs.to_base58(),
             "3Y19WiAiLD8kT8APmtk41NgHEpkYTzx28s1uwAX8LJq4"
@@ -223,8 +230,8 @@ fn test_string_bytes_buffer_write() {
         "#,
     );
     vm.constructor("Testing", &[]);
-    let returns = vm.function("testStringAndBytes", &[]);
-    let bytes = returns[0].clone().into_bytes().unwrap();
+    let returns = vm.function("testStringAndBytes", &[]).unwrap();
+    let bytes = returns.into_bytes().unwrap();
 
     assert_eq!(bytes.len(), 9);
     assert_eq!(&bytes[0..6], b"coffee");

--- a/tests/solana_tests/call.rs
+++ b/tests/solana_tests/call.rs
@@ -28,7 +28,7 @@ fn simple_external_call() {
         }"#,
     );
 
-    vm.constructor("bar1", &[]);
+    vm.constructor(&[]);
 
     vm.function("test_bar", &[BorshToken::String(String::from("yo"))]);
 
@@ -40,7 +40,7 @@ fn simple_external_call() {
 
     vm.set_program(0);
 
-    vm.constructor("bar0", &[]);
+    vm.constructor(&[]);
 
     vm.function(
         "test_bar",
@@ -73,7 +73,7 @@ fn external_call_with_returns() {
         }"#,
     );
 
-    vm.constructor("bar1", &[]);
+    vm.constructor(&[]);
 
     let res = vm
         .function(
@@ -97,7 +97,7 @@ fn external_call_with_returns() {
 
     vm.set_program(0);
 
-    vm.constructor("bar0", &[]);
+    vm.constructor(&[]);
 
     let res = vm
         .function("test_other", &[BorshToken::Address(bar1_account)])
@@ -136,7 +136,7 @@ fn external_raw_call_with_returns() {
         }"#,
     );
 
-    vm.constructor("bar1", &[]);
+    vm.constructor(&[]);
 
     let res = vm
         .function(
@@ -160,7 +160,7 @@ fn external_raw_call_with_returns() {
 
     vm.set_program(0);
 
-    vm.constructor("bar0", &[]);
+    vm.constructor(&[]);
 
     let res = vm
         .function("test_other", &[BorshToken::Address(bar1_account)])
@@ -195,7 +195,7 @@ fn call_external_func_type() {
     "#,
     );
 
-    vm.constructor("testing", &[]);
+    vm.constructor(&[]);
 
     let res = vm.function("doTest", &[]).unwrap().unwrap_tuple();
 
@@ -242,7 +242,7 @@ fn external_call_with_string_returns() {
         }"#,
     );
 
-    vm.constructor("bar1", &[]);
+    vm.constructor(&[]);
 
     let res = vm
         .function(
@@ -260,7 +260,7 @@ fn external_call_with_string_returns() {
 
     vm.set_program(0);
 
-    vm.constructor("bar0", &[]);
+    vm.constructor(&[]);
 
     let res = vm
         .function("test_other", &[BorshToken::Address(bar1_account)])
@@ -295,7 +295,7 @@ fn encode_call() {
         }"#,
     );
 
-    vm.constructor("bar1", &[]);
+    vm.constructor(&[]);
 
     let res = vm
         .function(
@@ -319,7 +319,7 @@ fn encode_call() {
 
     vm.set_program(0);
 
-    vm.constructor("bar0", &[]);
+    vm.constructor(&[]);
 
     let res = vm
         .function("test_other", &[BorshToken::Address(bar1_account)])
@@ -363,7 +363,7 @@ fn internal_function_storage() {
         }"#,
     );
 
-    vm.constructor("ft", &[]);
+    vm.constructor(&[]);
 
     let res = vm.function("set_op", &[BorshToken::Bool(true)]);
 
@@ -459,7 +459,7 @@ fn raw_call_accounts() {
         }"#,
     );
 
-    vm.constructor("SplToken", &[]);
+    vm.constructor(&[]);
 
     let token = Pubkey(
         "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
@@ -540,7 +540,7 @@ fn pda() {
         }"#,
     );
 
-    vm.constructor("pda", &[]);
+    vm.constructor(&[]);
 
     let test_args = |vm: &VirtualMachine, _instr: &Instruction, signers: &[Pubkey]| {
         assert_eq!(

--- a/tests/solana_tests/call.rs
+++ b/tests/solana_tests/call.rs
@@ -75,20 +75,22 @@ fn external_call_with_returns() {
 
     vm.constructor("bar1", &[]);
 
-    let res = vm.function(
-        "test_bar",
-        &[BorshToken::Int {
-            width: 64,
-            value: BigInt::from(21),
-        }],
-    );
+    let res = vm
+        .function(
+            "test_bar",
+            &[BorshToken::Int {
+                width: 64,
+                value: BigInt::from(21),
+            }],
+        )
+        .unwrap();
 
     assert_eq!(
         res,
-        vec![BorshToken::Int {
+        BorshToken::Int {
             width: 64,
             value: BigInt::from(24u8)
-        }]
+        }
     );
 
     let bar1_account = vm.stack[0].data;
@@ -97,14 +99,16 @@ fn external_call_with_returns() {
 
     vm.constructor("bar0", &[]);
 
-    let res = vm.function("test_other", &[BorshToken::Address(bar1_account)]);
+    let res = vm
+        .function("test_other", &[BorshToken::Address(bar1_account)])
+        .unwrap();
 
     assert_eq!(
         res,
-        vec![BorshToken::Int {
+        BorshToken::Int {
             width: 64,
             value: BigInt::from(15u8)
-        }]
+        }
     );
 }
 
@@ -134,20 +138,22 @@ fn external_raw_call_with_returns() {
 
     vm.constructor("bar1", &[]);
 
-    let res = vm.function(
-        "test_bar",
-        &[BorshToken::Int {
-            width: 64,
-            value: BigInt::from(21u8),
-        }],
-    );
+    let res = vm
+        .function(
+            "test_bar",
+            &[BorshToken::Int {
+                width: 64,
+                value: BigInt::from(21u8),
+            }],
+        )
+        .unwrap();
 
     assert_eq!(
         res,
-        vec![BorshToken::Int {
+        BorshToken::Int {
             width: 64,
             value: BigInt::from(24u8),
-        }]
+        }
     );
 
     let bar1_account = vm.stack[0].data;
@@ -156,14 +162,16 @@ fn external_raw_call_with_returns() {
 
     vm.constructor("bar0", &[]);
 
-    let res = vm.function("test_other", &[BorshToken::Address(bar1_account)]);
+    let res = vm
+        .function("test_other", &[BorshToken::Address(bar1_account)])
+        .unwrap();
 
     assert_eq!(
         res,
-        vec![BorshToken::Int {
+        BorshToken::Int {
             width: 64,
             value: BigInt::from(15u8),
-        }]
+        }
     );
 }
 
@@ -189,7 +197,7 @@ fn call_external_func_type() {
 
     vm.constructor("testing", &[]);
 
-    let res = vm.function("doTest", &[]);
+    let res = vm.function("doTest", &[]).unwrap().unwrap_tuple();
 
     assert_eq!(
         res,
@@ -236,15 +244,17 @@ fn external_call_with_string_returns() {
 
     vm.constructor("bar1", &[]);
 
-    let res = vm.function(
-        "test_bar",
-        &[BorshToken::Int {
-            width: 64,
-            value: BigInt::from(22u8),
-        }],
-    );
+    let res = vm
+        .function(
+            "test_bar",
+            &[BorshToken::Int {
+                width: 64,
+                value: BigInt::from(22u8),
+            }],
+        )
+        .unwrap();
 
-    assert_eq!(res, vec![BorshToken::String(String::from("foo:22"))]);
+    assert_eq!(res, BorshToken::String(String::from("foo:22")));
 
     let bar1_account = vm.stack[0].data;
 
@@ -252,9 +262,11 @@ fn external_call_with_string_returns() {
 
     vm.constructor("bar0", &[]);
 
-    let res = vm.function("test_other", &[BorshToken::Address(bar1_account)]);
+    let res = vm
+        .function("test_other", &[BorshToken::Address(bar1_account)])
+        .unwrap();
 
-    assert_eq!(res, vec![BorshToken::String(String::from("foo:7"))]);
+    assert_eq!(res, BorshToken::String(String::from("foo:7")));
 
     vm.function("test_this", &[BorshToken::Address(bar1_account)]);
 }
@@ -285,20 +297,22 @@ fn encode_call() {
 
     vm.constructor("bar1", &[]);
 
-    let res = vm.function(
-        "test_bar",
-        &[BorshToken::Int {
-            width: 64,
-            value: BigInt::from(21u8),
-        }],
-    );
+    let res = vm
+        .function(
+            "test_bar",
+            &[BorshToken::Int {
+                width: 64,
+                value: BigInt::from(21u8),
+            }],
+        )
+        .unwrap();
 
     assert_eq!(
         res,
-        vec![BorshToken::Int {
+        BorshToken::Int {
             width: 64,
             value: BigInt::from(24u8)
-        }]
+        }
     );
 
     let bar1_account = vm.stack[0].data;
@@ -307,14 +321,16 @@ fn encode_call() {
 
     vm.constructor("bar0", &[]);
 
-    let res = vm.function("test_other", &[BorshToken::Address(bar1_account)]);
+    let res = vm
+        .function("test_other", &[BorshToken::Address(bar1_account)])
+        .unwrap();
 
     assert_eq!(
         res,
-        vec![BorshToken::Int {
+        BorshToken::Int {
             width: 64,
             value: BigInt::from(15u8)
-        }]
+        }
     );
 }
 
@@ -351,54 +367,58 @@ fn internal_function_storage() {
 
     let res = vm.function("set_op", &[BorshToken::Bool(true)]);
 
-    assert_eq!(res, vec![]);
+    assert!(res.is_none());
 
-    let res = vm.function(
-        "test",
-        &[
-            BorshToken::Int {
-                width: 32,
-                value: BigInt::from(3u8),
-            },
-            BorshToken::Int {
-                width: 32,
-                value: BigInt::from(5u8),
-            },
-        ],
-    );
+    let res = vm
+        .function(
+            "test",
+            &[
+                BorshToken::Int {
+                    width: 32,
+                    value: BigInt::from(3u8),
+                },
+                BorshToken::Int {
+                    width: 32,
+                    value: BigInt::from(5u8),
+                },
+            ],
+        )
+        .unwrap();
 
     assert_eq!(
         res,
-        vec![BorshToken::Int {
+        BorshToken::Int {
             width: 32,
             value: BigInt::from(15u8)
-        },]
+        }
     );
 
     let res = vm.function("set_op", &[BorshToken::Bool(false)]);
 
-    assert_eq!(res, vec![]);
+    assert!(res.is_none());
 
-    let res = vm.function(
-        "test",
-        &[
-            BorshToken::Int {
-                width: 32,
-                value: BigInt::from(3u8),
-            },
-            BorshToken::Int {
-                width: 32,
-                value: BigInt::from(5u8),
-            },
-        ],
-    );
+    let res = vm
+        .function(
+            "test",
+            &[
+                BorshToken::Int {
+                    width: 32,
+                    value: BigInt::from(3u8),
+                },
+                BorshToken::Int {
+                    width: 32,
+                    value: BigInt::from(5u8),
+                },
+            ],
+        )
+        .unwrap();
 
     assert_eq!(
         res,
-        vec![BorshToken::Int {
+        BorshToken::Int {
             width: 32,
             value: BigInt::from(8u8)
-        }]
+        }
     );
 }
 

--- a/tests/solana_tests/constant.rs
+++ b/tests/solana_tests/constant.rs
@@ -20,7 +20,7 @@ fn constant() {
         "#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("f", &[]).unwrap();
     assert_eq!(
@@ -46,7 +46,7 @@ fn constant() {
         "#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("f", &[]).unwrap();
     assert_eq!(

--- a/tests/solana_tests/constant.rs
+++ b/tests/solana_tests/constant.rs
@@ -22,13 +22,13 @@ fn constant() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function("f", &[]);
+    let returns = vm.function("f", &[]).unwrap();
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::from(42u8)
-        }]
+        }
     );
 
     let mut vm = build_solidity(
@@ -48,12 +48,12 @@ fn constant() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function("f", &[]);
+    let returns = vm.function("f", &[]).unwrap();
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::from(42u8)
-        }]
+        }
     );
 }

--- a/tests/solana_tests/create_contract.rs
+++ b/tests/solana_tests/create_contract.rs
@@ -58,10 +58,12 @@ fn simple_create_contract_no_seed() {
         },
     );
 
-    let bar1 = vm.function(
-        "test_other",
-        &[BorshToken::Address(acc), BorshToken::Address(payer)],
-    );
+    let bar1 = vm
+        .function(
+            "test_other",
+            &[BorshToken::Address(acc), BorshToken::Address(payer)],
+        )
+        .unwrap();
 
     assert_eq!(vm.logs, "bar1 says: yo from bar0");
 
@@ -71,7 +73,7 @@ fn simple_create_contract_no_seed() {
 
     vm.function(
         "call_bar1_at_address",
-        &[bar1[0].clone(), BorshToken::String(String::from("xywoleh"))],
+        &[bar1, BorshToken::String(String::from("xywoleh"))],
     );
 
     assert_eq!(vm.logs, "Hello xywoleh");
@@ -119,10 +121,12 @@ fn simple_create_contract() {
     let seed = vm.create_pda(&program_id);
     let payer = account_new();
 
-    let bar1 = vm.function(
-        "test_other",
-        &[BorshToken::Address(seed.0), BorshToken::Address(payer)],
-    );
+    let bar1 = vm
+        .function(
+            "test_other",
+            &[BorshToken::Address(seed.0), BorshToken::Address(payer)],
+        )
+        .unwrap();
 
     assert_eq!(vm.logs, "bar1 says: yo from bar0");
 
@@ -132,7 +136,7 @@ fn simple_create_contract() {
 
     vm.function(
         "call_bar1_at_address",
-        &[bar1[0].clone(), BorshToken::String(String::from("xywoleh"))],
+        &[bar1, BorshToken::String(String::from("xywoleh"))],
     );
 
     assert_eq!(vm.logs, "Hello xywoleh");
@@ -195,10 +199,10 @@ fn create_contract_with_payer() {
 
     vm.constructor("x", &[BorshToken::Address(payer)]);
 
-    let ret = vm.function("f", &[]);
+    let ret = vm.function("f", &[]).unwrap();
 
     assert_eq!(
-        ret[0],
+        ret,
         BorshToken::Uint {
             width: 64,
             value: 102.into()
@@ -342,9 +346,9 @@ fn account_with_space() {
 
     assert_eq!(vm.account_data.get_mut(&data).unwrap().data.len(), 3 * 102);
 
-    let ret = vm.function("hello", &[]);
+    let ret = vm.function("hello", &[]).unwrap();
 
-    assert_eq!(ret[0], BorshToken::Bool(true));
+    assert_eq!(ret, BorshToken::Bool(true));
 }
 
 #[test]
@@ -383,9 +387,9 @@ fn account_with_seed() {
         511 + 102
     );
 
-    let ret = vm.function("hello", &[]);
+    let ret = vm.function("hello", &[]).unwrap();
 
-    assert_eq!(ret[0], BorshToken::Bool(true));
+    assert_eq!(ret, BorshToken::Bool(true));
 }
 
 #[test]
@@ -434,9 +438,9 @@ fn account_with_seed_bump() {
         511 + 102
     );
 
-    let ret = vm.function("hello", &[]);
+    let ret = vm.function("hello", &[]).unwrap();
 
-    assert_eq!(ret[0], BorshToken::Bool(true));
+    assert_eq!(ret, BorshToken::Bool(true));
 }
 
 #[test]
@@ -473,9 +477,9 @@ fn account_with_seed_bump_literals() {
         8192
     );
 
-    let ret = vm.function("hello", &[]);
+    let ret = vm.function("hello", &[]).unwrap();
 
-    assert_eq!(ret[0], BorshToken::Bool(true));
+    assert_eq!(ret, BorshToken::Bool(true));
 }
 
 #[test]

--- a/tests/solana_tests/create_contract.rs
+++ b/tests/solana_tests/create_contract.rs
@@ -36,7 +36,7 @@ fn simple_create_contract_no_seed() {
 
     vm.set_program(0);
 
-    vm.constructor("bar0", &[]);
+    vm.constructor(&[]);
 
     let program_id: Account = "CPDgqnhHDCsjFkJKMturRQ1QeM9EXZg3EYCeDoRP8pdT"
         .from_base58()
@@ -110,7 +110,7 @@ fn simple_create_contract() {
 
     vm.set_program(0);
 
-    vm.constructor("bar0", &[]);
+    vm.constructor(&[]);
 
     let program_id: Account = "CPDgqnhHDCsjFkJKMturRQ1QeM9EXZg3EYCeDoRP8pdT"
         .from_base58()
@@ -151,7 +151,7 @@ fn create_contract_wrong_program_id() {
         "#,
     );
 
-    vm.constructor("bar0", &[]);
+    vm.constructor(&[]);
 
     let program = &vm.programs[0].program;
     let code = vm.account_data[program].data.clone();
@@ -197,7 +197,7 @@ fn create_contract_with_payer() {
     vm.account_data.get_mut(&data).unwrap().data.truncate(0);
     let payer = account_new();
 
-    vm.constructor("x", &[BorshToken::Address(payer)]);
+    vm.constructor(&[BorshToken::Address(payer)]);
 
     let ret = vm.function("f", &[]).unwrap();
 
@@ -241,7 +241,7 @@ fn missing_contract() {
 
     vm.set_program(0);
 
-    vm.constructor("bar0", &[]);
+    vm.constructor(&[]);
 
     let missing = account_new();
 
@@ -273,7 +273,7 @@ fn two_contracts() {
 
     vm.set_program(0);
 
-    vm.constructor("bar0", &[]);
+    vm.constructor(&[]);
 
     let program_id: Account = "CPDgqnhHDCsjFkJKMturRQ1QeM9EXZg3EYCeDoRP8pdT"
         .from_base58()
@@ -333,16 +333,13 @@ fn account_with_space() {
 
     let payer = account_new();
 
-    vm.constructor(
-        "bar",
-        &[
-            BorshToken::Uint {
-                width: 64,
-                value: 3.into(),
-            },
-            BorshToken::Address(payer),
-        ],
-    );
+    vm.constructor(&[
+        BorshToken::Uint {
+            width: 64,
+            value: 3.into(),
+        },
+        BorshToken::Address(payer),
+    ]);
 
     assert_eq!(vm.account_data.get_mut(&data).unwrap().data.len(), 3 * 102);
 
@@ -377,10 +374,7 @@ fn account_with_seed() {
 
     let payer = account_new();
 
-    vm.constructor(
-        "bar",
-        &[BorshToken::Bytes(seed.1), BorshToken::Address(payer)],
-    );
+    vm.constructor(&[BorshToken::Bytes(seed.1), BorshToken::Address(payer)]);
 
     assert_eq!(
         vm.account_data.get_mut(&seed.0).unwrap().data.len(),
@@ -421,17 +415,14 @@ fn account_with_seed_bump() {
 
     let payer = account_new();
 
-    vm.constructor(
-        "bar",
-        &[
-            BorshToken::Bytes(seed.1),
-            BorshToken::Address(payer),
-            BorshToken::Uint {
-                width: 8,
-                value: bump.into(),
-            },
-        ],
-    );
+    vm.constructor(&[
+        BorshToken::Bytes(seed.1),
+        BorshToken::Address(payer),
+        BorshToken::Uint {
+            width: 8,
+            value: bump.into(),
+        },
+    ]);
 
     assert_eq!(
         vm.account_data.get_mut(&seed.0).unwrap().data.len(),
@@ -470,7 +461,7 @@ fn account_with_seed_bump_literals() {
 
     vm.stack[0].data = account.0;
 
-    vm.constructor("bar", &[]);
+    vm.constructor(&[]);
 
     assert_eq!(
         vm.account_data.get_mut(&account.0).unwrap().data.len(),
@@ -512,7 +503,7 @@ fn create_child() {
     );
 
     vm.set_program(0);
-    vm.constructor("creator", &[]);
+    vm.constructor(&[]);
 
     let payer = account_new();
 

--- a/tests/solana_tests/destructure.rs
+++ b/tests/solana_tests/destructure.rs
@@ -18,7 +18,7 @@ fn conditional_destructure() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm
         .function("f", &[BorshToken::Bool(true), BorshToken::Bool(true)])
@@ -113,7 +113,7 @@ fn casting_destructure() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("f", &[]).unwrap().unwrap_tuple();
 
@@ -141,7 +141,7 @@ fn casting_destructure() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("f", &[]).unwrap();
 

--- a/tests/solana_tests/destructure.rs
+++ b/tests/solana_tests/destructure.rs
@@ -20,7 +20,10 @@ fn conditional_destructure() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function("f", &[BorshToken::Bool(true), BorshToken::Bool(true)]);
+    let returns = vm
+        .function("f", &[BorshToken::Bool(true), BorshToken::Bool(true)])
+        .unwrap()
+        .unwrap_tuple();
 
     assert_eq!(
         returns,
@@ -36,7 +39,10 @@ fn conditional_destructure() {
         ]
     );
 
-    let returns = vm.function("f", &[BorshToken::Bool(true), BorshToken::Bool(false)]);
+    let returns = vm
+        .function("f", &[BorshToken::Bool(true), BorshToken::Bool(false)])
+        .unwrap()
+        .unwrap_tuple();
 
     assert_eq!(
         returns,
@@ -52,7 +58,10 @@ fn conditional_destructure() {
         ]
     );
 
-    let returns = vm.function("f", &[BorshToken::Bool(false), BorshToken::Bool(false)]);
+    let returns = vm
+        .function("f", &[BorshToken::Bool(false), BorshToken::Bool(false)])
+        .unwrap()
+        .unwrap_tuple();
 
     assert_eq!(
         returns,
@@ -68,7 +77,10 @@ fn conditional_destructure() {
         ]
     );
 
-    let returns = vm.function("f", &[BorshToken::Bool(false), BorshToken::Bool(true)]);
+    let returns = vm
+        .function("f", &[BorshToken::Bool(false), BorshToken::Bool(true)])
+        .unwrap()
+        .unwrap_tuple();
 
     assert_eq!(
         returns,
@@ -103,7 +115,7 @@ fn casting_destructure() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function("f", &[]);
+    let returns = vm.function("f", &[]).unwrap().unwrap_tuple();
 
     assert_eq!(
         returns,
@@ -131,7 +143,7 @@ fn casting_destructure() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function("f", &[]);
+    let returns = vm.function("f", &[]).unwrap();
 
-    assert_eq!(returns, vec![BorshToken::String(String::from("Hello")),]);
+    assert_eq!(returns, BorshToken::String(String::from("Hello")));
 }

--- a/tests/solana_tests/events.rs
+++ b/tests/solana_tests/events.rs
@@ -23,7 +23,7 @@ fn simple_event() {
         }"#,
     );
 
-    vm.constructor("c", &[]);
+    vm.constructor(&[]);
 
     vm.function("go", &[]);
 
@@ -79,7 +79,7 @@ fn less_simple_event() {
         }"#,
     );
 
-    vm.constructor("c", &[]);
+    vm.constructor(&[]);
 
     vm.function("go", &[]);
 

--- a/tests/solana_tests/expressions.rs
+++ b/tests/solana_tests/expressions.rs
@@ -22,13 +22,11 @@ fn interfaceid() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function("get", &[]);
+    let returns = vm.function("get", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::FixedBytes(
-            0x88632631fac67239u64.to_be_bytes().to_vec()
-        )]
+        BorshToken::uint8_fixed_array(0x88632631fac67239u64.to_be_bytes().to_vec())
     );
 }
 
@@ -61,21 +59,19 @@ fn write_buffer() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function("test1", &[]);
+    let returns = vm.function("test1", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Bytes(
-            [0xbc, 0xbc, 0xbd, 0xbe, 8, 7, 6, 5, 4, 3, 2, 1].to_vec()
-        )]
+        BorshToken::Bytes([0xbc, 0xbc, 0xbd, 0xbe, 8, 7, 6, 5, 4, 3, 2, 1].to_vec())
     );
 
-    let returns = vm.function("test2", &[]);
+    let returns = vm.function("test2", &[]).unwrap();
 
     let mut buf = vec![0x42u8, 0x41u8];
     buf.extend_from_slice(&vm.stack[0].program);
 
-    assert_eq!(returns, vec![BorshToken::Bytes(buf)]);
+    assert_eq!(returns, BorshToken::Bytes(buf));
 
     let res = vm.function_must_fail("test3", &[]);
     assert_eq!(res, Ok(4294967296));
@@ -98,12 +94,15 @@ fn read_buffer() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function(
-        "test1",
-        &[BorshToken::Bytes(
-            [0xbc, 0xbc, 0xbd, 0xbe, 8, 7, 6, 5, 4, 3, 2, 1].to_vec(),
-        )],
-    );
+    let returns = vm
+        .function(
+            "test1",
+            &[BorshToken::Bytes(
+                [0xbc, 0xbc, 0xbd, 0xbe, 8, 7, 6, 5, 4, 3, 2, 1].to_vec(),
+            )],
+        )
+        .unwrap()
+        .unwrap_tuple();
 
     assert_eq!(
         returns,
@@ -130,7 +129,10 @@ fn read_buffer() {
     let mut buf = vec![0x42u8, 0x41u8];
     buf.extend_from_slice(&vm.origin);
 
-    let returns = vm.function("test2", &[BorshToken::Bytes(buf.clone())]);
+    let returns = vm
+        .function("test2", &[BorshToken::Bytes(buf.clone())])
+        .unwrap()
+        .unwrap_tuple();
 
     assert_eq!(
         returns,
@@ -139,7 +141,7 @@ fn read_buffer() {
                 width: 16,
                 value: BigInt::from(0x4142u16)
             },
-            BorshToken::FixedBytes(vm.origin.to_vec())
+            BorshToken::Address(vm.origin)
         ]
     );
 
@@ -166,19 +168,23 @@ fn bytes_compare() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function(
-        "test1",
-        &[BorshToken::FixedBytes([0xbc, 0xbc, 0xbd, 0xbe].to_vec())],
-    );
+    let returns = vm
+        .function(
+            "test1",
+            &[BorshToken::FixedBytes([0xbc, 0xbc, 0xbd, 0xbe].to_vec())],
+        )
+        .unwrap();
 
-    assert_eq!(returns, vec![BorshToken::Bool(true)]);
+    assert_eq!(returns, BorshToken::Bool(true));
 
-    let returns = vm.function(
-        "test2",
-        &[BorshToken::FixedBytes([0xbc, 0xbc, 0xbd, 0xbe].to_vec())],
-    );
+    let returns = vm
+        .function(
+            "test2",
+            &[BorshToken::FixedBytes([0xbc, 0xbc, 0xbd, 0xbe].to_vec())],
+        )
+        .unwrap();
 
-    assert_eq!(returns, vec![BorshToken::Bool(false)]);
+    assert_eq!(returns, BorshToken::Bool(false));
 }
 
 #[test]
@@ -200,26 +206,28 @@ fn assignment_in_ternary() {
         let left = rng.gen::<u64>();
         let right = rng.gen::<u64>();
 
-        let returns = vm.function(
-            "minimum",
-            &[
-                BorshToken::Uint {
-                    width: 64,
-                    value: BigInt::from(left),
-                },
-                BorshToken::Uint {
-                    width: 64,
-                    value: BigInt::from(right),
-                },
-            ],
-        );
+        let returns = vm
+            .function(
+                "minimum",
+                &[
+                    BorshToken::Uint {
+                        width: 64,
+                        value: BigInt::from(left),
+                    },
+                    BorshToken::Uint {
+                        width: 64,
+                        value: BigInt::from(right),
+                    },
+                ],
+            )
+            .unwrap();
 
         assert_eq!(
             returns,
-            vec![BorshToken::Uint {
+            BorshToken::Uint {
                 width: 64,
                 value: BigInt::from(std::cmp::min(left, right))
-            },]
+            },
         );
     }
 }
@@ -237,13 +245,13 @@ fn power() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function("power", &[]);
+    let returns = vm.function("power", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::from(2417851639229258349412352u128)
-        },]
+        }
     );
 }

--- a/tests/solana_tests/expressions.rs
+++ b/tests/solana_tests/expressions.rs
@@ -20,7 +20,7 @@ fn interfaceid() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("get", &[]).unwrap();
 
@@ -57,7 +57,7 @@ fn write_buffer() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("test1", &[]).unwrap();
 
@@ -92,7 +92,7 @@ fn read_buffer() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm
         .function(
@@ -166,7 +166,7 @@ fn bytes_compare() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm
         .function(
@@ -200,7 +200,7 @@ fn assignment_in_ternary() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     for _ in 0..10 {
         let left = rng.gen::<u64>();
@@ -243,7 +243,7 @@ fn power() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("power", &[]).unwrap();
 

--- a/tests/solana_tests/hash.rs
+++ b/tests/solana_tests/hash.rs
@@ -61,13 +61,15 @@ fn hash_tests() {
     );
 
     runtime.constructor("tester", &[]);
-    let hash = runtime.function("test", &[BorshToken::Bytes(b"Hello, World!".to_vec())]);
+    let hash = runtime
+        .function("test", &[BorshToken::Bytes(b"Hello, World!".to_vec())])
+        .unwrap();
 
     assert_eq!(
         hash,
-        vec![BorshToken::FixedBytes(
+        BorshToken::uint8_fixed_array(
             hex::decode("527a6a4b9a6da75607546842e0e00105350b1aaf").unwrap()
-        )]
+        )
     );
 
     let mut runtime = build_solidity(
@@ -82,14 +84,16 @@ fn hash_tests() {
     );
 
     runtime.constructor("tester", &[]);
-    let hash = runtime.function("test", &[BorshToken::Bytes(b"Hello, World!".to_vec())]);
+    let hash = runtime
+        .function("test", &[BorshToken::Bytes(b"Hello, World!".to_vec())])
+        .unwrap();
 
     assert_eq!(
         hash,
-        vec![BorshToken::FixedBytes(
+        BorshToken::uint8_fixed_array(
             hex::decode("dffd6021bb2bd5b0af676290809ec3a53191dd81c7f70a4b28688a362182986f")
                 .unwrap()
-        )]
+        )
     );
 
     let mut runtime = build_solidity(
@@ -104,13 +108,15 @@ fn hash_tests() {
     );
 
     runtime.constructor("tester", &[]);
-    let hash = runtime.function("test", &[BorshToken::Bytes(b"Hello, World!".to_vec())]);
+    let hash = runtime
+        .function("test", &[BorshToken::Bytes(b"Hello, World!".to_vec())])
+        .unwrap();
 
     assert_eq!(
         hash,
-        vec![BorshToken::FixedBytes(
+        BorshToken::uint8_fixed_array(
             hex::decode("acaf3289d7b601cbd114fb36c4d29c85bbfd5e133f14cb355c3fd8d99367964f")
                 .unwrap()
-        )]
+        )
     );
 }

--- a/tests/solana_tests/hash.rs
+++ b/tests/solana_tests/hash.rs
@@ -15,7 +15,7 @@ fn constants_hash_tests() {
         }"##,
     );
 
-    runtime.constructor("tester", &[]);
+    runtime.constructor(&[]);
     runtime.function("test", &[]);
 
     let mut runtime = build_solidity(
@@ -29,7 +29,7 @@ fn constants_hash_tests() {
         }"##,
     );
 
-    runtime.constructor("tester", &[]);
+    runtime.constructor(&[]);
     runtime.function("test", &[]);
 
     let mut runtime = build_solidity(
@@ -43,7 +43,7 @@ fn constants_hash_tests() {
         }"##,
     );
 
-    runtime.constructor("tester", &[]);
+    runtime.constructor(&[]);
     runtime.function("test", &[]);
 }
 
@@ -60,7 +60,7 @@ fn hash_tests() {
         }"##,
     );
 
-    runtime.constructor("tester", &[]);
+    runtime.constructor(&[]);
     let hash = runtime
         .function("test", &[BorshToken::Bytes(b"Hello, World!".to_vec())])
         .unwrap();
@@ -83,7 +83,7 @@ fn hash_tests() {
         }"##,
     );
 
-    runtime.constructor("tester", &[]);
+    runtime.constructor(&[]);
     let hash = runtime
         .function("test", &[BorshToken::Bytes(b"Hello, World!".to_vec())])
         .unwrap();
@@ -107,7 +107,7 @@ fn hash_tests() {
         }"##,
     );
 
-    runtime.constructor("tester", &[]);
+    runtime.constructor(&[]);
     let hash = runtime
         .function("test", &[BorshToken::Bytes(b"Hello, World!".to_vec())])
         .unwrap();

--- a/tests/solana_tests/mappings.rs
+++ b/tests/solana_tests/mappings.rs
@@ -25,7 +25,7 @@ fn simple_mapping() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     for i in 0..10 {
         vm.function(
@@ -150,7 +150,7 @@ fn less_simple_mapping() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     vm.function(
         "set_string",
@@ -231,7 +231,7 @@ fn string_mapping() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     vm.function(
         "set_string",
@@ -293,7 +293,7 @@ fn contract_mapping() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let index = BorshToken::Address(account_new());
 
@@ -331,7 +331,7 @@ fn mapping_in_mapping() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     vm.function(
         "set",
@@ -421,7 +421,7 @@ fn sparse_array() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     vm.function(
         "set_string",
@@ -501,7 +501,7 @@ fn massive_sparse_array() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     vm.function(
         "set_string",
@@ -585,7 +585,7 @@ fn mapping_in_dynamic_array() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     vm.function(
         "setNumber",
@@ -802,7 +802,7 @@ fn mapping_in_struct_in_dynamic_array() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     vm.function(
         "setNumber",
@@ -987,7 +987,7 @@ contract DeleteTest {
 
     let sender = account_new();
 
-    vm.constructor("DeleteTest", &[]);
+    vm.constructor(&[]);
     let _ = vm.function("addData", &[BorshToken::Address(sender)]);
     let _ = vm.function("deltest", &[]);
     let returns = vm.function("get", &[]).unwrap();
@@ -1048,7 +1048,7 @@ function getArrAmt() public view returns (uint) {
 
     let sender = account_new();
 
-    vm.constructor("CrowdFunding", &[]);
+    vm.constructor(&[]);
 
     let ret = vm
         .function("newCampaign", &[BorshToken::Address(sender)])

--- a/tests/solana_tests/mappings.rs
+++ b/tests/solana_tests/mappings.rs
@@ -44,37 +44,41 @@ fn simple_mapping() {
     }
 
     for i in 0..10 {
-        let returns = vm.function(
-            "get",
-            &[BorshToken::Uint {
-                width: 64,
-                value: BigInt::from(102 + i),
-            }],
-        );
+        let returns = vm
+            .function(
+                "get",
+                &[BorshToken::Uint {
+                    width: 64,
+                    value: BigInt::from(102 + i),
+                }],
+            )
+            .unwrap();
 
         assert_eq!(
             returns,
-            vec![BorshToken::Uint {
+            BorshToken::Uint {
                 width: 64,
                 value: BigInt::from(300331 + i)
-            }]
+            }
         );
     }
 
-    let returns = vm.function(
-        "get",
-        &[BorshToken::Uint {
-            width: 64,
-            value: BigInt::from(101u8),
-        }],
-    );
+    let returns = vm
+        .function(
+            "get",
+            &[BorshToken::Uint {
+                width: 64,
+                value: BigInt::from(101u8),
+            }],
+        )
+        .unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 64,
             value: BigInt::zero()
-        }]
+        }
     );
 
     vm.function(
@@ -86,29 +90,31 @@ fn simple_mapping() {
     );
 
     for i in 0..10 {
-        let returns = vm.function(
-            "get",
-            &[BorshToken::Uint {
-                width: 64,
-                value: BigInt::from(102 + i),
-            }],
-        );
+        let returns = vm
+            .function(
+                "get",
+                &[BorshToken::Uint {
+                    width: 64,
+                    value: BigInt::from(102 + i),
+                }],
+            )
+            .unwrap();
 
         if 102 + i != 104 {
             assert_eq!(
                 returns,
-                vec![BorshToken::Uint {
+                BorshToken::Uint {
                     width: 64,
                     value: BigInt::from(300331 + i)
-                }]
+                }
             );
         } else {
             assert_eq!(
                 returns,
-                vec![BorshToken::Uint {
+                BorshToken::Uint {
                     width: 64,
                     value: BigInt::zero(),
-                }]
+                }
             );
         }
     }
@@ -171,17 +177,19 @@ fn less_simple_mapping() {
         ],
     );
 
-    let returns = vm.function(
-        "get",
-        &[BorshToken::Uint {
-            width: 256,
-            value: BigInt::from(12313132131321312311213131u128),
-        }],
-    );
+    let returns = vm
+        .function(
+            "get",
+            &[BorshToken::Uint {
+                width: 256,
+                value: BigInt::from(12313132131321312311213131u128),
+            }],
+        )
+        .unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Tuple(vec![
+        BorshToken::Tuple(vec![
             BorshToken::String(String::from("This is a string which should be a little longer than 32 bytes so we the the abi encoder")),
             BorshToken::Array(vec![
                 BorshToken::Int{
@@ -189,7 +197,7 @@ fn less_simple_mapping() {
                     value: BigInt::from(102u8)
                 },
             ]),
-        ])]
+        ])
     );
 }
 
@@ -244,11 +252,13 @@ fn string_mapping() {
         ],
     );
 
-    let returns = vm.function("get", &[BorshToken::String(String::from("a"))]);
+    let returns = vm
+        .function("get", &[BorshToken::String(String::from("a"))])
+        .unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Tuple(vec![
+        BorshToken::Tuple(vec![
             BorshToken::String(String::from("This is a string which should be a little longer than 32 bytes so we the the abi encoder")),
             BorshToken::Array(vec![
                 BorshToken::Int{
@@ -256,7 +266,7 @@ fn string_mapping() {
                     value: BigInt::from(102u8)
                 },
             ]),
-        ])]
+        ])
     );
 }
 
@@ -294,18 +304,18 @@ fn contract_mapping() {
             BorshToken::String(String::from("This is a string which should be a little longer than 32 bytes so we the the abi encoder")),
         ], );
 
-    let returns = vm.function("get", &[index.clone()]);
+    let returns = vm.function("get", &[index.clone()]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::String(String::from("This is a string which should be a little longer than 32 bytes so we the the abi encoder"))]
+        BorshToken::String(String::from("This is a string which should be a little longer than 32 bytes so we the the abi encoder"))
     );
 
     vm.function("rm", &[index.clone()]);
 
-    let returns = vm.function("get", &[index]);
+    let returns = vm.function("get", &[index]).unwrap();
 
-    assert_eq!(returns, vec![BorshToken::String(String::from(""))]);
+    assert_eq!(returns, BorshToken::String(String::from("")));
 }
 
 #[test]
@@ -335,44 +345,50 @@ fn mapping_in_mapping() {
         ],
     );
 
-    let returns = vm.function(
-        "map",
-        &[
-            BorshToken::String(String::from("a")),
-            BorshToken::Int {
-                width: 64,
-                value: BigInt::from(102u8),
-            },
-        ],
-    );
+    let returns = vm
+        .function(
+            "map",
+            &[
+                BorshToken::String(String::from("a")),
+                BorshToken::Int {
+                    width: 64,
+                    value: BigInt::from(102u8),
+                },
+            ],
+        )
+        .unwrap();
 
-    assert_eq!(returns, vec![BorshToken::FixedBytes(vec![0x98])]);
+    assert_eq!(returns, BorshToken::uint8_fixed_array(vec![0x98]));
 
-    let returns = vm.function(
-        "map",
-        &[
-            BorshToken::String(String::from("a")),
-            BorshToken::Int {
-                width: 64,
-                value: BigInt::from(103u8),
-            },
-        ],
-    );
+    let returns = vm
+        .function(
+            "map",
+            &[
+                BorshToken::String(String::from("a")),
+                BorshToken::Int {
+                    width: 64,
+                    value: BigInt::from(103u8),
+                },
+            ],
+        )
+        .unwrap();
 
-    assert_eq!(returns, vec![BorshToken::FixedBytes(vec![0])]);
+    assert_eq!(returns, BorshToken::uint8_fixed_array(vec![0]));
 
-    let returns = vm.function(
-        "map",
-        &[
-            BorshToken::String(String::from("b")),
-            BorshToken::Int {
-                width: 64,
-                value: BigInt::from(102u8),
-            },
-        ],
-    );
+    let returns = vm
+        .function(
+            "map",
+            &[
+                BorshToken::String(String::from("b")),
+                BorshToken::Int {
+                    width: 64,
+                    value: BigInt::from(102u8),
+                },
+            ],
+        )
+        .unwrap();
 
-    assert_eq!(returns, vec![BorshToken::FixedBytes(vec![0])]);
+    assert_eq!(returns, BorshToken::uint8_fixed_array(vec![0]));
 }
 
 #[test]
@@ -431,17 +447,19 @@ fn sparse_array() {
         ],
     );
 
-    let returns = vm.function(
-        "get",
-        &[BorshToken::Uint {
-            width: 256,
-            value: BigInt::from(909090909u64),
-        }],
-    );
+    let returns = vm
+        .function(
+            "get",
+            &[BorshToken::Uint {
+                width: 256,
+                value: BigInt::from(909090909u64),
+            }],
+        )
+        .unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Tuple(vec![
+        BorshToken::Tuple(vec![
             BorshToken::String(String::from("This is a string which should be a little longer than 32 bytes so we the the abi encoder")),
             BorshToken::Array(vec![
                 BorshToken::Int{
@@ -449,7 +467,7 @@ fn sparse_array() {
                     value: BigInt::from(102u8)
                 },
             ]),
-        ])]
+        ])
     );
 }
 
@@ -509,17 +527,19 @@ fn massive_sparse_array() {
         ],
     );
 
-    let returns = vm.function(
-        "get",
-        &[BorshToken::Uint {
-            width: 256,
-            value: BigInt::from(786868768768678687686877u128),
-        }],
-    );
+    let returns = vm
+        .function(
+            "get",
+            &[BorshToken::Uint {
+                width: 256,
+                value: BigInt::from(786868768768678687686877u128),
+            }],
+        )
+        .unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Tuple(vec![
+        BorshToken::Tuple(vec![
             BorshToken::String(String::from("This is a string which should be a little longer than 32 bytes so we the the abi encoder")),
             BorshToken::Array(vec![
                 BorshToken::Int {
@@ -527,7 +547,7 @@ fn massive_sparse_array() {
                     value: BigInt::from(102u8)
                 },
             ]),
-        ])]
+        ])
     );
 }
 
@@ -602,50 +622,54 @@ fn mapping_in_dynamic_array() {
 
     for array_no in 0..2 {
         for i in 0..10 {
-            let returns = vm.function(
-                "map",
-                &[
-                    BorshToken::Uint {
-                        width: 256,
-                        value: BigInt::from(array_no),
-                    },
-                    BorshToken::Uint {
-                        width: 64,
-                        value: BigInt::from(102 + i + array_no * 500),
-                    },
-                ],
-            );
+            let returns = vm
+                .function(
+                    "map",
+                    &[
+                        BorshToken::Uint {
+                            width: 256,
+                            value: BigInt::from(array_no),
+                        },
+                        BorshToken::Uint {
+                            width: 64,
+                            value: BigInt::from(102 + i + array_no * 500),
+                        },
+                    ],
+                )
+                .unwrap();
 
             assert_eq!(
                 returns,
-                vec![BorshToken::Uint {
+                BorshToken::Uint {
                     width: 64,
                     value: BigInt::from(300331 + i)
-                },]
+                },
             );
         }
     }
 
-    let returns = vm.function(
-        "map",
-        &[
-            BorshToken::Uint {
-                width: 256,
-                value: BigInt::zero(),
-            },
-            BorshToken::Uint {
-                width: 64,
-                value: BigInt::from(101u8),
-            },
-        ],
-    );
+    let returns = vm
+        .function(
+            "map",
+            &[
+                BorshToken::Uint {
+                    width: 256,
+                    value: BigInt::zero(),
+                },
+                BorshToken::Uint {
+                    width: 64,
+                    value: BigInt::from(101u8),
+                },
+            ],
+        )
+        .unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 64,
             value: BigInt::zero()
-        }]
+        }
     );
 
     vm.function(
@@ -663,78 +687,80 @@ fn mapping_in_dynamic_array() {
     );
 
     for i in 0..10 {
-        let returns = vm.function(
-            "map",
-            &[
-                BorshToken::Uint {
-                    width: 256,
-                    value: BigInt::zero(),
-                },
-                BorshToken::Uint {
-                    width: 64,
-                    value: BigInt::from(102 + i),
-                },
-            ],
-        );
+        let returns = vm
+            .function(
+                "map",
+                &[
+                    BorshToken::Uint {
+                        width: 256,
+                        value: BigInt::zero(),
+                    },
+                    BorshToken::Uint {
+                        width: 64,
+                        value: BigInt::from(102 + i),
+                    },
+                ],
+            )
+            .unwrap();
 
         if 102 + i != 104 {
             assert_eq!(
                 returns,
-                vec![BorshToken::Uint {
+                BorshToken::Uint {
                     width: 64,
                     value: BigInt::from(300331 + i)
-                },]
+                },
             );
         } else {
             assert_eq!(
                 returns,
-                vec![BorshToken::Uint {
+                BorshToken::Uint {
                     width: 64,
                     value: BigInt::zero()
-                }]
+                }
             );
         }
     }
 
-    let returns = vm.function("length", &[]);
+    let returns = vm.function("length", &[]).unwrap();
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 64,
             value: BigInt::from(2u8)
-        }]
+        }
     );
 
     vm.function("pop", &[]);
 
-    let returns = vm.function("length", &[]);
+    let returns = vm.function("length", &[]).unwrap();
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 64,
             value: BigInt::one()
-        }]
+        }
     );
 
     vm.function("pop", &[]);
 
-    let returns = vm.function("length", &[]);
+    let returns = vm.function("length", &[]).unwrap();
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 64,
             value: BigInt::zero()
-        }]
+        }
     );
 
-    let returns = vm.function("number", &[]);
+    let returns = vm.function("number", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Int {
+        BorshToken::Int {
             width: 64,
             value: BigInt::from(2147483647u64)
-        }]
+        }
     );
 }
 
@@ -813,50 +839,54 @@ fn mapping_in_struct_in_dynamic_array() {
 
     for array_no in 0..2 {
         for i in 0..10 {
-            let returns = vm.function(
-                "get",
-                &[
-                    BorshToken::Uint {
-                        width: 64,
-                        value: BigInt::from(array_no),
-                    },
-                    BorshToken::Uint {
-                        width: 64,
-                        value: BigInt::from(102 + i + array_no * 500),
-                    },
-                ],
-            );
+            let returns = vm
+                .function(
+                    "get",
+                    &[
+                        BorshToken::Uint {
+                            width: 64,
+                            value: BigInt::from(array_no),
+                        },
+                        BorshToken::Uint {
+                            width: 64,
+                            value: BigInt::from(102 + i + array_no * 500),
+                        },
+                    ],
+                )
+                .unwrap();
 
             assert_eq!(
                 returns,
-                vec![BorshToken::Uint {
+                BorshToken::Uint {
                     width: 256,
                     value: BigInt::from(300331 + i)
-                },]
+                },
             );
         }
     }
 
-    let returns = vm.function(
-        "get",
-        &[
-            BorshToken::Uint {
-                width: 64,
-                value: BigInt::zero(),
-            },
-            BorshToken::Uint {
-                width: 64,
-                value: BigInt::from(101u8),
-            },
-        ],
-    );
+    let returns = vm
+        .function(
+            "get",
+            &[
+                BorshToken::Uint {
+                    width: 64,
+                    value: BigInt::zero(),
+                },
+                BorshToken::Uint {
+                    width: 64,
+                    value: BigInt::from(101u8),
+                },
+            ],
+        )
+        .unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::zero(),
-        },]
+        },
     );
 
     vm.function(
@@ -874,35 +904,37 @@ fn mapping_in_struct_in_dynamic_array() {
     );
 
     for i in 0..10 {
-        let returns = vm.function(
-            "get",
-            &[
-                BorshToken::Uint {
-                    width: 64,
-                    value: BigInt::zero(),
-                },
-                BorshToken::Uint {
-                    width: 64,
-                    value: BigInt::from(102 + i),
-                },
-            ],
-        );
+        let returns = vm
+            .function(
+                "get",
+                &[
+                    BorshToken::Uint {
+                        width: 64,
+                        value: BigInt::zero(),
+                    },
+                    BorshToken::Uint {
+                        width: 64,
+                        value: BigInt::from(102 + i),
+                    },
+                ],
+            )
+            .unwrap();
 
         if 102 + i != 104 {
             assert_eq!(
                 returns,
-                vec![BorshToken::Uint {
+                BorshToken::Uint {
                     width: 256,
                     value: BigInt::from(300331 + i)
-                }]
+                }
             );
         } else {
             assert_eq!(
                 returns,
-                vec![BorshToken::Uint {
+                BorshToken::Uint {
                     width: 256,
                     value: BigInt::zero()
-                }]
+                }
             );
         }
     }
@@ -910,14 +942,14 @@ fn mapping_in_struct_in_dynamic_array() {
     vm.function("pop", &[]);
     vm.function("pop", &[]);
 
-    let returns = vm.function("number", &[]);
+    let returns = vm.function("number", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Int {
+        BorshToken::Int {
             width: 64,
             value: BigInt::from(2147483647u64),
-        }]
+        }
     );
 }
 
@@ -958,19 +990,19 @@ contract DeleteTest {
     vm.constructor("DeleteTest", &[]);
     let _ = vm.function("addData", &[BorshToken::Address(sender)]);
     let _ = vm.function("deltest", &[]);
-    let returns = vm.function("get", &[]);
+    let returns = vm.function("get", &[]).unwrap();
     assert_eq!(
         returns,
-        vec![BorshToken::Tuple(vec![
-            BorshToken::FixedBytes(vec![
+        BorshToken::Tuple(vec![
+            BorshToken::Address([
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                 0, 0, 0, 0
             ]),
-            BorshToken::FixedBytes(vec![
+            BorshToken::Address([
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                 0, 0, 0, 0
             ])
-        ])],
+        ]),
     );
 }
 
@@ -1018,31 +1050,33 @@ function getArrAmt() public view returns (uint) {
 
     vm.constructor("CrowdFunding", &[]);
 
-    let ret = vm.function("newCampaign", &[BorshToken::Address(sender)]);
+    let ret = vm
+        .function("newCampaign", &[BorshToken::Address(sender)])
+        .unwrap();
 
     assert_eq!(
         ret,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::zero(),
-        }]
+        }
     );
 
-    let ret = vm.function("getAmt", &[]);
+    let ret = vm.function("getAmt", &[]).unwrap();
     assert_eq!(
         ret,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::from(100u8),
-        }]
+        }
     );
 
-    let ret = vm.function("getArrAmt", &[]);
+    let ret = vm.function("getArrAmt", &[]).unwrap();
     assert_eq!(
         ret,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::from(105u8),
-        }]
+        }
     );
 }

--- a/tests/solana_tests/math.rs
+++ b/tests/solana_tests/math.rs
@@ -39,7 +39,7 @@ fn safe_math() {
         }"#,
     );
 
-    vm.constructor("math", &[]);
+    vm.constructor(&[]);
 
     let returns = vm
         .function(

--- a/tests/solana_tests/math.rs
+++ b/tests/solana_tests/math.rs
@@ -41,70 +41,76 @@ fn safe_math() {
 
     vm.constructor("math", &[]);
 
-    let returns = vm.function(
-        "mul_test",
-        &[
-            BorshToken::Uint {
-                width: 256,
-                value: BigInt::from_str("1000000000000000000").unwrap(),
-            },
-            BorshToken::Uint {
-                width: 256,
-                value: BigInt::from_str("4000000000000000000").unwrap(),
-            },
-        ],
-    );
+    let returns = vm
+        .function(
+            "mul_test",
+            &[
+                BorshToken::Uint {
+                    width: 256,
+                    value: BigInt::from_str("1000000000000000000").unwrap(),
+                },
+                BorshToken::Uint {
+                    width: 256,
+                    value: BigInt::from_str("4000000000000000000").unwrap(),
+                },
+            ],
+        )
+        .unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::from_str("4000000000000000000000000000000000000").unwrap(),
-        },]
+        },
     );
 
-    let returns = vm.function(
-        "add_test",
-        &[
-            BorshToken::Uint {
-                width: 256,
-                value: BigInt::from_str("1000000000000000000").unwrap(),
-            },
-            BorshToken::Uint {
-                width: 256,
-                value: BigInt::from_str("4000000000000000000").unwrap(),
-            },
-        ],
-    );
+    let returns = vm
+        .function(
+            "add_test",
+            &[
+                BorshToken::Uint {
+                    width: 256,
+                    value: BigInt::from_str("1000000000000000000").unwrap(),
+                },
+                BorshToken::Uint {
+                    width: 256,
+                    value: BigInt::from_str("4000000000000000000").unwrap(),
+                },
+            ],
+        )
+        .unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::from_str("5000000000000000000").unwrap(),
-        },]
+        },
     );
 
-    let returns = vm.function(
-        "sub_test",
-        &[
-            BorshToken::Uint {
-                width: 256,
-                value: BigInt::from_str("4000000000000000000").unwrap(),
-            },
-            BorshToken::Uint {
-                width: 256,
-                value: BigInt::from_str("1000000000000000000").unwrap(),
-            },
-        ],
-    );
+    let returns = vm
+        .function(
+            "sub_test",
+            &[
+                BorshToken::Uint {
+                    width: 256,
+                    value: BigInt::from_str("4000000000000000000").unwrap(),
+                },
+                BorshToken::Uint {
+                    width: 256,
+                    value: BigInt::from_str("1000000000000000000").unwrap(),
+                },
+            ],
+        )
+        .unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::from_str("3000000000000000000").unwrap(),
-        },]
+        },
     );
 
     let res = vm.function_must_fail(

--- a/tests/solana_tests/metas.rs
+++ b/tests/solana_tests/metas.rs
@@ -20,15 +20,15 @@ fn use_authority() {
     vm.constructor("AuthorityExample", &[BorshToken::Address(authority)]);
 
     let res = vm.function_must_fail("inc", &[]).unwrap();
-    assert!(res != 0);
+    assert_ne!(res, 0);
 
-    let res = vm.function("get", &[]);
+    let res = vm.function("get", &[]).unwrap();
     assert_eq!(
         res,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 64,
             value: 0.into()
-        }]
+        }
     );
 
     let mut metas = vm.default_metas();
@@ -40,12 +40,12 @@ fn use_authority() {
 
     vm.function_metas(&metas, "inc", &[]);
 
-    let res = vm.function("get", &[]);
+    let res = vm.function("get", &[]).unwrap();
     assert_eq!(
         res,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 64,
             value: 1.into()
-        }]
+        }
     );
 }

--- a/tests/solana_tests/metas.rs
+++ b/tests/solana_tests/metas.rs
@@ -17,7 +17,7 @@ fn use_authority() {
         },
     );
 
-    vm.constructor("AuthorityExample", &[BorshToken::Address(authority)]);
+    vm.constructor(&[BorshToken::Address(authority)]);
 
     let res = vm.function_must_fail("inc", &[]).unwrap();
     assert_ne!(res, 0);

--- a/tests/solana_tests/modifiers.rs
+++ b/tests/solana_tests/modifiers.rs
@@ -28,7 +28,7 @@ fn returns_and_phis_needed() {
         }"#,
     );
 
-    vm.constructor("c", &[]);
+    vm.constructor(&[]);
 
     let returns = vm
         .function("func", &[BorshToken::Bool(false)])

--- a/tests/solana_tests/modifiers.rs
+++ b/tests/solana_tests/modifiers.rs
@@ -30,7 +30,10 @@ fn returns_and_phis_needed() {
 
     vm.constructor("c", &[]);
 
-    let returns = vm.function("func", &[BorshToken::Bool(false)]);
+    let returns = vm
+        .function("func", &[BorshToken::Bool(false)])
+        .unwrap()
+        .unwrap_tuple();
 
     assert_eq!(
         returns,
@@ -43,7 +46,10 @@ fn returns_and_phis_needed() {
         ]
     );
 
-    let returns = vm.function("func", &[BorshToken::Bool(true)]);
+    let returns = vm
+        .function("func", &[BorshToken::Bool(true)])
+        .unwrap()
+        .unwrap_tuple();
 
     assert_eq!(
         returns,

--- a/tests/solana_tests/primitives.rs
+++ b/tests/solana_tests/primitives.rs
@@ -79,13 +79,13 @@ fn boolean() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function("return_true", &[]);
+    let returns = vm.function("return_true", &[]).unwrap();
 
-    assert_eq!(returns, vec![BorshToken::Bool(true),]);
+    assert_eq!(returns, BorshToken::Bool(true));
 
-    let returns = vm.function("return_false", &[]);
+    let returns = vm.function("return_false", &[]).unwrap();
 
-    assert_eq!(returns, vec![BorshToken::Bool(false),]);
+    assert_eq!(returns, BorshToken::Bool(false));
 
     vm.function("true_arg", &[BorshToken::Bool(true)]);
     vm.function("false_arg", &[BorshToken::Bool(false)]);
@@ -113,19 +113,19 @@ fn address() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function("return_address", &[]);
+    let returns = vm.function("return_address", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::FixedBytes(vec![
+        BorshToken::Address([
             171, 59, 10, 127, 211, 122, 217, 123, 53, 213, 159, 40, 54, 36, 50, 52, 196, 144, 17,
             226, 97, 168, 69, 213, 79, 14, 6, 232, 165, 44, 58, 31
-        ]),]
+        ]),
     );
 
     vm.function(
         "address_arg",
-        &[BorshToken::FixedBytes(vec![
+        &[BorshToken::Address([
             75, 161, 209, 89, 47, 84, 50, 13, 23, 127, 94, 21, 50, 249, 250, 185, 117, 49, 186,
             134, 82, 130, 112, 97, 218, 24, 157, 198, 40, 105, 118, 27,
         ])],
@@ -155,14 +155,14 @@ fn test_enum() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function("return_enum", &[]);
+    let returns = vm.function("return_enum", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 8,
             value: BigInt::from(9u8)
-        }]
+        }
     );
 
     vm.function(
@@ -215,21 +215,23 @@ fn bytes() {
 
         vm.constructor("test", &[]);
 
-        let returns = vm.function("return_literal", &[]);
+        let returns = vm.function("return_literal", &[]).unwrap();
 
         assert_eq!(
             returns,
-            vec![BorshToken::FixedBytes(vec![1, 2, 3, 4, 5, 6, 7]),]
+            BorshToken::uint8_fixed_array(vec![1, 2, 3, 4, 5, 6, 7])
         );
 
-        let returns = vm.function(
-            "return_arg",
-            &[BorshToken::FixedBytes(vec![1, 2, 3, 4, 5, 6, 7])],
-        );
+        let returns = vm
+            .function(
+                "return_arg",
+                &[BorshToken::FixedBytes(vec![1, 2, 3, 4, 5, 6, 7])],
+            )
+            .unwrap();
 
         assert_eq!(
             returns,
-            vec![BorshToken::FixedBytes(vec![1, 2, 3, 4, 5, 6, 7])]
+            BorshToken::uint8_fixed_array(vec![1, 2, 3, 4, 5, 6, 7])
         );
 
         for _ in 0..10 {
@@ -242,13 +244,15 @@ fn bytes() {
             rng.fill(&mut a[..]);
             rng.fill(&mut b[..]);
 
-            let or = vm.function(
-                "or",
-                &[
-                    BorshToken::FixedBytes(a.to_vec()),
-                    BorshToken::FixedBytes(b.to_vec()),
-                ],
-            );
+            let or = vm
+                .function(
+                    "or",
+                    &[
+                        BorshToken::FixedBytes(a.to_vec()),
+                        BorshToken::FixedBytes(b.to_vec()),
+                    ],
+                )
+                .unwrap();
 
             let res: Vec<u8> = a.iter().zip(b.iter()).map(|(a, b)| a | b).collect();
 
@@ -259,46 +263,52 @@ fn bytes() {
                 hex::encode(&res)
             );
 
-            assert_eq!(or, vec![BorshToken::FixedBytes(res)]);
+            assert_eq!(or, BorshToken::uint8_fixed_array(res));
 
-            let and = vm.function(
-                "and",
-                &[
-                    BorshToken::FixedBytes(a.to_vec()),
-                    BorshToken::FixedBytes(b.to_vec()),
-                ],
-            );
+            let and = vm
+                .function(
+                    "and",
+                    &[
+                        BorshToken::FixedBytes(a.to_vec()),
+                        BorshToken::FixedBytes(b.to_vec()),
+                    ],
+                )
+                .unwrap();
 
             let res: Vec<u8> = a.iter().zip(b.iter()).map(|(a, b)| a & b).collect();
 
-            assert_eq!(and, vec![BorshToken::FixedBytes(res)]);
+            assert_eq!(and, BorshToken::uint8_fixed_array(res));
 
-            let xor = vm.function(
-                "xor",
-                &[
-                    BorshToken::FixedBytes(a.to_vec()),
-                    BorshToken::FixedBytes(b.to_vec()),
-                ],
-            );
+            let xor = vm
+                .function(
+                    "xor",
+                    &[
+                        BorshToken::FixedBytes(a.to_vec()),
+                        BorshToken::FixedBytes(b.to_vec()),
+                    ],
+                )
+                .unwrap();
 
             let res: Vec<u8> = a.iter().zip(b.iter()).map(|(a, b)| a ^ b).collect();
 
-            assert_eq!(xor, vec![BorshToken::FixedBytes(res)]);
+            assert_eq!(xor, BorshToken::uint8_fixed_array(res));
 
             let r = rng.gen::<u32>() % (width as u32 * 8);
 
             println!("w = {} r = {}", width, r);
 
-            let shl = vm.function(
-                "shift_left",
-                &[
-                    BorshToken::FixedBytes(a.to_vec()),
-                    BorshToken::Uint {
-                        width: 32,
-                        value: BigInt::from(r),
-                    },
-                ],
-            );
+            let shl = vm
+                .function(
+                    "shift_left",
+                    &[
+                        BorshToken::FixedBytes(a.to_vec()),
+                        BorshToken::Uint {
+                            width: 32,
+                            value: BigInt::from(r),
+                        },
+                    ],
+                )
+                .unwrap();
 
             let mut res = (BigUint::from_bytes_be(&a) << r).to_bytes_be();
 
@@ -310,18 +320,20 @@ fn bytes() {
                 res.insert(0, 0);
             }
 
-            assert_eq!(shl, vec![BorshToken::FixedBytes(res)]);
+            assert_eq!(shl, BorshToken::uint8_fixed_array(res));
 
-            let shr = vm.function(
-                "shift_right",
-                &[
-                    BorshToken::FixedBytes(a.to_vec()),
-                    BorshToken::Uint {
-                        width: 32,
-                        value: BigInt::from(r),
-                    },
-                ],
-            );
+            let shr = vm
+                .function(
+                    "shift_right",
+                    &[
+                        BorshToken::FixedBytes(a.to_vec()),
+                        BorshToken::Uint {
+                            width: 32,
+                            value: BigInt::from(r),
+                        },
+                    ],
+                )
+                .unwrap();
 
             let mut res = (BigUint::from_bytes_be(&a) >> r).to_bytes_be();
 
@@ -329,7 +341,7 @@ fn bytes() {
                 res.insert(0, 0);
             }
 
-            assert_eq!(shr, vec![BorshToken::FixedBytes(res)]);
+            assert_eq!(shr, BorshToken::uint8_fixed_array(res));
         }
     }
 }
@@ -338,7 +350,7 @@ fn bytes() {
 fn uint() {
     let mut rng = rand::thread_rng();
 
-    for width in (8..=256).step_by(8) {
+    for width in (8u16..=256).step_by(8) {
         let src = r#"
         contract test {
             function pass(uintN a) public returns (uintN) {
@@ -401,6 +413,7 @@ fn uint() {
         vm.constructor("test", &[]);
 
         println!("width:{}", width);
+        let returned_width = width.next_power_of_two();
 
         for _ in 0..10 {
             let mut a = rng.gen_biguint(width as u64);
@@ -412,26 +425,28 @@ fn uint() {
             let res = vm.function(
                 "pass",
                 &[BorshToken::Uint {
-                    width: width as u16,
+                    width,
                     value: a.to_bigint().unwrap(),
                 }],
             );
 
             println!("{:x} = {:?} o", a, res);
 
-            let add = vm.function(
-                "add",
-                &[
-                    BorshToken::Uint {
-                        width: width as u16,
-                        value: a.to_bigint().unwrap(),
-                    },
-                    BorshToken::Uint {
-                        width: width as u16,
-                        value: b.to_bigint().unwrap(),
-                    },
-                ],
-            );
+            let add = vm
+                .function(
+                    "add",
+                    &[
+                        BorshToken::Uint {
+                            width,
+                            value: a.to_bigint().unwrap(),
+                        },
+                        BorshToken::Uint {
+                            width,
+                            value: b.to_bigint().unwrap(),
+                        },
+                    ],
+                )
+                .unwrap();
 
             let mut res = a.clone().add(&b);
             truncate_biguint(&mut res, width);
@@ -440,104 +455,112 @@ fn uint() {
 
             assert_eq!(
                 add,
-                vec![BorshToken::Uint {
-                    width: width as u16,
+                BorshToken::Uint {
+                    width: returned_width,
                     value: res.to_bigint().unwrap(),
-                }]
+                }
             );
 
-            let sub = vm.function(
-                "sub",
-                &[
-                    BorshToken::Uint {
-                        width: width as u16,
-                        value: a.to_bigint().unwrap(),
-                    },
-                    BorshToken::Uint {
-                        width: width as u16,
-                        value: b.to_bigint().unwrap(),
-                    },
-                ],
-            );
+            let sub = vm
+                .function(
+                    "sub",
+                    &[
+                        BorshToken::Uint {
+                            width,
+                            value: a.to_bigint().unwrap(),
+                        },
+                        BorshToken::Uint {
+                            width,
+                            value: b.to_bigint().unwrap(),
+                        },
+                    ],
+                )
+                .unwrap();
 
             let mut res = a.clone().sub(&b);
             truncate_biguint(&mut res, width);
 
             assert_eq!(
                 sub,
-                vec![BorshToken::Uint {
-                    width: width as u16,
+                BorshToken::Uint {
+                    width: returned_width,
                     value: res.to_bigint().unwrap(),
-                }]
+                }
             );
 
-            let mul = vm.function(
-                "mul",
-                &[
-                    BorshToken::Uint {
-                        width: width as u16,
-                        value: a.to_bigint().unwrap(),
-                    },
-                    BorshToken::Uint {
-                        width: width as u16,
-                        value: b.to_bigint().unwrap(),
-                    },
-                ],
-            );
+            let mul = vm
+                .function(
+                    "mul",
+                    &[
+                        BorshToken::Uint {
+                            width,
+                            value: a.to_bigint().unwrap(),
+                        },
+                        BorshToken::Uint {
+                            width,
+                            value: b.to_bigint().unwrap(),
+                        },
+                    ],
+                )
+                .unwrap();
 
             let mut res = a.clone().mul(&b);
             truncate_biguint(&mut res, width);
 
             assert_eq!(
                 mul,
-                vec![BorshToken::Uint {
-                    width: width as u16,
+                BorshToken::Uint {
+                    width: returned_width,
                     value: res.to_bigint().unwrap(),
-                }]
+                }
             );
 
             if let Some(mut n) = b.to_u32() {
                 n %= 65536;
-                let pow = vm.function(
-                    "pow",
-                    &[
-                        BorshToken::Uint {
-                            width: width as u16,
-                            value: a.to_bigint().unwrap(),
-                        },
-                        BorshToken::Uint {
-                            width: width as u16,
-                            value: BigInt::from(n),
-                        },
-                    ],
-                );
+                let pow = vm
+                    .function(
+                        "pow",
+                        &[
+                            BorshToken::Uint {
+                                width,
+                                value: a.to_bigint().unwrap(),
+                            },
+                            BorshToken::Uint {
+                                width,
+                                value: BigInt::from(n),
+                            },
+                        ],
+                    )
+                    .unwrap();
 
                 let mut res = a.clone().pow(n);
                 truncate_biguint(&mut res, width);
 
                 assert_eq!(
                     pow,
-                    vec![BorshToken::Uint {
-                        width: width as u16,
+                    BorshToken::Uint {
+                        width: returned_width,
                         value: res.to_bigint().unwrap(),
-                    }]
+                    }
                 );
             }
 
             if b != BigUint::zero() {
-                let div = vm.function(
-                    "div",
-                    &[
-                        BorshToken::Uint {
-                            width: width as u16,
-                            value: a.to_bigint().unwrap(),
-                        },
-                        BorshToken::Uint {
-                            width: width as u16,
-                            value: b.to_bigint().unwrap(),
-                        },
-                    ],
-                );
+                let div = vm
+                    .function(
+                        "div",
+                        &[
+                            BorshToken::Uint {
+                                width,
+                                value: a.to_bigint().unwrap(),
+                            },
+                            BorshToken::Uint {
+                                width,
+                                value: b.to_bigint().unwrap(),
+                            },
+                        ],
+                    )
+                    .unwrap();
 
                 let mut res = a.clone().div(&b);
 
@@ -545,25 +568,27 @@ fn uint() {
 
                 assert_eq!(
                     div,
-                    vec![BorshToken::Uint {
-                        width: width as u16,
+                    BorshToken::Uint {
+                        width: returned_width,
                         value: res.to_bigint().unwrap(),
-                    }]
+                    }
                 );
 
-                let add = vm.function(
-                    "mod",
-                    &[
-                        BorshToken::Uint {
-                            width: width as u16,
-                            value: a.to_bigint().unwrap(),
-                        },
-                        BorshToken::Uint {
-                            width: width as u16,
-                            value: b.to_bigint().unwrap(),
-                        },
-                    ],
-                );
+                let add = vm
+                    .function(
+                        "mod",
+                        &[
+                            BorshToken::Uint {
+                                width,
+                                value: a.to_bigint().unwrap(),
+                            },
+                            BorshToken::Uint {
+                                width,
+                                value: b.to_bigint().unwrap(),
+                            },
+                        ],
+                    )
+                    .unwrap();
 
                 let mut res = a.clone().rem(&b);
 
@@ -571,103 +596,111 @@ fn uint() {
 
                 assert_eq!(
                     add,
-                    vec![BorshToken::Uint {
-                        width: width as u16,
+                    BorshToken::Uint {
+                        width: returned_width,
                         value: res.to_bigint().unwrap(),
-                    }]
+                    }
                 );
             }
 
-            let or = vm.function(
-                "or",
-                &[
-                    BorshToken::Uint {
-                        width: width as u16,
-                        value: a.to_bigint().unwrap(),
-                    },
-                    BorshToken::Uint {
-                        width: width as u16,
-                        value: b.to_bigint().unwrap(),
-                    },
-                ],
-            );
+            let or = vm
+                .function(
+                    "or",
+                    &[
+                        BorshToken::Uint {
+                            width,
+                            value: a.to_bigint().unwrap(),
+                        },
+                        BorshToken::Uint {
+                            width,
+                            value: b.to_bigint().unwrap(),
+                        },
+                    ],
+                )
+                .unwrap();
 
             let mut res = a.clone().bitor(&b);
             truncate_biguint(&mut res, width);
 
             assert_eq!(
                 or,
-                vec![BorshToken::Uint {
-                    width: width as u16,
+                BorshToken::Uint {
+                    width: returned_width,
                     value: res.to_bigint().unwrap(),
-                }]
+                }
             );
 
-            let and = vm.function(
-                "and",
-                &[
-                    BorshToken::Uint {
-                        width: width as u16,
-                        value: a.to_bigint().unwrap(),
-                    },
-                    BorshToken::Uint {
-                        width: width as u16,
-                        value: b.to_bigint().unwrap(),
-                    },
-                ],
-            );
+            let and = vm
+                .function(
+                    "and",
+                    &[
+                        BorshToken::Uint {
+                            width,
+                            value: a.to_bigint().unwrap(),
+                        },
+                        BorshToken::Uint {
+                            width,
+                            value: b.to_bigint().unwrap(),
+                        },
+                    ],
+                )
+                .unwrap();
 
             let mut res = a.clone().bitand(&b);
             truncate_biguint(&mut res, width);
 
             assert_eq!(
                 and,
-                vec![BorshToken::Uint {
-                    width: width as u16,
+                BorshToken::Uint {
+                    width: returned_width,
                     value: res.to_bigint().unwrap(),
-                }]
+                }
             );
 
-            let xor = vm.function(
-                "xor",
-                &[
-                    BorshToken::Uint {
-                        width: width as u16,
-                        value: a.to_bigint().unwrap(),
-                    },
-                    BorshToken::Uint {
-                        width: width as u16,
-                        value: b.to_bigint().unwrap(),
-                    },
-                ],
-            );
+            let xor = vm
+                .function(
+                    "xor",
+                    &[
+                        BorshToken::Uint {
+                            width,
+                            value: a.to_bigint().unwrap(),
+                        },
+                        BorshToken::Uint {
+                            width,
+                            value: b.to_bigint().unwrap(),
+                        },
+                    ],
+                )
+                .unwrap();
 
             let mut res = a.clone().bitxor(&b);
             truncate_biguint(&mut res, width);
 
             assert_eq!(
                 xor,
-                vec![BorshToken::Uint {
-                    width: width as u16,
+                BorshToken::Uint {
+                    width: returned_width,
                     value: res.to_bigint().unwrap(),
-                }]
+                }
             );
 
             let r = rng.gen::<u32>() % (width as u32);
 
-            let shl = vm.function(
-                "shift_left",
-                &[
-                    BorshToken::Uint {
-                        width: width as u16,
-                        value: a.to_bigint().unwrap(),
-                    },
-                    BorshToken::Uint {
-                        width: 32,
-                        value: BigInt::from(r),
-                    },
-                ],
-            );
+            let shl = vm
+                .function(
+                    "shift_left",
+                    &[
+                        BorshToken::Uint {
+                            width,
+                            value: a.to_bigint().unwrap(),
+                        },
+                        BorshToken::Uint {
+                            width: 32,
+                            value: BigInt::from(r),
+                        },
+                    ],
+                )
+                .unwrap();
 
             let mut res = a.clone();
             res.shl_assign(r);
@@ -675,25 +708,27 @@ fn uint() {
 
             assert_eq!(
                 shl,
-                vec![BorshToken::Uint {
-                    width: width as u16,
+                BorshToken::Uint {
+                    width: returned_width,
                     value: res.to_bigint().unwrap(),
-                }]
+                }
             );
 
-            let shr = vm.function(
-                "shift_right",
-                &[
-                    BorshToken::Uint {
-                        width: width as u16,
-                        value: a.to_bigint().unwrap(),
-                    },
-                    BorshToken::Uint {
-                        width: 32,
-                        value: BigInt::from(r),
-                    },
-                ],
-            );
+            let shr = vm
+                .function(
+                    "shift_right",
+                    &[
+                        BorshToken::Uint {
+                            width,
+                            value: a.to_bigint().unwrap(),
+                        },
+                        BorshToken::Uint {
+                            width: 32,
+                            value: BigInt::from(r),
+                        },
+                    ],
+                )
+                .unwrap();
 
             let mut res = a.clone();
             res.shr_assign(&r);
@@ -701,18 +736,18 @@ fn uint() {
 
             assert_eq!(
                 shr,
-                vec![BorshToken::Uint {
-                    width: width as u16,
+                BorshToken::Uint {
+                    width: returned_width,
                     value: res.to_bigint().unwrap(),
-                }]
+                }
             );
         }
     }
 }
 
-fn truncate_biguint(n: &mut BigUint, width: usize) {
+fn truncate_biguint(n: &mut BigUint, width: u16) {
     let mut bytes = n.to_bytes_le();
-    let byte_width = width / 8;
+    let byte_width = (width / 8) as usize;
     if bytes.len() < byte_width {
         return;
     }
@@ -726,7 +761,7 @@ fn truncate_biguint(n: &mut BigUint, width: usize) {
 
 #[test]
 fn test_power_overflow_boundaries() {
-    for width in (8..=256).step_by(8) {
+    for width in (8u16..=256).step_by(8) {
         let src = r#"
         contract test {
             function pow(uintN a, uintN b) public returns (uintN) {
@@ -738,28 +773,30 @@ fn test_power_overflow_boundaries() {
         let mut contract = build_solidity_with_overflow_check(&src, true);
         contract.constructor("test", &[]);
 
-        let return_value = contract.function(
-            "pow",
-            &[
-                BorshToken::Uint {
-                    width,
-                    value: BigInt::from(2u8),
-                },
-                BorshToken::Uint {
-                    width,
-                    value: BigInt::from(width - 1),
-                },
-            ],
-        );
+        let return_value = contract
+            .function(
+                "pow",
+                &[
+                    BorshToken::Uint {
+                        width,
+                        value: BigInt::from(2u8),
+                    },
+                    BorshToken::Uint {
+                        width,
+                        value: BigInt::from(width - 1),
+                    },
+                ],
+            )
+            .unwrap();
 
         let res = BigUint::from(2_u32).pow((width - 1) as u32);
 
         assert_eq!(
             return_value,
-            vec![BorshToken::Uint {
-                width,
+            BorshToken::Uint {
+                width: width.next_power_of_two(),
                 value: res.to_bigint().unwrap(),
-            }]
+            }
         );
 
         let sesa = contract.function_must_fail(
@@ -799,48 +836,54 @@ fn test_overflow_boundaries() {
         lower_boundary.mul_assign(-1);
         let second_op = BigInt::from(1_u32);
 
+        let returned_width = (width as u16).next_power_of_two();
+
         // Multiply the boundaries by 1.
         contract.constructor("test", &[]);
-        let return_value = contract.function(
-            "mul",
-            &[
-                BorshToken::Int {
-                    width: width as u16,
-                    value: upper_boundary.clone(),
-                },
-                BorshToken::Int {
-                    width: width as u16,
-                    value: second_op.clone(),
-                },
-            ],
-        );
+        let return_value = contract
+            .function(
+                "mul",
+                &[
+                    BorshToken::Int {
+                        width: width as u16,
+                        value: upper_boundary.clone(),
+                    },
+                    BorshToken::Int {
+                        width: width as u16,
+                        value: second_op.clone(),
+                    },
+                ],
+            )
+            .unwrap();
         assert_eq!(
             return_value,
-            vec![BorshToken::Int {
-                width: width as u16,
+            BorshToken::Int {
+                width: returned_width,
                 value: upper_boundary.clone(),
-            }]
+            }
         );
 
-        let return_value = contract.function(
-            "mul",
-            &[
-                BorshToken::Int {
-                    width: width as u16,
-                    value: lower_boundary.clone(),
-                },
-                BorshToken::Int {
-                    width: width as u16,
-                    value: second_op.clone(),
-                },
-            ],
-        );
+        let return_value = contract
+            .function(
+                "mul",
+                &[
+                    BorshToken::Int {
+                        width: width as u16,
+                        value: lower_boundary.clone(),
+                    },
+                    BorshToken::Int {
+                        width: width as u16,
+                        value: second_op.clone(),
+                    },
+                ],
+            )
+            .unwrap();
         assert_eq!(
             return_value,
-            vec![BorshToken::Int {
-                width: width as u16,
+            BorshToken::Int {
+                width: returned_width,
                 value: lower_boundary.clone(),
-            },]
+            },
         );
 
         let upper_boundary_plus_one: BigInt = BigInt::from(2_u32).pow((width - 1) as u32);
@@ -961,27 +1004,29 @@ fn test_mul_within_range_signed() {
         println!("second op : {:?}", second_op);
 
         contract.constructor("test", &[]);
-        let return_value = contract.function(
-            "mul",
-            &[
-                BorshToken::Int {
-                    width: width as u16,
-                    value: first_operand_rand.clone(),
-                },
-                BorshToken::Int {
-                    width: width as u16,
-                    value: second_op.clone(),
-                },
-            ],
-        );
+        let return_value = contract
+            .function(
+                "mul",
+                &[
+                    BorshToken::Int {
+                        width: width as u16,
+                        value: first_operand_rand.clone(),
+                    },
+                    BorshToken::Int {
+                        width: width as u16,
+                        value: second_op.clone(),
+                    },
+                ],
+            )
+            .unwrap();
 
         let res = first_operand_rand.mul(second_op);
         assert_eq!(
             return_value,
-            vec![BorshToken::Int {
-                width: width as u16,
+            BorshToken::Int {
+                width: width.next_power_of_two() as u16,
                 value: res,
-            }]
+            }
         );
     }
 }
@@ -1011,27 +1056,29 @@ fn test_mul_within_range() {
             // Calculate a number that when multiplied by first_operand_rand, the result will not overflow N bits (the result of this division will cast the float result to int result, therefore lowering it. The result of multiplication will never overflow).
             let second_operand_rand = limit.div(&first_operand_rand);
 
-            let return_value = contract.function(
-                "mul",
-                &[
-                    BorshToken::Uint {
-                        width: width as u16,
-                        value: first_operand_rand.to_bigint().unwrap(),
-                    },
-                    BorshToken::Uint {
-                        width: width as u16,
-                        value: second_operand_rand.to_bigint().unwrap(),
-                    },
-                ],
-            );
+            let return_value = contract
+                .function(
+                    "mul",
+                    &[
+                        BorshToken::Uint {
+                            width: width as u16,
+                            value: first_operand_rand.to_bigint().unwrap(),
+                        },
+                        BorshToken::Uint {
+                            width: width as u16,
+                            value: second_operand_rand.to_bigint().unwrap(),
+                        },
+                    ],
+                )
+                .unwrap();
             let res = first_operand_rand * second_operand_rand;
 
             assert_eq!(
                 return_value,
-                vec![BorshToken::Uint {
-                    width: width as u16,
+                BorshToken::Uint {
+                    width: (width as u16).next_power_of_two(),
                     value: res.to_bigint().unwrap(),
-                }]
+                }
             );
         }
     }
@@ -1206,113 +1253,152 @@ fn int() {
 
         vm.constructor("test", &[]);
 
+        let returned_width = (width as u16).next_power_of_two();
+
         for _ in 0..10 {
             let a = rng.gen_bigint(width - 1);
             let b = rng.gen_bigint(width - 1);
 
-            let add = vm.function(
-                "add",
-                &[
-                    BorshToken::Int {
-                        width: width as u16,
-                        value: a.clone(),
-                    },
-                    BorshToken::Int {
-                        width: width as u16,
-                        value: b.clone(),
-                    },
-                ],
-            );
+            let add = vm
+                .function(
+                    "add",
+                    &[
+                        BorshToken::Int {
+                            width: width as u16,
+                            value: a.clone(),
+                        },
+                        BorshToken::Int {
+                            width: width as u16,
+                            value: b.clone(),
+                        },
+                    ],
+                )
+                .unwrap();
 
             let mut res = a.clone().add(&b);
             truncate_bigint(&mut res, width as usize);
 
             assert_eq!(
                 add,
-                vec![BorshToken::Int {
-                    width: width as u16,
+                BorshToken::Int {
+                    width: returned_width,
                     value: res,
-                }]
+                }
             );
 
-            let sub = vm.function(
-                "sub",
-                &[
-                    BorshToken::Int {
-                        width: width as u16,
-                        value: a.clone(),
-                    },
-                    BorshToken::Int {
-                        width: width as u16,
-                        value: b.clone(),
-                    },
-                ],
-            );
+            let sub = vm
+                .function(
+                    "sub",
+                    &[
+                        BorshToken::Int {
+                            width: width as u16,
+                            value: a.clone(),
+                        },
+                        BorshToken::Int {
+                            width: width as u16,
+                            value: b.clone(),
+                        },
+                    ],
+                )
+                .unwrap();
 
             let mut res = a.clone().sub(&b);
             truncate_bigint(&mut res, width as usize);
 
             assert_eq!(
                 sub,
-                vec![BorshToken::Int {
-                    width: width as u16,
+                BorshToken::Int {
+                    width: returned_width,
                     value: res,
-                }]
+                }
             );
 
-            let mul = vm.function(
-                "mul",
-                &[
-                    BorshToken::Int {
-                        width: width as u16,
-                        value: a.clone(),
-                    },
-                    BorshToken::Int {
-                        width: width as u16,
-                        value: b.clone(),
-                    },
-                ],
-            );
+            let mul = vm
+                .function(
+                    "mul",
+                    &[
+                        BorshToken::Int {
+                            width: width as u16,
+                            value: a.clone(),
+                        },
+                        BorshToken::Int {
+                            width: width as u16,
+                            value: b.clone(),
+                        },
+                    ],
+                )
+                .unwrap();
 
             let mut res = a.clone().mul(&b);
             truncate_bigint(&mut res, width as usize);
 
             assert_eq!(
                 mul,
-                vec![BorshToken::Int {
-                    width: width as u16,
+                BorshToken::Int {
+                    width: returned_width,
                     value: res,
-                }]
+                }
             );
 
             if b != BigInt::zero() {
-                let div = vm.function(
-                    "div",
-                    &[
-                        BorshToken::Int {
-                            width: width as u16,
-                            value: a.clone(),
-                        },
-                        BorshToken::Int {
-                            width: width as u16,
-                            value: b.clone(),
-                        },
-                    ],
-                );
+                let div = vm
+                    .function(
+                        "div",
+                        &[
+                            BorshToken::Int {
+                                width: width as u16,
+                                value: a.clone(),
+                            },
+                            BorshToken::Int {
+                                width: width as u16,
+                                value: b.clone(),
+                            },
+                        ],
+                    )
+                    .unwrap();
 
                 let mut res = a.clone().div(&b);
                 truncate_bigint(&mut res, width as usize);
 
                 assert_eq!(
                     div,
-                    vec![BorshToken::Int {
-                        width: width as u16,
+                    BorshToken::Int {
+                        width: returned_width,
                         value: res,
-                    }]
+                    }
                 );
 
-                let add = vm.function(
-                    "mod",
+                let add = vm
+                    .function(
+                        "mod",
+                        &[
+                            BorshToken::Int {
+                                width: width as u16,
+                                value: a.clone(),
+                            },
+                            BorshToken::Int {
+                                width: width as u16,
+                                value: b.clone(),
+                            },
+                        ],
+                    )
+                    .unwrap();
+
+                let mut res = a.clone().rem(&b);
+                truncate_bigint(&mut res, width as usize);
+
+                assert_eq!(
+                    add,
+                    BorshToken::Int {
+                        width: returned_width,
+                        value: res,
+                    }
+                );
+            }
+
+            let or = vm
+                .function(
+                    "or",
                     &[
                         BorshToken::Int {
                             width: width as u16,
@@ -1323,110 +1409,91 @@ fn int() {
                             value: b.clone(),
                         },
                     ],
-                );
-
-                let mut res = a.clone().rem(&b);
-                truncate_bigint(&mut res, width as usize);
-
-                assert_eq!(
-                    add,
-                    vec![BorshToken::Int {
-                        width: width as u16,
-                        value: res,
-                    }]
-                );
-            }
-
-            let or = vm.function(
-                "or",
-                &[
-                    BorshToken::Int {
-                        width: width as u16,
-                        value: a.clone(),
-                    },
-                    BorshToken::Int {
-                        width: width as u16,
-                        value: b.clone(),
-                    },
-                ],
-            );
+                )
+                .unwrap();
 
             let mut res = a.clone().bitor(&b);
             truncate_bigint(&mut res, width as usize);
 
             assert_eq!(
                 or,
-                vec![BorshToken::Int {
-                    width: width as u16,
+                BorshToken::Int {
+                    width: returned_width,
                     value: res,
-                }]
+                }
             );
 
-            let and = vm.function(
-                "and",
-                &[
-                    BorshToken::Int {
-                        width: width as u16,
-                        value: a.clone(),
-                    },
-                    BorshToken::Int {
-                        width: width as u16,
-                        value: b.clone(),
-                    },
-                ],
-            );
+            let and = vm
+                .function(
+                    "and",
+                    &[
+                        BorshToken::Int {
+                            width: width as u16,
+                            value: a.clone(),
+                        },
+                        BorshToken::Int {
+                            width: width as u16,
+                            value: b.clone(),
+                        },
+                    ],
+                )
+                .unwrap();
 
             let mut res = a.clone().bitand(&b);
             truncate_bigint(&mut res, width as usize);
 
             assert_eq!(
                 and,
-                vec![BorshToken::Int {
-                    width: width as u16,
+                BorshToken::Int {
+                    width: returned_width,
                     value: res,
-                }]
+                }
             );
 
-            let xor = vm.function(
-                "xor",
-                &[
-                    BorshToken::Int {
-                        width: width as u16,
-                        value: a.clone(),
-                    },
-                    BorshToken::Int {
-                        width: width as u16,
-                        value: b.clone(),
-                    },
-                ],
-            );
+            let xor = vm
+                .function(
+                    "xor",
+                    &[
+                        BorshToken::Int {
+                            width: width as u16,
+                            value: a.clone(),
+                        },
+                        BorshToken::Int {
+                            width: width as u16,
+                            value: b.clone(),
+                        },
+                    ],
+                )
+                .unwrap();
 
             let mut res = a.clone().bitxor(&b);
             truncate_bigint(&mut res, width as usize);
 
             assert_eq!(
                 xor,
-                vec![BorshToken::Int {
-                    width: width as u16,
+                BorshToken::Int {
+                    width: returned_width,
                     value: res,
-                }]
+                }
             );
 
             let r = rng.gen::<u32>() % (width as u32);
 
-            let shl = vm.function(
-                "shift_left",
-                &[
-                    BorshToken::Int {
-                        width: width as u16,
-                        value: a.clone(),
-                    },
-                    BorshToken::Uint {
-                        width: 32,
-                        value: BigInt::from(r),
-                    },
-                ],
-            );
+            let shl = vm
+                .function(
+                    "shift_left",
+                    &[
+                        BorshToken::Int {
+                            width: width as u16,
+                            value: a.clone(),
+                        },
+                        BorshToken::Uint {
+                            width: 32,
+                            value: BigInt::from(r),
+                        },
+                    ],
+                )
+                .unwrap();
 
             let mut res = a.clone().shl(r);
 
@@ -1434,34 +1501,36 @@ fn int() {
 
             assert_eq!(
                 shl,
-                vec![BorshToken::Int {
-                    width: width as u16,
+                BorshToken::Int {
+                    width: returned_width,
                     value: res,
-                }]
+                }
             );
 
-            let shr = vm.function(
-                "shift_right",
-                &[
-                    BorshToken::Int {
-                        width: width as u16,
-                        value: a.clone(),
-                    },
-                    BorshToken::Uint {
-                        width: 32,
-                        value: BigInt::from(r),
-                    },
-                ],
-            );
+            let shr = vm
+                .function(
+                    "shift_right",
+                    &[
+                        BorshToken::Int {
+                            width: width as u16,
+                            value: a.clone(),
+                        },
+                        BorshToken::Uint {
+                            width: 32,
+                            value: BigInt::from(r),
+                        },
+                    ],
+                )
+                .unwrap();
 
             let mut res = a.shr(r);
             truncate_bigint(&mut res, width as usize);
             assert_eq!(
                 shr,
-                vec![BorshToken::Int {
-                    width: width as u16,
+                BorshToken::Int {
+                    width: returned_width,
                     value: res,
-                }]
+                }
             );
         }
     }
@@ -1497,11 +1566,15 @@ fn bytes_cast() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function("to_bytes", &[BorshToken::FixedBytes(b"abcd".to_vec())]);
+    let returns = vm
+        .function("to_bytes", &[BorshToken::FixedBytes(b"abcd".to_vec())])
+        .unwrap();
 
-    assert_eq!(returns, vec![BorshToken::Bytes(b"abcd".to_vec())]);
+    assert_eq!(returns, BorshToken::Bytes(b"abcd".to_vec()));
 
-    let returns = vm.function("to_bytes5", &[BorshToken::Bytes(b"abcde".to_vec())]);
+    let returns = vm
+        .function("to_bytes5", &[BorshToken::Bytes(b"abcde".to_vec())])
+        .unwrap();
 
-    assert_eq!(returns, vec![BorshToken::FixedBytes(b"abcde".to_vec())]);
+    assert_eq!(returns, BorshToken::uint8_fixed_array(b"abcde".to_vec()));
 }

--- a/tests/solana_tests/primitives.rs
+++ b/tests/solana_tests/primitives.rs
@@ -28,7 +28,7 @@ fn assert_false() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     vm.function("assert_fails", &[]);
 }
@@ -45,7 +45,7 @@ fn assert_true() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     vm.function("assert_fails", &[]);
 }
@@ -77,7 +77,7 @@ fn boolean() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("return_true", &[]).unwrap();
 
@@ -111,7 +111,7 @@ fn address() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("return_address", &[]).unwrap();
 
@@ -153,7 +153,7 @@ fn test_enum() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("return_enum", &[]).unwrap();
 
@@ -213,7 +213,7 @@ fn bytes() {
 
         let mut vm = build_solidity(&src);
 
-        vm.constructor("test", &[]);
+        vm.constructor(&[]);
 
         let returns = vm.function("return_literal", &[]).unwrap();
 
@@ -410,7 +410,7 @@ fn uint() {
 
         let mut vm = build_solidity(&src);
 
-        vm.constructor("test", &[]);
+        vm.constructor(&[]);
 
         println!("width:{}", width);
         let returned_width = width.next_power_of_two();
@@ -771,7 +771,7 @@ fn test_power_overflow_boundaries() {
         .replace("intN", &format!("int{}", width));
 
         let mut contract = build_solidity_with_overflow_check(&src, true);
-        contract.constructor("test", &[]);
+        contract.constructor(&[]);
 
         let return_value = contract
             .function(
@@ -839,7 +839,7 @@ fn test_overflow_boundaries() {
         let returned_width = (width as u16).next_power_of_two();
 
         // Multiply the boundaries by 1.
-        contract.constructor("test", &[]);
+        contract.constructor(&[]);
         let return_value = contract
             .function(
                 "mul",
@@ -1003,7 +1003,7 @@ fn test_mul_within_range_signed() {
         let second_op = BigInt::from(*side.choose(&mut rng).unwrap());
         println!("second op : {:?}", second_op);
 
-        contract.constructor("test", &[]);
+        contract.constructor(&[]);
         let return_value = contract
             .function(
                 "mul",
@@ -1044,7 +1044,7 @@ fn test_mul_within_range() {
         .replace("intN", &format!("int{}", width));
 
         let mut contract = build_solidity_with_overflow_check(&src, true);
-        contract.constructor("test", &[]);
+        contract.constructor(&[]);
         for _ in 0..10 {
             // Max number to fit unsigned N bits is (2^N)-1
             let mut limit: BigUint = BigUint::from(2_u32).pow(width as u32);
@@ -1097,7 +1097,7 @@ fn test_overflow_detect_signed() {
         .replace("intN", &format!("int{}", width));
         let mut contract = build_solidity_with_overflow_check(&src, true);
 
-        contract.constructor("test", &[]);
+        contract.constructor(&[]);
 
         // The range of values that can be held in signed N bits is [-2^(N-1), 2^(N-1)-1] .
         let mut limit: BigInt = BigInt::from(2_u32).pow((width - 1) as u32);
@@ -1166,7 +1166,7 @@ fn test_overflow_detect_unsigned() {
         .replace("intN", &format!("int{}", width));
         let mut contract = build_solidity_with_overflow_check(&src, true);
 
-        contract.constructor("test", &[]);
+        contract.constructor(&[]);
 
         for _ in 0..10 {
             // N bits can hold the range [0, (2^N)-1]. Generate a value that overflows N bits
@@ -1251,7 +1251,7 @@ fn int() {
 
         let mut vm = build_solidity(&src);
 
-        vm.constructor("test", &[]);
+        vm.constructor(&[]);
 
         let returned_width = (width as u16).next_power_of_two();
 
@@ -1564,7 +1564,7 @@ fn bytes_cast() {
         "#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm
         .function("to_bytes", &[BorshToken::FixedBytes(b"abcd".to_vec())])

--- a/tests/solana_tests/rational.rs
+++ b/tests/solana_tests/rational.rs
@@ -23,24 +23,24 @@ fn rational() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function("test", &[]);
+    let returns = vm.function("test", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::from(4u8)
-        }]
+        }
     );
 
-    let returns = vm.function("test2", &[]);
+    let returns = vm.function("test2", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::from(4u8)
-        }]
+        }
     );
 
     let mut vm = build_solidity(
@@ -55,14 +55,14 @@ fn rational() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function("test", &[]);
+    let returns = vm.function("test", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::from(5u8)
-        }]
+        }
     );
 
     let mut vm = build_solidity(
@@ -77,14 +77,14 @@ fn rational() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function("test", &[]);
+    let returns = vm.function("test", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::from(24)
-        }]
+        }
     );
 
     let mut vm = build_solidity(
@@ -99,14 +99,14 @@ fn rational() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function("test", &[]);
+    let returns = vm.function("test", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::zero(),
-        }]
+        }
     );
 
     let mut vm = build_solidity(
@@ -121,14 +121,14 @@ fn rational() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function("test", &[]);
+    let returns = vm.function("test", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::from(4u8),
-        }]
+        }
     );
 
     let mut vm = build_solidity(
@@ -142,14 +142,14 @@ fn rational() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function("test", &[]);
+    let returns = vm.function("test", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::from(3u8)
-        }]
+        }
     );
 
     let mut vm = build_solidity(
@@ -163,14 +163,14 @@ fn rational() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function("test", &[]);
+    let returns = vm.function("test", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::from(15600u32)
-        }]
+        }
     );
 
     let mut vm = build_solidity(
@@ -184,13 +184,16 @@ fn rational() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function(
-        "test",
-        &[BorshToken::Uint {
-            width: 64,
-            value: BigInt::from(982451653u32),
-        }],
-    );
+    let returns = vm
+        .function(
+            "test",
+            &[BorshToken::Uint {
+                width: 64,
+                value: BigInt::from(982451653u32),
+            }],
+        )
+        .unwrap()
+        .unwrap_tuple();
 
     assert_eq!(
         returns,

--- a/tests/solana_tests/rational.rs
+++ b/tests/solana_tests/rational.rs
@@ -21,7 +21,7 @@ fn rational() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("test", &[]).unwrap();
 
@@ -53,7 +53,7 @@ fn rational() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("test", &[]).unwrap();
 
@@ -75,7 +75,7 @@ fn rational() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("test", &[]).unwrap();
 
@@ -97,7 +97,7 @@ fn rational() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("test", &[]).unwrap();
 
@@ -119,7 +119,7 @@ fn rational() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("test", &[]).unwrap();
 
@@ -140,7 +140,7 @@ fn rational() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("test", &[]).unwrap();
 
@@ -161,7 +161,7 @@ fn rational() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("test", &[]).unwrap();
 
@@ -182,7 +182,7 @@ fn rational() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm
         .function(

--- a/tests/solana_tests/returns.rs
+++ b/tests/solana_tests/returns.rs
@@ -31,7 +31,7 @@ fn return_single() {
             }
         }"#,
     );
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("f", &[]).unwrap();
     assert_eq!(
@@ -90,7 +90,7 @@ fn return_ternary() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
     let returns = vm.function("f", &[]).unwrap().unwrap_tuple();
 
     assert_eq!(
@@ -116,7 +116,7 @@ fn return_ternary() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
     let returns = vm.function("f", &[]).unwrap().unwrap_tuple();
 
     assert_eq!(
@@ -156,7 +156,7 @@ fn return_nothing() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
     let _returns = vm.function("strange", &[]);
     let _returns = vm.function("inc", &[]);
     let returns = vm.function("get", &[]).unwrap();
@@ -192,7 +192,7 @@ fn return_nothing() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
     let _returns = vm.function("f", &[]);
     let returns = vm.function("get", &[]).unwrap();
 
@@ -220,7 +220,7 @@ fn return_function() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
     let returns = vm.function("f", &[]).unwrap().unwrap_tuple();
 
     assert_eq!(
@@ -250,7 +250,7 @@ fn return_function() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
     let returns = vm.function("f", &[]).unwrap().unwrap_tuple();
 
     assert_eq!(

--- a/tests/solana_tests/returns.rs
+++ b/tests/solana_tests/returns.rs
@@ -33,49 +33,49 @@ fn return_single() {
     );
     vm.constructor("foo", &[]);
 
-    let returns = vm.function("f", &[]);
+    let returns = vm.function("f", &[]).unwrap();
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::from(2u8)
-        },]
+        },
     );
 
-    let returns = vm.function("g", &[]);
+    let returns = vm.function("g", &[]).unwrap();
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::from(3u8)
-        },]
+        },
     );
 
-    let returns = vm.function("h", &[]);
+    let returns = vm.function("h", &[]).unwrap();
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::from(2u8)
-        },]
+        },
     );
 
-    let returns = vm.function("i", &[]);
+    let returns = vm.function("i", &[]).unwrap();
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::from(24u8)
-        },]
+        },
     );
 
-    let returns = vm.function("j", &[]);
+    let returns = vm.function("j", &[]).unwrap();
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::from(5u8)
-        },]
+        },
     );
 }
 
@@ -91,7 +91,7 @@ fn return_ternary() {
     );
 
     vm.constructor("foo", &[]);
-    let returns = vm.function("f", &[]);
+    let returns = vm.function("f", &[]).unwrap().unwrap_tuple();
 
     assert_eq!(
         returns,
@@ -117,7 +117,7 @@ fn return_ternary() {
     );
 
     vm.constructor("foo", &[]);
-    let returns = vm.function("f", &[]);
+    let returns = vm.function("f", &[]).unwrap().unwrap_tuple();
 
     assert_eq!(
         returns,
@@ -159,14 +159,14 @@ fn return_nothing() {
     vm.constructor("foo", &[]);
     let _returns = vm.function("strange", &[]);
     let _returns = vm.function("inc", &[]);
-    let returns = vm.function("get", &[]);
+    let returns = vm.function("get", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::from(2u8)
-        },]
+        },
     );
 
     let mut vm = build_solidity(
@@ -194,14 +194,14 @@ fn return_nothing() {
 
     vm.constructor("foo", &[]);
     let _returns = vm.function("f", &[]);
-    let returns = vm.function("get", &[]);
+    let returns = vm.function("get", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::from(5u8)
-        },]
+        },
     );
 }
 
@@ -221,7 +221,7 @@ fn return_function() {
     );
 
     vm.constructor("foo", &[]);
-    let returns = vm.function("f", &[]);
+    let returns = vm.function("f", &[]).unwrap().unwrap_tuple();
 
     assert_eq!(
         returns,
@@ -251,7 +251,7 @@ fn return_function() {
     );
 
     vm.constructor("foo", &[]);
-    let returns = vm.function("f", &[]);
+    let returns = vm.function("f", &[]).unwrap().unwrap_tuple();
 
     assert_eq!(
         returns,

--- a/tests/solana_tests/signature_verify.rs
+++ b/tests/solana_tests/signature_verify.rs
@@ -59,16 +59,18 @@ fn verify() {
     println!("T: SIG: {}", hex::encode(&signature_bs));
     println!("T: MES: {}", hex::encode(message));
 
-    let returns = vm.function(
-        "verify",
-        &[
-            BorshToken::Address(keypair.public.to_bytes()),
-            BorshToken::Bytes(message.to_vec()),
-            BorshToken::Bytes(signature_bs.clone()),
-        ],
-    );
+    let returns = vm
+        .function(
+            "verify",
+            &[
+                BorshToken::Address(keypair.public.to_bytes()),
+                BorshToken::Bytes(message.to_vec()),
+                BorshToken::Bytes(signature_bs.clone()),
+            ],
+        )
+        .unwrap();
 
-    assert_eq!(returns, vec![BorshToken::Bool(false)]);
+    assert_eq!(returns, BorshToken::Bool(false));
 
     let instructions_account: Account = "Sysvar1nstructions1111111111111111111111111"
         .from_base58()
@@ -88,16 +90,18 @@ fn verify() {
 
     println!("Now try for real");
 
-    let returns = vm.function(
-        "verify",
-        &[
-            BorshToken::Address(keypair.public.to_bytes()),
-            BorshToken::Bytes(message.to_vec()),
-            BorshToken::Bytes(signature_bs.clone()),
-        ],
-    );
+    let returns = vm
+        .function(
+            "verify",
+            &[
+                BorshToken::Address(keypair.public.to_bytes()),
+                BorshToken::Bytes(message.to_vec()),
+                BorshToken::Bytes(signature_bs.clone()),
+            ],
+        )
+        .unwrap();
 
-    assert_eq!(returns, vec![BorshToken::Bool(true)]);
+    assert_eq!(returns, BorshToken::Bool(true));
 
     println!("now try with bad signature");
 
@@ -116,16 +120,18 @@ fn verify() {
         },
     );
 
-    let returns = vm.function(
-        "verify",
-        &[
-            BorshToken::Address(keypair.public.to_bytes()),
-            BorshToken::Bytes(message.to_vec()),
-            BorshToken::Bytes(signature_bs),
-        ],
-    );
+    let returns = vm
+        .function(
+            "verify",
+            &[
+                BorshToken::Address(keypair.public.to_bytes()),
+                BorshToken::Bytes(message.to_vec()),
+                BorshToken::Bytes(signature_bs),
+            ],
+        )
+        .unwrap();
 
-    assert_eq!(returns, vec![BorshToken::Bool(false)]);
+    assert_eq!(returns, BorshToken::Bool(false));
 }
 
 fn encode_instructions(public_key: &[u8], signature: &[u8], message: &[u8]) -> Vec<u8> {

--- a/tests/solana_tests/signature_verify.rs
+++ b/tests/solana_tests/signature_verify.rs
@@ -43,7 +43,7 @@ fn verify() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let mut csprng = rand_07::thread_rng();
     let keypair: Keypair = Keypair::generate(&mut csprng);

--- a/tests/solana_tests/simple.rs
+++ b/tests/solana_tests/simple.rs
@@ -20,7 +20,7 @@ fn simple() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     assert_eq!(vm.logs, "Hello from constructor");
 
@@ -44,7 +44,7 @@ fn format() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     assert_eq!(
         vm.logs,
@@ -69,7 +69,7 @@ fn parameters() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     vm.function(
         "test",
@@ -117,7 +117,7 @@ fn returns() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm
         .function(
@@ -146,7 +146,7 @@ fn returns() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm
         .function(
@@ -197,7 +197,7 @@ fn flipper() {
         }"#,
     );
 
-    vm.constructor("flipper", &[BorshToken::Bool(true)]);
+    vm.constructor(&[BorshToken::Bool(true)]);
 
     assert_eq!(
         vm.data()[0..17].to_vec(),
@@ -251,13 +251,10 @@ fn incrementer() {
         }"#,
     );
 
-    vm.constructor(
-        "incrementer",
-        &[BorshToken::Uint {
-            width: 32,
-            value: BigInt::from(5u8),
-        }],
-    );
+    vm.constructor(&[BorshToken::Uint {
+        width: 32,
+        value: BigInt::from(5u8),
+    }]);
 
     let returns = vm.function("get", &[]).unwrap();
 
@@ -332,7 +329,7 @@ fn two_arrays() {
         }"#,
     );
 
-    vm.constructor("two_arrays", &[]);
+    vm.constructor(&[]);
 }
 
 #[test]
@@ -357,7 +354,7 @@ fn dead_storage_bug() {
         }"#,
     );
 
-    vm.constructor("deadstorage", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("v", &[]).unwrap();
 
@@ -416,7 +413,7 @@ contract test3 {
     );
 
     // call constructor
-    runtime.constructor("test3", &[]);
+    runtime.constructor(&[]);
 
     for i in 0..=50 {
         let res = ((50 - i) * 100 + 5) + i * 1000;

--- a/tests/solana_tests/simple.rs
+++ b/tests/solana_tests/simple.rs
@@ -119,20 +119,22 @@ fn returns() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function(
-        "test",
-        &[BorshToken::Uint {
-            width: 32,
-            value: BigInt::from(10u8),
-        }],
-    );
+    let returns = vm
+        .function(
+            "test",
+            &[BorshToken::Uint {
+                width: 32,
+                value: BigInt::from(10u8),
+            }],
+        )
+        .unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 32,
             value: BigInt::from(100u8)
-        },]
+        }
     );
 
     let mut vm = build_solidity(
@@ -146,13 +148,16 @@ fn returns() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function(
-        "test",
-        &[BorshToken::Uint {
-            width: 64,
-            value: BigInt::from(982451653u64),
-        }],
-    );
+    let returns = vm
+        .function(
+            "test",
+            &[BorshToken::Uint {
+                width: 64,
+                value: BigInt::from(982451653u64),
+            }],
+        )
+        .unwrap()
+        .unwrap_tuple();
 
     assert_eq!(
         returns,
@@ -199,9 +204,9 @@ fn flipper() {
         hex::decode("6fc90ec500000000000000001800000001").unwrap()
     );
 
-    let returns = vm.function("get", &[]);
+    let returns = vm.function("get", &[]).unwrap();
 
-    assert_eq!(returns, vec![BorshToken::Bool(true)]);
+    assert_eq!(returns, BorshToken::Bool(true));
 
     vm.function("flip", &[]);
 
@@ -210,9 +215,9 @@ fn flipper() {
         hex::decode("6fc90ec500000000000000001800000000").unwrap()
     );
 
-    let returns = vm.function("get", &[]);
+    let returns = vm.function("get", &[]).unwrap();
 
-    assert_eq!(returns, vec![BorshToken::Bool(false)]);
+    assert_eq!(returns, BorshToken::Bool(false));
 }
 
 #[test]
@@ -254,14 +259,14 @@ fn incrementer() {
         }],
     );
 
-    let returns = vm.function("get", &[]);
+    let returns = vm.function("get", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 32,
             value: BigInt::from(5u8),
-        }]
+        }
     );
 
     vm.function(
@@ -272,14 +277,14 @@ fn incrementer() {
         }],
     );
 
-    let returns = vm.function("get", &[]);
+    let returns = vm.function("get", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 32,
             value: BigInt::from(10u8),
-        }]
+        }
     );
 }
 
@@ -354,14 +359,14 @@ fn dead_storage_bug() {
 
     vm.constructor("deadstorage", &[]);
 
-    let returns = vm.function("v", &[]);
+    let returns = vm.function("v", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::from(9991u16)
-        }]
+        }
     );
 }
 
@@ -416,43 +421,47 @@ contract test3 {
     for i in 0..=50 {
         let res = ((50 - i) * 100 + 5) + i * 1000;
 
-        let returns = runtime.function(
-            "foo",
-            &[BorshToken::Uint {
-                width: 32,
-                value: BigInt::from(i),
-            }],
-        );
+        let returns = runtime
+            .function(
+                "foo",
+                &[BorshToken::Uint {
+                    width: 32,
+                    value: BigInt::from(i),
+                }],
+            )
+            .unwrap();
 
         assert_eq!(
             returns,
-            vec![BorshToken::Uint {
+            BorshToken::Uint {
                 width: 32,
                 value: BigInt::from(res)
-            }]
+            }
         );
     }
 
     for i in 0..=50 {
         let res = (i + 1) * 10 + 1;
 
-        let returns = runtime.function(
-            "bar",
-            &[
-                BorshToken::Uint {
-                    width: 32,
-                    value: BigInt::from(i),
-                },
-                BorshToken::Bool(true),
-            ],
-        );
+        let returns = runtime
+            .function(
+                "bar",
+                &[
+                    BorshToken::Uint {
+                        width: 32,
+                        value: BigInt::from(i),
+                    },
+                    BorshToken::Bool(true),
+                ],
+            )
+            .unwrap();
 
         assert_eq!(
             returns,
-            vec![BorshToken::Uint {
+            BorshToken::Uint {
                 width: 32,
                 value: BigInt::from(res)
-            }]
+            }
         );
     }
 
@@ -463,23 +472,25 @@ contract test3 {
             res *= 3;
         }
 
-        let returns = runtime.function(
-            "bar",
-            &[
-                BorshToken::Uint {
-                    width: 32,
-                    value: BigInt::from(i),
-                },
-                BorshToken::Bool(false),
-            ],
-        );
+        let returns = runtime
+            .function(
+                "bar",
+                &[
+                    BorshToken::Uint {
+                        width: 32,
+                        value: BigInt::from(i),
+                    },
+                    BorshToken::Bool(false),
+                ],
+            )
+            .unwrap();
 
         assert_eq!(
             returns,
-            vec![BorshToken::Uint {
+            BorshToken::Uint {
                 width: 32,
                 value: BigInt::from(res)
-            }]
+            }
         );
     }
 
@@ -494,20 +505,22 @@ contract test3 {
             res += 1;
         }
 
-        let returns = runtime.function(
-            "baz",
-            &[BorshToken::Uint {
-                width: 32,
-                value: BigInt::from(i),
-            }],
-        );
+        let returns = runtime
+            .function(
+                "baz",
+                &[BorshToken::Uint {
+                    width: 32,
+                    value: BigInt::from(i),
+                }],
+            )
+            .unwrap();
 
         assert_eq!(
             returns,
-            vec![BorshToken::Uint {
+            BorshToken::Uint {
                 width: 32,
                 value: BigInt::from(res)
-            }]
+            }
         );
     }
 }

--- a/tests/solana_tests/storage.rs
+++ b/tests/solana_tests/storage.rs
@@ -18,7 +18,7 @@ fn simple() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
     let returns = vm.function("boom", &[]).unwrap();
     assert_eq!(
         returns,
@@ -48,7 +48,7 @@ fn simple() {
         }"#,
     );
 
-    vm.constructor("c", &[]);
+    vm.constructor(&[]);
     let returns = vm.function("func", &[]).unwrap();
     assert_eq!(
         returns,
@@ -76,7 +76,7 @@ fn string() {
         }"#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     assert_eq!(
         vm.data()[0..20].to_vec(),
@@ -152,7 +152,7 @@ fn bytes() {
         }"#,
     );
 
-    vm.constructor("c", &[]);
+    vm.constructor(&[]);
 
     assert_eq!(
         vm.data()[0..20].to_vec(),
@@ -264,7 +264,7 @@ fn bytes_set_subscript_range() {
         }"#,
     );
 
-    vm.constructor("c", &[]);
+    vm.constructor(&[]);
 
     vm.function(
         "set_foo_offset",
@@ -304,7 +304,7 @@ fn bytes_get_subscript_range() {
         }"#,
     );
 
-    vm.constructor("c", &[]);
+    vm.constructor(&[]);
 
     vm.function(
         "set_foo",
@@ -335,7 +335,7 @@ fn storage_alignment() {
         }"#,
     );
 
-    vm.constructor("c", &[]);
+    vm.constructor(&[]);
 
     assert_eq!(
         vm.data()[0..40].to_vec(),
@@ -367,7 +367,7 @@ fn bytes_push_pop() {
         }"#,
     );
 
-    vm.constructor("c", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("get_bs", &[]).unwrap();
 
@@ -410,7 +410,7 @@ fn bytes_empty_pop() {
         }"#,
     );
 
-    vm.constructor("c", &[]);
+    vm.constructor(&[]);
 
     vm.function("pop", &[]);
 }
@@ -442,7 +442,7 @@ fn simple_struct() {
         }"#,
     );
 
-    vm.constructor("c", &[]);
+    vm.constructor(&[]);
 
     vm.function("set_s2", &[]);
 
@@ -534,7 +534,7 @@ fn struct_in_struct() {
         }"#,
     );
 
-    vm.constructor("c", &[]);
+    vm.constructor(&[]);
 
     vm.function("set_s2", &[]);
 
@@ -643,7 +643,7 @@ fn string_in_struct() {
             }"#,
     );
 
-    vm.constructor("c", &[]);
+    vm.constructor(&[]);
 
     vm.function("set_s2", &[]);
 
@@ -758,7 +758,7 @@ fn complex_struct() {
         }"#,
     );
 
-    vm.constructor("c", &[]);
+    vm.constructor(&[]);
 
     vm.function("set_s2", &[]);
 

--- a/tests/solana_tests/strings.rs
+++ b/tests/solana_tests/strings.rs
@@ -20,7 +20,7 @@ fn storage_string_length() {
     }
     "#,
     );
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
 
     let _ = vm.function(
         "setString",
@@ -59,7 +59,7 @@ fn load_string_vector() {
       "#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
     let returns = vm.function("testLength", &[]).unwrap().unwrap_tuple();
     assert_eq!(
         returns[0],

--- a/tests/solana_tests/strings.rs
+++ b/tests/solana_tests/strings.rs
@@ -26,10 +26,10 @@ fn storage_string_length() {
         "setString",
         &[BorshToken::String("coffee_tastes_good".to_string())],
     );
-    let returns = vm.function("getLength", &[]);
+    let returns = vm.function("getLength", &[]).unwrap();
 
     assert_eq!(
-        returns[0],
+        returns,
         BorshToken::Uint {
             width: 32,
             value: BigInt::from(18u8),
@@ -60,7 +60,7 @@ fn load_string_vector() {
     );
 
     vm.constructor("Testing", &[]);
-    let returns = vm.function("testLength", &[]);
+    let returns = vm.function("testLength", &[]).unwrap().unwrap_tuple();
     assert_eq!(
         returns[0],
         BorshToken::Uint {
@@ -83,30 +83,36 @@ fn load_string_vector() {
         }
     );
 
-    let returns = vm.function(
-        "getString",
-        &[BorshToken::Uint {
-            width: 32,
-            value: BigInt::zero(),
-        }],
-    );
-    assert_eq!(returns[0], BorshToken::String("tea".to_string()));
+    let returns = vm
+        .function(
+            "getString",
+            &[BorshToken::Uint {
+                width: 32,
+                value: BigInt::zero(),
+            }],
+        )
+        .unwrap();
+    assert_eq!(returns, BorshToken::String("tea".to_string()));
 
-    let returns = vm.function(
-        "getString",
-        &[BorshToken::Uint {
-            width: 32,
-            value: BigInt::one(),
-        }],
-    );
-    assert_eq!(returns[0], BorshToken::String("coffe".to_string()));
+    let returns = vm
+        .function(
+            "getString",
+            &[BorshToken::Uint {
+                width: 32,
+                value: BigInt::one(),
+            }],
+        )
+        .unwrap();
+    assert_eq!(returns, BorshToken::String("coffe".to_string()));
 
-    let returns = vm.function(
-        "getString",
-        &[BorshToken::Uint {
-            width: 32,
-            value: BigInt::from(2u8),
-        }],
-    );
-    assert_eq!(returns[0], BorshToken::String("sixsix".to_string()));
+    let returns = vm
+        .function(
+            "getString",
+            &[BorshToken::Uint {
+                width: 32,
+                value: BigInt::from(2u8),
+            }],
+        )
+        .unwrap();
+    assert_eq!(returns, BorshToken::String("sixsix".to_string()));
 }

--- a/tests/solana_tests/unused_variable_elimination.rs
+++ b/tests/solana_tests/unused_variable_elimination.rs
@@ -39,30 +39,30 @@ fn test_returns() {
     let mut vm = build_solidity(file);
     vm.constructor("c1", &[]);
     let _ = vm.function("assign", &[]);
-    let returns = vm.function("pb1", &[]);
+    let returns = vm.function("pb1", &[]).unwrap();
 
     assert_eq!(
         returns,
-        vec![BorshToken::Int {
+        BorshToken::Int {
             width: 256,
             value: BigInt::from(5u8)
-        }]
+        }
     );
 
-    let returns = vm.function("test1", &[]);
+    let returns = vm.function("test1", &[]).unwrap();
     assert_eq!(
         returns,
-        vec![BorshToken::Int {
+        BorshToken::Int {
             width: 256,
             value: BigInt::from(52u8)
-        }]
+        }
     );
-    let returns = vm.function("test2", &[]);
+    let returns = vm.function("test2", &[]).unwrap();
     assert_eq!(
         returns,
-        vec![BorshToken::Int {
+        BorshToken::Int {
             width: 256,
             value: BigInt::from(5u8)
-        }]
+        }
     );
 }

--- a/tests/solana_tests/unused_variable_elimination.rs
+++ b/tests/solana_tests/unused_variable_elimination.rs
@@ -37,7 +37,7 @@ fn test_returns() {
     "#;
 
     let mut vm = build_solidity(file);
-    vm.constructor("c1", &[]);
+    vm.constructor(&[]);
     let _ = vm.function("assign", &[]);
     let returns = vm.function("pb1", &[]).unwrap();
 

--- a/tests/solana_tests/using.rs
+++ b/tests/solana_tests/using.rs
@@ -29,7 +29,7 @@ fn using_for_contracts() {
         }"#,
     );
 
-    runtime.constructor("C", &[]);
+    runtime.constructor(&[]);
     runtime.function("test", &[]);
 
     assert_eq!(runtime.logs, "Hello");
@@ -72,7 +72,7 @@ fn using_for_contracts() {
         }"#,
     );
 
-    runtime.constructor("foo", &[]);
+    runtime.constructor(&[]);
     runtime.function("test", &[]);
 
     assert_eq!(runtime.logs, "X libX contractx:2");

--- a/tests/solana_tests/vector_to_slice.rs
+++ b/tests/solana_tests/vector_to_slice.rs
@@ -21,7 +21,7 @@ fn test_slice_in_phi() {
 
     let mut vm = build_solidity(file);
     vm.constructor("c1", &[]);
-    let returns = vm.function("test", &[]);
+    let returns = vm.function("test", &[]).unwrap();
 
-    assert_eq!(returns, vec![BorshToken::String(String::from("Hello!"))]);
+    assert_eq!(returns, BorshToken::String(String::from("Hello!")));
 }

--- a/tests/solana_tests/vector_to_slice.rs
+++ b/tests/solana_tests/vector_to_slice.rs
@@ -20,7 +20,7 @@ fn test_slice_in_phi() {
     "#;
 
     let mut vm = build_solidity(file);
-    vm.constructor("c1", &[]);
+    vm.constructor(&[]);
     let returns = vm.function("test", &[]).unwrap();
 
     assert_eq!(returns, BorshToken::String(String::from("Hello!")));

--- a/tests/solana_tests/yul.rs
+++ b/tests/solana_tests/yul.rs
@@ -62,36 +62,39 @@ contract testing  {
 
     vm.constructor("testing", &[]);
 
-    let returns = vm.function("test_slot", &[]);
+    let returns = vm.function("test_slot", &[]).unwrap();
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::from(56016u16)
-        }]
+        }
     );
 
-    let returns = vm.function(
-        "call_data_array",
-        &[BorshToken::Array(vec![
-            BorshToken::Uint {
-                width: 32,
-                value: BigInt::from(3u8),
-            },
-            BorshToken::Uint {
-                width: 32,
-                value: BigInt::from(5u8),
-            },
-            BorshToken::Uint {
-                width: 32,
-                value: BigInt::from(7u8),
-            },
-            BorshToken::Uint {
-                width: 32,
-                value: BigInt::from(11u8),
-            },
-        ])],
-    );
+    let returns = vm
+        .function(
+            "call_data_array",
+            &[BorshToken::Array(vec![
+                BorshToken::Uint {
+                    width: 32,
+                    value: BigInt::from(3u8),
+                },
+                BorshToken::Uint {
+                    width: 32,
+                    value: BigInt::from(5u8),
+                },
+                BorshToken::Uint {
+                    width: 32,
+                    value: BigInt::from(7u8),
+                },
+                BorshToken::Uint {
+                    width: 32,
+                    value: BigInt::from(11u8),
+                },
+            ])],
+        )
+        .unwrap()
+        .unwrap_tuple();
 
     assert_eq!(
         returns,
@@ -108,7 +111,7 @@ contract testing  {
         ]
     );
 
-    let returns = vm.function("selector_address", &[]);
+    let returns = vm.function("selector_address", &[]).unwrap().unwrap_tuple();
     assert_eq!(
         returns,
         vec![
@@ -166,13 +169,16 @@ contract testing  {
 
     vm.constructor("testing", &[]);
 
-    let returns = vm.function(
-        "general_test",
-        &[BorshToken::Uint {
-            width: 64,
-            value: BigInt::from(5u8),
-        }],
-    );
+    let returns = vm
+        .function(
+            "general_test",
+            &[BorshToken::Uint {
+                width: 64,
+                value: BigInt::from(5u8),
+            }],
+        )
+        .unwrap()
+        .unwrap_tuple();
     assert_eq!(
         returns,
         vec![
@@ -187,13 +193,16 @@ contract testing  {
         ]
     );
 
-    let returns = vm.function(
-        "general_test",
-        &[BorshToken::Uint {
-            width: 64,
-            value: BigInt::from(78u8),
-        }],
-    );
+    let returns = vm
+        .function(
+            "general_test",
+            &[BorshToken::Uint {
+                width: 64,
+                value: BigInt::from(78u8),
+            }],
+        )
+        .unwrap()
+        .unwrap_tuple();
     assert_eq!(
         returns,
         vec![
@@ -208,13 +217,16 @@ contract testing  {
         ]
     );
 
-    let returns = vm.function(
-        "general_test",
-        &[BorshToken::Uint {
-            width: 64,
-            value: BigInt::from(259u16),
-        }],
-    );
+    let returns = vm
+        .function(
+            "general_test",
+            &[BorshToken::Uint {
+                width: 64,
+                value: BigInt::from(259u16),
+            }],
+        )
+        .unwrap()
+        .unwrap_tuple();
     assert_eq!(
         returns,
         vec![
@@ -266,34 +278,39 @@ contract c {
         0x11, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e,
         0x2f, 0x31,
     ];
-    let returns = vm.function(
-        "getByte",
-        &[BorshToken::Uint {
-            width: 256,
-            value: BigInt::from_bytes_be(Sign::Plus, &num),
-        }],
-    );
+    let returns = vm
+        .function(
+            "getByte",
+            &[BorshToken::Uint {
+                width: 256,
+                value: BigInt::from_bytes_be(Sign::Plus, &num),
+            }],
+        )
+        .unwrap();
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::from(6u8),
-        }]
+        }
     );
 
-    let returns = vm.function(
-        "divide",
-        &[
-            BorshToken::Uint {
-                width: 256,
-                value: BigInt::from(4u8),
-            },
-            BorshToken::Uint {
-                width: 256,
-                value: BigInt::from(3u8),
-            },
-        ],
-    );
+    let returns = vm
+        .function(
+            "divide",
+            &[
+                BorshToken::Uint {
+                    width: 256,
+                    value: BigInt::from(4u8),
+                },
+                BorshToken::Uint {
+                    width: 256,
+                    value: BigInt::from(3u8),
+                },
+            ],
+        )
+        .unwrap()
+        .unwrap_tuple();
     assert_eq!(
         returns,
         vec![
@@ -308,19 +325,22 @@ contract c {
         ]
     );
 
-    let returns = vm.function(
-        "divide",
-        &[
-            BorshToken::Uint {
-                width: 256,
-                value: BigInt::from(4u8),
-            },
-            BorshToken::Uint {
-                width: 256,
-                value: BigInt::zero(),
-            },
-        ],
-    );
+    let returns = vm
+        .function(
+            "divide",
+            &[
+                BorshToken::Uint {
+                    width: 256,
+                    value: BigInt::from(4u8),
+                },
+                BorshToken::Uint {
+                    width: 256,
+                    value: BigInt::zero(),
+                },
+            ],
+        )
+        .unwrap()
+        .unwrap_tuple();
     assert_eq!(
         returns,
         vec![
@@ -335,23 +355,26 @@ contract c {
         ]
     );
 
-    let returns = vm.function(
-        "mods",
-        &[
-            BorshToken::Uint {
-                width: 256,
-                value: BigInt::from(4u8),
-            },
-            BorshToken::Uint {
-                width: 256,
-                value: BigInt::from(2u8),
-            },
-            BorshToken::Uint {
-                width: 256,
-                value: BigInt::from(3u8),
-            },
-        ],
-    );
+    let returns = vm
+        .function(
+            "mods",
+            &[
+                BorshToken::Uint {
+                    width: 256,
+                    value: BigInt::from(4u8),
+                },
+                BorshToken::Uint {
+                    width: 256,
+                    value: BigInt::from(2u8),
+                },
+                BorshToken::Uint {
+                    width: 256,
+                    value: BigInt::from(3u8),
+                },
+            ],
+        )
+        .unwrap()
+        .unwrap_tuple();
     assert_eq!(
         returns,
         vec![
@@ -366,23 +389,26 @@ contract c {
         ]
     );
 
-    let returns = vm.function(
-        "mods",
-        &[
-            BorshToken::Uint {
-                width: 256,
-                value: BigInt::from(4u8),
-            },
-            BorshToken::Uint {
-                width: 256,
-                value: BigInt::from(2u8),
-            },
-            BorshToken::Uint {
-                width: 256,
-                value: BigInt::zero(),
-            },
-        ],
-    );
+    let returns = vm
+        .function(
+            "mods",
+            &[
+                BorshToken::Uint {
+                    width: 256,
+                    value: BigInt::from(4u8),
+                },
+                BorshToken::Uint {
+                    width: 256,
+                    value: BigInt::from(2u8),
+                },
+                BorshToken::Uint {
+                    width: 256,
+                    value: BigInt::zero(),
+                },
+            ],
+        )
+        .unwrap()
+        .unwrap_tuple();
     assert_eq!(
         returns,
         vec![
@@ -425,16 +451,19 @@ fn external_function() {
     vm.constructor("C", &[]);
     let mut addr: Vec<u8> = vec![0; 32];
     addr[5] = 90;
-    let returns = vm.function(
-        "test",
-        &[
-            BorshToken::Uint {
-                width: 256,
-                value: BigInt::from_bytes_le(Sign::Plus, addr.as_slice()),
-            },
-            BorshToken::FixedBytes(vec![1, 2, 3, 4, 5, 6, 7, 8]),
-        ],
-    );
+    let returns = vm
+        .function(
+            "test",
+            &[
+                BorshToken::Uint {
+                    width: 256,
+                    value: BigInt::from_bytes_le(Sign::Plus, addr.as_slice()),
+                },
+                BorshToken::FixedBytes(vec![1, 2, 3, 4, 5, 6, 7, 8]),
+            ],
+        )
+        .unwrap()
+        .unwrap_tuple();
 
     let selector = returns[0].clone().into_fixed_bytes().unwrap();
     assert_eq!(selector, vec![1, 2, 3, 4, 5, 6, 7, 8]);
@@ -471,8 +500,8 @@ contract testing  {
     );
 
     runtime.constructor("testing", &[]);
-    let returns = runtime.function("test_address", &[]);
-    let addr = returns[0].clone().into_bigint().unwrap();
+    let returns = runtime.function("test_address", &[]).unwrap();
+    let addr = returns.into_bigint().unwrap();
     let b_vec = addr.to_bytes_be().1;
     assert_eq!(&b_vec, runtime.stack[0].data.as_ref());
 
@@ -481,22 +510,22 @@ contract testing  {
         .get_mut(&runtime.stack[0].data)
         .unwrap()
         .lamports = 102;
-    let returns = runtime.function("test_balance", &[]);
+    let returns = runtime.function("test_balance", &[]).unwrap();
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::from(102u8),
-        },]
+        }
     );
 
-    let returns = runtime.function("test_selfbalance", &[]);
+    let returns = runtime.function("test_selfbalance", &[]).unwrap();
     assert_eq!(
         returns,
-        vec![BorshToken::Uint {
+        BorshToken::Uint {
             width: 256,
             value: BigInt::from(102u8),
-        },]
+        },
     );
 }
 
@@ -522,7 +551,7 @@ fn addmod_mulmod() {
 
     vm.constructor("foo", &[]);
 
-    let returns = vm.function("testMod", &[]);
+    let returns = vm.function("testMod", &[]).unwrap().unwrap_tuple();
     assert_eq!(
         returns,
         vec![
@@ -600,105 +629,119 @@ contract Testing {
 
     vm.constructor("Testing", &[]);
 
-    let returns = vm.function(
-        "switch_default",
-        &[BorshToken::Uint {
-            width: 256,
-            value: BigInt::one(),
-        }],
-    );
+    let returns = vm
+        .function(
+            "switch_default",
+            &[BorshToken::Uint {
+                width: 256,
+                value: BigInt::one(),
+            }],
+        )
+        .unwrap();
     assert_eq!(
-        returns[0],
+        returns,
         BorshToken::Uint {
             width: 256,
             value: BigInt::from(5u8),
         }
     );
 
-    let returns = vm.function(
-        "switch_default",
-        &[BorshToken::Uint {
-            width: 256,
-            value: BigInt::from(2u8),
-        }],
-    );
+    let returns = vm
+        .function(
+            "switch_default",
+            &[BorshToken::Uint {
+                width: 256,
+                value: BigInt::from(2u8),
+            }],
+        )
+        .unwrap();
     assert_eq!(
-        returns[0],
+        returns,
         BorshToken::Uint {
             width: 256,
             value: BigInt::from(6u8),
         },
     );
 
-    let returns = vm.function(
-        "switch_default",
-        &[BorshToken::Uint {
-            width: 256,
-            value: BigInt::from(6u8),
-        }],
-    );
+    let returns = vm
+        .function(
+            "switch_default",
+            &[BorshToken::Uint {
+                width: 256,
+                value: BigInt::from(6u8),
+            }],
+        )
+        .unwrap();
     assert_eq!(
-        returns[0],
+        returns,
         BorshToken::Uint {
             width: 256,
             value: BigInt::from(9u8),
         }
     );
 
-    let returns = vm.function(
-        "switch_no_default",
-        &[BorshToken::Uint {
-            width: 256,
-            value: BigInt::one(),
-        }],
-    );
+    let returns = vm
+        .function(
+            "switch_no_default",
+            &[BorshToken::Uint {
+                width: 256,
+                value: BigInt::one(),
+            }],
+        )
+        .unwrap();
     assert_eq!(
-        returns[0],
+        returns,
         BorshToken::Uint {
             width: 256,
             value: BigInt::from(3u8),
         },
     );
 
-    let returns = vm.function(
-        "switch_no_default",
-        &[BorshToken::Uint {
-            width: 256,
-            value: BigInt::from(2u8),
-        }],
-    );
+    let returns = vm
+        .function(
+            "switch_no_default",
+            &[BorshToken::Uint {
+                width: 256,
+                value: BigInt::from(2u8),
+            }],
+        )
+        .unwrap();
     assert_eq!(
-        returns[0],
+        returns,
         BorshToken::Uint {
             width: 256,
             value: BigInt::from(6u8),
         },
     );
 
-    let returns = vm.function(
-        "switch_no_default",
-        &[BorshToken::Uint {
-            width: 256,
-            value: BigInt::from(6u8),
-        }],
-    );
+    let returns = vm
+        .function(
+            "switch_no_default",
+            &[BorshToken::Uint {
+                width: 256,
+                value: BigInt::from(6u8),
+            }],
+        )
+        .unwrap();
     assert_eq!(
-        returns[0],
+        returns,
         BorshToken::Uint {
             width: 256,
             value: BigInt::from(4u8),
         },
     );
 
-    let returns = vm.function(
-        "switch_no_case",
-        &[BorshToken::Uint {
-            width: 256,
-            value: BigInt::from(3u8),
-        }],
-    );
+    let returns = vm
+        .function(
+            "switch_no_case",
+            &[BorshToken::Uint {
+                width: 256,
+                value: BigInt::from(3u8),
+            }],
+        )
+        .unwrap();
     assert_eq!(
-        returns[0],
+        returns,
         BorshToken::Uint {
             width: 256,
             value: BigInt::from(4u8),

--- a/tests/solana_tests/yul.rs
+++ b/tests/solana_tests/yul.rs
@@ -60,7 +60,7 @@ contract testing  {
       "#,
     );
 
-    vm.constructor("testing", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("test_slot", &[]).unwrap();
     assert_eq!(
@@ -167,7 +167,7 @@ contract testing  {
       "#,
     );
 
-    vm.constructor("testing", &[]);
+    vm.constructor(&[]);
 
     let returns = vm
         .function(
@@ -272,7 +272,7 @@ contract c {
         "#,
     );
 
-    vm.constructor("c", &[]);
+    vm.constructor(&[]);
     let num: Vec<u8> = vec![
         0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
         0x11, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e,
@@ -448,7 +448,7 @@ fn external_function() {
         "#,
     );
 
-    vm.constructor("C", &[]);
+    vm.constructor(&[]);
     let mut addr: Vec<u8> = vec![0; 32];
     addr[5] = 90;
     let returns = vm
@@ -499,7 +499,7 @@ contract testing  {
 }"#,
     );
 
-    runtime.constructor("testing", &[]);
+    runtime.constructor(&[]);
     let returns = runtime.function("test_address", &[]).unwrap();
     let addr = returns.into_bigint().unwrap();
     let b_vec = addr.to_bytes_be().1;
@@ -549,7 +549,7 @@ fn addmod_mulmod() {
         "#,
     );
 
-    vm.constructor("foo", &[]);
+    vm.constructor(&[]);
 
     let returns = vm.function("testMod", &[]).unwrap().unwrap_tuple();
     assert_eq!(
@@ -627,7 +627,7 @@ contract Testing {
         "#,
     );
 
-    vm.constructor("Testing", &[]);
+    vm.constructor(&[]);
 
     let returns = vm
         .function(


### PR DESCRIPTION
This PR generates Anchor ⚓ IDL files for Solidity contracts. There are unit tests for the functions that construct the `struct IDL`. All Solana runtime tests have been updated to leverage Anchor IDL instead of Ethereum ABI.

The final json file is not generated when we compile a Solidity contract to avoid confusing users with files that are not yet useful for them.