### PR TITLE
Release v0.2.1: Rio

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update -y
 RUN apt-get upgrade -y
 RUN apt-get install -y libz-dev pkg-config libssl-dev git cmake ninja-build gcc g++ python3
 
-RUN git clone --single-branch --branch solana-rustc/13.0-2021-08-08 \
+RUN git clone --single-branch --branch solana-rustc/14.0-2022-03-22 \
     https://github.com/solana-labs/llvm-project.git
 
 WORKDIR /llvm-project
@@ -16,7 +16,7 @@ WORKDIR /llvm-project
 RUN cmake -G Ninja -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_ENABLE_TERMINFO=Off \
     -DLLVM_ENABLE_PROJECTS=clang\;lld \
     -DLLVM_TARGETS_TO_BUILD=WebAssembly\;BPF \
-    -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=/llvm13.0 llvm
+    -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=/llvm14.0 llvm
 
 RUN cmake --build . --target install
 
@@ -31,9 +31,9 @@ RUN apt-get autoclean
 # Get Rust
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain 1.63.0
 
-COPY --from=builder /llvm13.0 /llvm13.0/
+COPY --from=builder /llvm14.0 /llvm14.0/
 
-ENV PATH="/llvm13.0/bin:/root/.cargo/bin:/root/.local/share/solana/install/active_release/bin:${PATH}"
+ENV PATH="/llvm14.0/bin:/root/.cargo/bin:/root/.local/share/solana/install/active_release/bin:${PATH}"
 
 # Install Solana (x86-64 only, does not work on arm)
 RUN if test `arch` = x86_64; then sh -c "$(curl -sSfL https://release.solana.com/v1.11.10/install)"; fi

--- a/.github/workflows/build-llvm.yml
+++ b/.github/workflows/build-llvm.yml
@@ -13,8 +13,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: llvm13.0-1
-        release_name: LLVM Libraries v13.0 (v1)
+        tag_name: llvm14.0-1
+        release_name: LLVM Libraries v14.0 (v1)
         draft: false
         prerelease: false
 
@@ -23,18 +23,18 @@ jobs:
     runs-on: ubuntu-20.04
     needs: create
     steps:
-    - run: git clone --depth 1 --branch solana-rustc/13.0-2021-08-08 https://github.com/solana-labs/llvm-project.git
+    - run: git clone --depth 1 --branch solana-rustc/14.0-2022-03-22 https://github.com/solana-labs/llvm-project.git
     - name: Install Ninja
       uses: llvm/actions/install-ninja@main
     - run: cmake -G Ninja -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_ENABLE_TERMINFO=Off
         -DLLVM_ENABLE_LIBXML2=Off -DLLVM_ENABLE_ZLIB=Off
         -DLLVM_ENABLE_PROJECTS='clang;lld'
         -DLLVM_TARGETS_TO_BUILD='WebAssembly;BPF'
-        -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=../llvm13.0 llvm
+        -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=../llvm14.0 llvm
       working-directory: ./llvm-project/
     - run: cmake --build . --target install
       working-directory: ./llvm-project/
-    - run: tar Jcf ./llvm13.0-linux-x86-64.tar.xz ./llvm13.0/
+    - run: tar Jcf ./llvm14.0-linux-x86-64.tar.xz ./llvm14.0/
     - name: Upload Release Asset
       id: upload-release-asset
       uses: actions/upload-release-asset@v1
@@ -42,8 +42,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ needs.create.outputs.upload_url }}
-        asset_path: ./llvm13.0-linux-x86-64.tar.xz
-        asset_name: llvm13.0-linux-x86-64.tar.xz
+        asset_path: ./llvm14.0-linux-x86-64.tar.xz
+        asset_name: llvm14.0-linux-x86-64.tar.xz
         asset_content_type: application/x-xz
 
   linux-arm64:
@@ -52,16 +52,16 @@ jobs:
     if: ${{ github.repository_owner == 'hyperledger' }}
     needs: create
     steps:
-    - run: git clone --depth 1 --branch solana-rustc/13.0-2021-08-08 https://github.com/solana-labs/llvm-project.git
+    - run: git clone --depth 1 --branch solana-rustc/14.0-2022-03-22 https://github.com/solana-labs/llvm-project.git
     - run: cmake -G Ninja -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_ENABLE_TERMINFO=Off
         -DLLVM_ENABLE_LIBXML2=Off -DLLVM_ENABLE_ZLIB=Off
         -DLLVM_ENABLE_PROJECTS='clang;lld'
         -DLLVM_TARGETS_TO_BUILD='WebAssembly;BPF'
-        -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=../llvm13.0 llvm
+        -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=../llvm14.0 llvm
       working-directory: ./llvm-project/
     - run: cmake --build . --target install
       working-directory: ./llvm-project/
-    - run: tar Jcf ./llvm13.0-linux-arm64.tar.xz ./llvm13.0/
+    - run: tar Jcf ./llvm14.0-linux-arm64.tar.xz ./llvm14.0/
     - name: Upload Release Asset
       id: upload-release-asset
       uses: actions/upload-release-asset@v1
@@ -69,8 +69,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ needs.create.outputs.upload_url }}
-        asset_path: ./llvm13.0-linux-arm64.tar.xz
-        asset_name: llvm13.0-linux-arm64.tar.xz
+        asset_path: ./llvm14.0-linux-arm64.tar.xz
+        asset_name: llvm14.0-linux-arm64.tar.xz
         asset_content_type: application/x-xz
 
   mac-arm:
@@ -79,18 +79,18 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64, MacStadium]
     if: ${{ github.repository_owner == 'hyperledger' }}
     steps:
-    - run: git clone --depth 1 --branch solana-rustc/13.0-2021-08-08 https://github.com/solana-labs/llvm-project.git
+    - run: git clone --depth 1 --branch solana-rustc/14.0-2022-03-22 https://github.com/solana-labs/llvm-project.git
 #    - name: Install Ninja
 #      uses: llvm/actions/install-ninja@main
     - run: cmake -G Ninja -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_ENABLE_TERMINFO=Off
         -DLLVM_ENABLE_LIBXML2=Off -DLLVM_ENABLE_ZLIB=Off
         -DLLVM_ENABLE_PROJECTS='clang;lld'
         -DLLVM_TARGETS_TO_BUILD='WebAssembly;BPF'
-        -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=../llvm13.0 llvm
+        -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=../llvm14.0 llvm
       working-directory: ./llvm-project/
     - run: cmake --build . --target install
       working-directory: ./llvm-project/
-    - run: tar Jcf ./llvm13.0-mac-arm.tar.xz ./llvm13.0/
+    - run: tar Jcf ./llvm14.0-mac-arm.tar.xz ./llvm14.0/
     - name: Upload Release Asset
       id: upload-release-asset
       uses: actions/upload-release-asset@v1
@@ -98,8 +98,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ needs.create.outputs.upload_url }}
-        asset_path: ./llvm13.0-mac-arm.tar.xz
-        asset_name: llvm13.0-mac-arm.tar.xz
+        asset_path: ./llvm14.0-mac-arm.tar.xz
+        asset_name: llvm14.0-mac-arm.tar.xz
         asset_content_type: application/x-xz
 
   mac-intel:
@@ -107,18 +107,18 @@ jobs:
     needs: create
     runs-on: macos-11
     steps:
-    - run: git clone --depth 1 --branch solana-rustc/13.0-2021-08-08 https://github.com/solana-labs/llvm-project.git
+    - run: git clone --depth 1 --branch solana-rustc/14.0-2022-03-22 https://github.com/solana-labs/llvm-project.git
     - name: Install Ninja
       uses: llvm/actions/install-ninja@main
     - run: cmake -G Ninja -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_ENABLE_TERMINFO=Off
         -DLLVM_ENABLE_LIBXML2=Off -DLLVM_ENABLE_ZLIB=Off
         -DLLVM_ENABLE_PROJECTS='clang;lld'
         -DLLVM_TARGETS_TO_BUILD='WebAssembly;BPF'
-        -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=../llvm13.0 llvm
+        -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=../llvm14.0 llvm
       working-directory: ./llvm-project/
     - run: cmake --build . --target install
       working-directory: ./llvm-project/
-    - run: tar Jcf ./llvm13.0-mac-intel.tar.xz ./llvm13.0/
+    - run: tar Jcf ./llvm14.0-mac-intel.tar.xz ./llvm14.0/
     - name: Upload Release Asset
       id: upload-release-asset
       uses: actions/upload-release-asset@v1
@@ -126,8 +126,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ needs.create.outputs.upload_url }}
-        asset_path: ./llvm13.0-mac-intel.tar.xz
-        asset_name: llvm13.0-mac-intel.tar.xz
+        asset_path: ./llvm14.0-mac-intel.tar.xz
+        asset_name: llvm14.0-mac-intel.tar.xz
         asset_content_type: application/x-xz
 
   windows:
@@ -136,7 +136,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - run: Get-Volume
-    - run: git clone --depth 1 --branch solana-rustc/13.0-2021-08-08 https://github.com/solana-labs/llvm-project.git
+    - run: git clone --depth 1 --branch solana-rustc/14.0-2022-03-22 https://github.com/solana-labs/llvm-project.git
       # We may not have enough space to compile llvm, see https://github.com/actions/virtual-environments/issues/326
       working-directory: C:\
     - name: Setup Windows
@@ -148,11 +148,11 @@ jobs:
     - run: cmake -G Ninja -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_ENABLE_TERMINFO=Off
         -DLLVM_ENABLE_LIBXML2=Off -DLLVM_ENABLE_ZLIB=Off
         '-DLLVM_ENABLE_PROJECTS=clang;lld'
-        -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=C:/llvm13.0 llvm
+        -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=C:/llvm14.0 llvm
       working-directory: C:\llvm-project
     - run: cmake --build . --target install
       working-directory: C:\llvm-project
-    - run: Compress-Archive -Path C:\llvm13.0 -DestinationPath C:\llvm13.0-win.zip
+    - run: Compress-Archive -Path C:\llvm14.0 -DestinationPath C:\llvm14.0-win.zip
     - name: Upload Release Asset
       id: upload-release-asset
       uses: actions/upload-release-asset@v1
@@ -160,6 +160,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ needs.create.outputs.upload_url }}
-        asset_path: C:\llvm13.0-win.zip
-        asset_name: llvm13.0-win.zip
+        asset_path: C:\llvm14.0-win.zip
+        asset_name: llvm14.0-win.zip
         asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,27 +14,27 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: recursive
-    - run: git clone --depth 1 --branch solana-rustc/13.0-2021-08-08 https://github.com/solana-labs/llvm-project.git
+    - run: git clone --depth 1 --branch solana-rustc/14.0-2022-03-22 https://github.com/solana-labs/llvm-project.git
     - name: Install Ninja
       uses: llvm/actions/install-ninja@main
     - run: cmake -G Ninja -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_ENABLE_TERMINFO=Off
         -DLLVM_ENABLE_LIBXML2=Off -DLLVM_ENABLE_ZLIB=Off
         -DLLVM_ENABLE_PROJECTS='clang;lld'
         -DLLVM_TARGETS_TO_BUILD='WebAssembly;BPF'
-        -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=../llvm13.0 llvm
+        -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=../llvm14.0 llvm
       working-directory: ./llvm-project/
     - run: cmake --build . --target install
       working-directory: ./llvm-project/
-    - run: tar Jcf ./llvm13.0-linux-x86-64.tar.xz ./llvm13.0/
+    - run: tar Jcf ./llvm14.0-linux-x86-64.tar.xz ./llvm14.0/
     - name: Upload llvm
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: llvm13.0-linux-x86-64.tar.xz
-        asset_name: llvm13.0-linux-x86-64.tar.xz
+        file: llvm14.0-linux-x86-64.tar.xz
+        asset_name: llvm14.0-linux-x86-64.tar.xz
         tag: ${{ github.ref }}
     - name: Add LLVM to Path
-      run: echo "$(pwd)/llvm13.0/bin" >> $GITHUB_PATH
+      run: echo "$(pwd)/llvm14.0/bin" >> $GITHUB_PATH
     - name: Rust stable
       run: rustup default 1.63.0
     - name: Build
@@ -58,26 +58,26 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: recursive
-    - run: git clone --depth 1 --branch solana-rustc/13.0-2021-08-08 https://github.com/solana-labs/llvm-project.git
+    - run: git clone --depth 1 --branch solana-rustc/14.0-2022-03-22 https://github.com/solana-labs/llvm-project.git
     - run: cmake -G Ninja -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_ENABLE_TERMINFO=Off
         -DLLVM_ENABLE_LIBXML2=Off -DLLVM_ENABLE_ZLIB=Off
         -DLLVM_ENABLE_PROJECTS='clang;lld'
         -DLLVM_TARGETS_TO_BUILD='WebAssembly;BPF'
-        -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=../llvm13.0 llvm
+        -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=../llvm14.0 llvm
       working-directory: ./llvm-project/
     - run: cmake --build . --target install
       working-directory: ./llvm-project/
       # compression takes a long time on linux-arm64, use multithreaded compression
-    - run: tar cf ./llvm13.0-linux-arm64.tar.xz -I 'xz -T 0' ./llvm13.0/
+    - run: tar cf ./llvm14.0-linux-arm64.tar.xz -I 'xz -T 0' ./llvm14.0/
     - name: Upload llvm
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: llvm13.0-linux-arm64.tar.xz
-        asset_name: llvm13.0-linux-arm64.tar.xz
+        file: llvm14.0-linux-arm64.tar.xz
+        asset_name: llvm14.0-linux-arm64.tar.xz
         tag: ${{ github.ref }}
     - name: Add LLVM to Path
-      run: echo "$(pwd)/llvm13.0/bin" >> $GITHUB_PATH
+      run: echo "$(pwd)/llvm14.0/bin" >> $GITHUB_PATH
     - name: Rust stable
       run: rustup default 1.63.0
     - name: Build
@@ -101,7 +101,7 @@ jobs:
       with:
         submodules: recursive
     - uses: dtolnay/rust-toolchain@1.63.0
-    - run: git clone --depth 1 --branch solana-rustc/13.0-2021-08-08 https://github.com/solana-labs/llvm-project.git
+    - run: git clone --depth 1 --branch solana-rustc/14.0-2022-03-22 https://github.com/solana-labs/llvm-project.git
       # We may not have enough space to compile llvm, see https://github.com/actions/virtual-environments/issues/326
       working-directory: C:\
     - name: Setup Windows
@@ -113,20 +113,20 @@ jobs:
     - run: cmake -G Ninja -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_ENABLE_TERMINFO=Off
         -DLLVM_ENABLE_LIBXML2=Off -DLLVM_ENABLE_ZLIB=Off
         '-DLLVM_ENABLE_PROJECTS=clang;lld'
-        -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=C:/llvm13.0 llvm
+        -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=C:/llvm14.0 llvm
       working-directory: C:\llvm-project
     - run: cmake --build . --target install
       working-directory: C:\llvm-project
-    - run: Compress-Archive -Path C:\llvm13.0 -DestinationPath C:\llvm13.0-win.zip
+    - run: Compress-Archive -Path C:\llvm14.0 -DestinationPath C:\llvm14.0-win.zip
     - name: Upload llvm
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: C:\llvm13.0-win.zip
-        asset_name: llvm13.0-win.zip
+        file: C:\llvm14.0-win.zip
+        asset_name: llvm14.0-win.zip
         tag: ${{ github.ref }}
     - name: Add LLVM to Path
-      run: echo "c:\llvm13.0\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
+      run: echo "c:\llvm14.0\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
     - name: Build
       run: cargo build --release --verbose
     - name: Run tests
@@ -149,27 +149,27 @@ jobs:
       with:
         submodules: recursive
     - uses: dtolnay/rust-toolchain@1.63.0
-    - run: git clone --depth 1 --branch solana-rustc/13.0-2021-08-08 https://github.com/solana-labs/llvm-project.git
+    - run: git clone --depth 1 --branch solana-rustc/14.0-2022-03-22 https://github.com/solana-labs/llvm-project.git
     - name: Install Ninja
       uses: llvm/actions/install-ninja@main
     - run: cmake -G Ninja -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_ENABLE_TERMINFO=Off
         -DLLVM_ENABLE_LIBXML2=Off -DLLVM_ENABLE_ZLIB=Off
         -DLLVM_ENABLE_PROJECTS='clang;lld'
         -DLLVM_TARGETS_TO_BUILD='WebAssembly;BPF'
-        -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=../llvm13.0 llvm
+        -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=../llvm14.0 llvm
       working-directory: ./llvm-project/
     - run: cmake --build . --target install
       working-directory: ./llvm-project/
-    - run: tar Jcf ./llvm13.0-mac-arm.tar.xz ./llvm13.0/
+    - run: tar Jcf ./llvm14.0-mac-arm.tar.xz ./llvm14.0/
     - name: Upload llvm
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: llvm13.0-mac-arm.tar.xz
-        asset_name: llvm13.0-mac-arm.tar.xz
+        file: llvm14.0-mac-arm.tar.xz
+        asset_name: llvm14.0-mac-arm.tar.xz
         tag: ${{ github.ref }}
     - name: Add LLVM to Path
-      run: echo "$(pwd)/llvm13.0/bin" >> $GITHUB_PATH
+      run: echo "$(pwd)/llvm14.0/bin" >> $GITHUB_PATH
     - name: Build
       run: cargo build --release --verbose
     - name: Run tests
@@ -194,27 +194,27 @@ jobs:
       with:
         submodules: recursive
     - uses: dtolnay/rust-toolchain@1.63.0
-    - run: git clone --depth 1 --branch solana-rustc/13.0-2021-08-08 https://github.com/solana-labs/llvm-project.git
+    - run: git clone --depth 1 --branch solana-rustc/14.0-2022-03-22 https://github.com/solana-labs/llvm-project.git
     - name: Install Ninja
       uses: llvm/actions/install-ninja@main
     - run: cmake -G Ninja -DLLVM_ENABLE_ASSERTIONS=On -DLLVM_ENABLE_TERMINFO=Off
         -DLLVM_ENABLE_LIBXML2=Off -DLLVM_ENABLE_ZLIB=Off
         -DLLVM_ENABLE_PROJECTS='clang;lld'
         -DLLVM_TARGETS_TO_BUILD='WebAssembly;BPF'
-        -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=../llvm13.0 llvm
+        -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=../llvm14.0 llvm
       working-directory: ./llvm-project/
     - run: cmake --build . --target install
       working-directory: ./llvm-project/
-    - run: tar Jcf ./llvm13.0-mac-intel.tar.xz ./llvm13.0/
+    - run: tar Jcf ./llvm14.0-mac-intel.tar.xz ./llvm14.0/
     - name: Upload llvm
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: llvm13.0-mac-intel.tar.xz
-        asset_name: llvm13.0-mac-intel.tar.xz
+        file: llvm14.0-mac-intel.tar.xz
+        asset_name: llvm14.0-mac-intel.tar.xz
         tag: ${{ github.ref }}
     - name: Add LLVM to Path
-      run: echo "$(pwd)/llvm13.0/bin" >> $GITHUB_PATH
+      run: echo "$(pwd)/llvm14.0/bin" >> $GITHUB_PATH
     - name: Build
       run: cargo build --release --verbose
     - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,11 +106,11 @@ jobs:
       with:
         submodules: recursive
     - name: Download LLVM
-      run: curl -sSL -o c:\llvm.zip https://github.com/hyperledger/solang/releases/download/v0.2.0/llvm13.0-win.zip
+      run: curl -sSL -o c:\llvm.zip https://github.com/hyperledger/solang/releases/download/v0.2.1/llvm14.0-win.zip
     - name: Extract LLVM
       run: unzip c:\llvm.zip -d c:/
     - name: Add LLVM to Path
-      run: echo "c:\llvm13.0\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
+      run: echo "c:\llvm14.0\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
     - uses: dtolnay/rust-toolchain@1.63.0
       with:
         components: clippy
@@ -137,11 +137,11 @@ jobs:
         submodules: recursive
     - uses: dtolnay/rust-toolchain@1.63.0
     - name: Get LLVM
-      run: curl -L --output llvm13.0-mac-arm.tar.xz https://github.com/hyperledger/solang/releases/download/v0.2.0/llvm13.0-mac-arm.tar.xz
+      run: curl -L --output llvm14.0-mac-arm.tar.xz https://github.com/hyperledger/solang/releases/download/v0.2.1/llvm14.0-mac-arm.tar.xz
     - name: Extract LLVM
-      run: tar Jxf llvm13.0-mac-arm.tar.xz
+      run: tar Jxf llvm14.0-mac-arm.tar.xz
     - name: Add LLVM to Path
-      run: echo "$(pwd)/llvm13.0/bin" >> $GITHUB_PATH
+      run: echo "$(pwd)/llvm14.0/bin" >> $GITHUB_PATH
     - name: Build
       run: cargo build --verbose
     - name: Run tests
@@ -161,11 +161,11 @@ jobs:
         submodules: recursive
     - uses: dtolnay/rust-toolchain@1.63.0
     - name: Get LLVM
-      run: wget -q -O llvm13.0-mac-intel.tar.xz https://github.com/hyperledger/solang/releases/download/v0.2.0/llvm13.0-mac-intel.tar.xz
+      run: wget -q -O llvm14.0-mac-intel.tar.xz https://github.com/hyperledger/solang/releases/download/v0.2.1/llvm14.0-mac-intel.tar.xz
     - name: Extract LLVM
-      run: tar Jxf llvm13.0-mac-intel.tar.xz
+      run: tar Jxf llvm14.0-mac-intel.tar.xz
     - name: Add LLVM to Path
-      run: echo "$(pwd)/llvm13.0/bin" >> $GITHUB_PATH
+      run: echo "$(pwd)/llvm14.0/bin" >> $GITHUB_PATH
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,29 @@
 All notable changes to [Solang](https://github.com/hyperledger/solang/)
 will be documented here.
 
-## Unreleased
+## v0.2.1 Rio
+
+### Added
+- The Anchor IDL data structure is now generated for every Solana contract, although the actual IDL json file is not yet saved.
+[LucasSte](https://github.com/LucasSte)
 
 ### Changed
+- The Solana target now utilizes eight byte Anchor discriminators for function dispatch instead
+of the four byte Ethereum selectors. [LucasSte](https://github.com/LucasSte)
+- The deployment of contracts on Solana now follows the same scheme as Anchor. [seanyoung](https://github.com/seanyoung)
+- Compares between rational literals and integers are not allowed. [seanyoung](https://github.com/seanyoung)
 - Overriding the function selector value is now done using the `@selector([1, 2, 3, 4])`
   syntax, and the old syntax `selector=hex"12345678"` has been removed.
-- 'msg.sender' was not implemented correctly on Solana, and
+- `msg.sender` was not implemented correctly on Solana, and
   [has now been removed](https://solang.readthedocs.io/en/latest/targets/solana.html#msg-sender-solana).
   [seanyoung](https://github.com/seanyoung)
+- Solang now uses LLVM 14. [LucasSte](https://github.com/LucasSte)
 
-## v0.2.0.0 Berlin
+### Fixed
+- Many bugs have been fixed by [seanyoung](https://github.com/seanyoung), [LucasSte](https://github.com/LucasSte)
+  and [xermicus](https://github.com/xermicus)
+
+## v0.2.0 Berlin
 We are happy to release solang `v0.2.0` codenamed `Berlin` today. Aside from
 containing many small fixes and improvements, this release marks a milestone
 towards maturing our Substrate compilation target: any regressions building up

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "solang"
-version = "0.2.0"
-authors = ["Sean Young <sean@mess.org>"]
+version = "0.2.1"
+authors = ["Sean Young <sean@mess.org>", "Lucas Steuernagel <lucas.tnagel@gmail.com>", "Cyrill Leutwiler <bigcyrill@hotmail.com>"]
 homepage = "https://github.com/hyperledger/solang"
 documentation = "https://solang.readthedocs.io/"
 license = "Apache-2.0"
@@ -28,7 +28,7 @@ tiny-keccak = { version = "2.0", features = ["keccak"] }
 serde_json = "1.0"
 serde = "1.0"
 serde_derive = { version = "1.0" }
-inkwell = { version = "0.1.0-beta.5", features = ["target-webassembly", "target-bpf", "no-libffi-linking", "llvm13-0"], optional = true }
+inkwell = { version = "0.1.0-beta.5", features = ["target-webassembly", "target-bpf", "no-libffi-linking", "llvm14-0"], optional = true }
 blake2-rfc = "0.2.18"
 handlebars = "4.2"
 contract-metadata = "1.5.0"
@@ -46,7 +46,7 @@ itertools = "0.10"
 num-rational = "0.4"
 indexmap = "1.8"
 once_cell = "1.16"
-solang-parser = { path = "solang-parser", version = "0.2.0" }
+solang-parser = { path = "solang-parser", version = "0.2.1" }
 codespan-reporting = "0.11"
 phf = { version = "0.11", features = ["macros"] }
 rust-lapper = "1.0"

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -6,12 +6,17 @@
 - Copy the contents of the CHANGELOG for this release into commit message,
   using `git commit -s --cleanup=whitespace` so the that the lines beginning
   with `#` are not removed.
-- Ensure the cargo publish is happy `cargo publish --dry-run`
 - Try the release github actions by pushing a tag to your solang fork
 - Ensure the release text uses the markdown formatting
 - If build succeeds, merge the release commits
+- Open a PR on Solang's repository containing the release changes, and wait for approval
+- Run `cargo publish --dry-run` in the `solang-parser` folder.
+- Publish the solang-parser crate, by running `cargo publish` in the solang-parser folder
+- Ensure the cargo publish is happy `cargo publish --dry-run`
+- Merge the PR
 - Apply tag to merged commit on main branch
 - Push tag to origin
+- When changing LLVM version, regenerate the CI image using GitHub's manual actions trigger
 - Wait for build to succeed
 - `cargo publish`
 - Release new version of vscode plugin if needed

--- a/build.rs
+++ b/build.rs
@@ -35,14 +35,12 @@ fn main() {
         let libdir = String::from_utf8(libdir.stdout).unwrap();
 
         println!("cargo:libdir={}", libdir);
-        for lib in &["lldELF", "lldDriver", "lldCore", "lldCommon", "lldWasm"] {
+        for lib in &["lldELF", "lldCommon", "lldWasm"] {
             println!("cargo:rustc-link-lib=static={}", lib);
         }
 
-        // And all the symbols were not using, needed by Windows and debug builds
-        for lib in &["lldReaderWriter", "lldMachO", "lldYAML"] {
-            println!("cargo:rustc-link-lib=static={}", lib);
-        }
+        // And all the symbols we're not using, needed by Windows and debug builds
+        println!("cargo:rustc-link-lib=static=lldMachO");
     }
 
     let output = Command::new("git")

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -28,11 +28,11 @@ Option 2: Download binaries
 
 There are binaries available on github releases:
 
-- `Linux x86-64 <https://github.com/hyperledger/solang/releases/download/v0.2.0/solang-linux-x86-64>`_
-- `Linux arm64 <https://github.com/hyperledger/solang/releases/download/v0.2.0/solang-linux-arm64>`_
-- `Windows x64 <https://github.com/hyperledger/solang/releases/download/v0.2.0/solang.exe>`_
-- `MacOS intel <https://github.com/hyperledger/solang/releases/download/v0.2.0/solang-mac-intel>`_
-- `MacOS arm <https://github.com/hyperledger/solang/releases/download/v0.2.0/solang-mac-arm>`_
+- `Linux x86-64 <https://github.com/hyperledger/solang/releases/download/v0.2.1/solang-linux-x86-64>`_
+- `Linux arm64 <https://github.com/hyperledger/solang/releases/download/v0.2.1/solang-linux-arm64>`_
+- `Windows x64 <https://github.com/hyperledger/solang/releases/download/v0.2.1/solang.exe>`_
+- `MacOS intel <https://github.com/hyperledger/solang/releases/download/v0.2.1/solang-mac-intel>`_
+- `MacOS arm <https://github.com/hyperledger/solang/releases/download/v0.2.1/solang-mac-arm>`_
 
 Download the file and save it somewhere in your ``$PATH``, for example the bin directory in your home directory. If the
 path you use is not already in ``$PATH``, then you need to add it yourself.
@@ -56,7 +56,7 @@ Option 3: Use ghcr.io/hyperledger/solang containers
 
 New images are automatically made available on
 `solang containers <https://github.com/hyperledger/solang/pkgs/container/solang>`_.
-There is a release `v0.2.0` tag and a `latest` tag:
+There is a release `v0.2.1` tag and a `latest` tag:
 
 .. code-block:: bash
 
@@ -113,7 +113,7 @@ These patches make it possible to generate code for Solana, and fixes
 concurrency issues in the lld linker.
 
 You can either download the pre-built libraries from
-`github <https://github.com/hyperledger/solang/releases/tag/v0.2.0>`_
+`github <https://github.com/hyperledger/solang/releases/tag/v0.2.1>`_
 or :ref:`build your own from source <llvm-from-source>`. After that, you need to add the ``bin`` of your
 LLVM directory to your path, so that the build system of Solang can find the correct version of LLVM to use.
 
@@ -121,39 +121,40 @@ Linux
 ~~~~~
 
 A pre-built version of LLVM, specifically configured for Solang, is available at
-`<https://github.com/hyperledger/solang/releases/download/v0.2.0/llvm13.0-linux-x86-64.tar.xz>`_.
+`<https://github.com/hyperledger/solang/releases/download/v0.2.1/llvm14.0-linux-x86-64.tar.xz>`_ for x86 processors
+and at `<https://github.com/hyperledger/solang/releases/download/v0.2.1/llvm14.0-linux-arm64.tar.xz>`_ for ARM.
 After downloading, untar the file in a terminal and add it to your path.
 
 .. code-block:: bash
 
-	tar Jxf llvm13.0-linux-x86-64.tar.xz
-	export PATH=$(pwd)/llvm13.0/bin:$PATH
+	tar Jxf llvm14.0-linux-x86-64.tar.xz
+	export PATH=$(pwd)/llvm14.0/bin:$PATH
 
 Windows
 ~~~~~~~
 
 A pre-built version of LLVM, specifically configured for Solang, is available at
-`<https://github.com/hyperledger/solang/releases/download/v0.2.0/llvm13.0-win.zip>`_.
+`<https://github.com/hyperledger/solang/releases/download/v0.2.1/llvm14.0-win.zip>`_.
 
 After unzipping the file, add the bin directory to your path.
 
 .. code-block:: batch
 
-	set PATH=%PATH%;C:\llvm13.0\bin
+	set PATH=%PATH%;C:\llvm14.0\bin
 
 Mac
 ~~~
 
 A pre-built version of LLVM for intel macs, is available at
-`<https://github.com/hyperledger/solang/releases/download/v0.2.0/llvm13.0-mac-intel.tar.xz>`_ and for arm macs there is
-`<https://github.com/hyperledger/solang/releases/download/v0.2.0/llvm13.0-mac-arm.tar.xz>`_. After downloading,
+`<https://github.com/hyperledger/solang/releases/download/v0.2.1/llvm14.0-mac-intel.tar.xz>`_ and for arm macs there is
+`<https://github.com/hyperledger/solang/releases/download/v0.2.1/llvm14.0-mac-arm.tar.xz>`_. After downloading,
 untar the file in a terminal and add it to your path like so:
 
 .. code-block:: bash
 
-	tar Jxf llvm13.0-mac-arm.tar.xz
-	xattr -rd com.apple.quarantine llvm13.0
-	export PATH=$(pwd)/llvm13.0/bin:$PATH
+	tar Jxf llvm14.0-mac-arm.tar.xz
+	xattr -rd com.apple.quarantine llvm14.0
+	export PATH=$(pwd)/llvm14.0/bin:$PATH
 
 .. _llvm-from-source:
 
@@ -165,7 +166,7 @@ you may need to consult. First if all clone our LLVM repository:
 
 .. code-block:: bash
 
-	git clone --depth 1 --branch solana-rustc/13.0-2021-08-08 https://github.com/solana-labs/llvm-project
+	git clone --depth 1 --branch solana-rustc/14.0-2022-03-22 https://github.com/solana-labs/llvm-project
 	cd llvm-project
 
 Now run cmake to create the makefiles. Replace the *installdir* argument to ``CMAKE_INSTALL_PREFIX`` with with a directory where you would like to have LLVM installed, and then run the build:

--- a/solang-parser/Cargo.toml
+++ b/solang-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "solang-parser"
-version = "0.2.0"
-authors = ["Sean Young <sean@mess.org>"]
+version = "0.2.1"
+authors = ["Sean Young <sean@mess.org>", "Lucas Steuernagel <lucas.tnagel@gmail.com>", "Cyrill Leutwiler <bigcyrill@hotmail.com>"]
 homepage = "https://github.com/hyperledger/solang"
 documentation = "https://solang.readthedocs.io/"
 license = "Apache-2.0"

--- a/src/linker/linker.cpp
+++ b/src/linker/linker.cpp
@@ -7,12 +7,12 @@ extern "C" bool LLDWasmLink(const char *argv[], size_t length)
 {
 	llvm::ArrayRef<const char *> args(argv, length);
 
-	return lld::wasm::link(args, false, llvm::outs(), llvm::errs());
+	return lld::wasm::link(args, llvm::outs(), llvm::errs(), false, false);
 }
 
 extern "C" bool LLDELFLink(const char *argv[], size_t length)
 {
 	llvm::ArrayRef<const char *> args(argv, length);
 
-	return lld::elf::link(args, false, llvm::outs(), llvm::errs());
+	return lld::elf::link(args, llvm::outs(), llvm::errs(), false, false);
 }


### PR DESCRIPTION
The release is necessary to move Solang to LLVM 14. Tests to build the release binarie have run [here](https://github.com/LucasSte/solang/actions/runs/3832831823/jobs/6523592431).