### PR TITLE
Update Rust version from workflows

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get clean
 RUN apt-get autoclean
 
 # Get Rust
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain 1.63.0
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain 1.64.0
 
 COPY --from=builder /llvm14.0 /llvm14.0/
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Add LLVM to Path
       run: echo "$(pwd)/llvm14.0/bin" >> $GITHUB_PATH
     - name: Rust stable
-      run: rustup default 1.63.0
+      run: rustup default 1.64.0
     - name: Build
       run: cargo build --verbose --release
     - name: Run tests
@@ -79,7 +79,7 @@ jobs:
     - name: Add LLVM to Path
       run: echo "$(pwd)/llvm14.0/bin" >> $GITHUB_PATH
     - name: Rust stable
-      run: rustup default 1.63.0
+      run: rustup default 1.64.0
     - name: Build
       run: cargo build --verbose --release
     - name: Run tests
@@ -100,7 +100,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: recursive
-    - uses: dtolnay/rust-toolchain@1.63.0
+    - uses: dtolnay/rust-toolchain@1.64.0
     - run: git clone --depth 1 --branch solana-rustc/14.0-2022-03-22 https://github.com/solana-labs/llvm-project.git
       # We may not have enough space to compile llvm, see https://github.com/actions/virtual-environments/issues/326
       working-directory: C:\
@@ -148,7 +148,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: recursive
-    - uses: dtolnay/rust-toolchain@1.63.0
+    - uses: dtolnay/rust-toolchain@1.64.0
     - run: git clone --depth 1 --branch solana-rustc/14.0-2022-03-22 https://github.com/solana-labs/llvm-project.git
     - name: Install Ninja
       uses: llvm/actions/install-ninja@main
@@ -193,7 +193,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: recursive
-    - uses: dtolnay/rust-toolchain@1.63.0
+    - uses: dtolnay/rust-toolchain@1.64.0
     - run: git clone --depth 1 --branch solana-rustc/14.0-2022-03-22 https://github.com/solana-labs/llvm-project.git
     - name: Install Ninja
       uses: llvm/actions/install-ninja@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
       with:
         submodules: recursive
     - name: Rust stable
-      run: rustup default 1.63.0
+      run: rustup default 1.64.0
     - name: Build
       run: cargo build --verbose
     - name: Run tests
@@ -87,7 +87,7 @@ jobs:
       with:
         submodules: recursive
     - name: Rust stable
-      run: rustup default 1.63.0
+      run: rustup default 1.64.0
     - name: Build
       run: cargo build --verbose
     - name: Run tests
@@ -111,7 +111,7 @@ jobs:
       run: unzip c:\llvm.zip -d c:/
     - name: Add LLVM to Path
       run: echo "c:\llvm14.0\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
-    - uses: dtolnay/rust-toolchain@1.63.0
+    - uses: dtolnay/rust-toolchain@1.64.0
       with:
         components: clippy
     # We run clippy on Linux in the lint job above, but this does not check #[cfg(windows)] items
@@ -135,7 +135,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: recursive
-    - uses: dtolnay/rust-toolchain@1.63.0
+    - uses: dtolnay/rust-toolchain@1.64.0
     - name: Get LLVM
       run: curl -L --output llvm14.0-mac-arm.tar.xz https://github.com/hyperledger/solang/releases/download/v0.2.1/llvm14.0-mac-arm.tar.xz
     - name: Extract LLVM
@@ -159,7 +159,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: recursive
-    - uses: dtolnay/rust-toolchain@1.63.0
+    - uses: dtolnay/rust-toolchain@1.64.0
     - name: Get LLVM
       run: wget -q -O llvm14.0-mac-intel.tar.xz https://github.com/hyperledger/solang/releases/download/v0.2.1/llvm14.0-mac-intel.tar.xz
     - name: Extract LLVM

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 build = "build.rs"
 description = "Solang Solidity Compiler"
 keywords = [ "solidity", "compiler", "solana", "substrate" ]
-rust-version = "1.63.0"
+rust-version = "1.64.0"
 edition = "2021"
 
 [build-dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY . src
 WORKDIR /src/stdlib/
 RUN make
 
-RUN rustup default 1.63.0
+RUN rustup default 1.64.0
 
 WORKDIR /src
 RUN cargo build --release

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -87,7 +87,7 @@ Then you can build the image using:
 Option 5: Build Solang from source
 ----------------------------------
 
-In order to build Solang from source, you will need rust 1.63.0 or higher,
+In order to build Solang from source, you will need rust 1.64.0 or higher,
 and a build of LLVM based on the Solana LLVM tree. There are a few LLVM patches required that are not upstream yet.
 First, follow the steps below for installing LLVM and then proceed from there.
 


### PR DESCRIPTION
The test workflows are failing because clap does not support Rust 1.63 anymore, so I updated it to 1.64.