### PR TITLE
Fix mappings docs

### DIFF
--- a/docs/examples/mapping_type.sol
+++ b/docs/examples/mapping_type.sol
@@ -6,11 +6,10 @@ contract b {
     mapping(string => user) users;
 
     function add(string name, address addr) public {
-        // assigning to a storage variable creates a reference
-        user storage s = users[name];
-
-        s.exists = true;
-        s.addr = addr;
+        // This construction is not recommended, because it requires two hash calculations.
+        // See the tip below.
+        users[name].exists = true;
+        users[name].addr = addr;
     }
 
     function get(string name) public view returns (bool, address) {


### PR DESCRIPTION
This PR clarifies some aspects of the documentation about mappings:

1. The tip below the example is misleading, because its example shows the way NOT to use the mapping. I added the inefficient way in the example and moved the efficient one to the tip. This is aimed at a faster understanding because people don't like reading.
2. The link that describes hash flooding leads to an old page from 2011. The wikipedia page has more meaningful information about the attack.