### PR TITLE
Fix encoder for multidimensional dynamic arrays

### DIFF
--- a/src/codegen/encoding/mod.rs
+++ b/src/codegen/encoding/mod.rs
@@ -240,13 +240,18 @@ fn calculate_array_size<T: AbiEncoding>(
         }
 
         let type_size = Expression::NumberLiteral(Loc::Codegen, Type::Uint(32), compile_type_size);
-        let size = Expression::Multiply(
+        let mut size = Expression::Multiply(
             Loc::Codegen,
             Type::Uint(32),
             false,
             Box::new(size),
             Box::new(type_size),
         );
+
+        if !encoder.is_packed() && dims.last().unwrap() == &ArrayLength::Dynamic {
+            size = increment_four(size);
+        }
+
         let size_var = vartab.temp_anonymous(&Type::Uint(32));
         cfg.add(
             vartab,
@@ -287,30 +292,6 @@ fn calculate_array_size<T: AbiEncoding>(
         size_var
     };
 
-    // Each dynamic dimension size occupies 4 bytes in the buffer
-    let dyn_dims = dims.iter().filter(|d| **d == ArrayLength::Dynamic).count();
-
-    if dyn_dims > 0 && !encoder.is_packed() {
-        cfg.add(
-            vartab,
-            Instr::Set {
-                loc: Loc::Codegen,
-                res: size_var,
-                expr: Expression::Add(
-                    Loc::Codegen,
-                    Type::Uint(32),
-                    false,
-                    Box::new(Expression::Variable(Loc::Codegen, Type::Uint(32), size_var)),
-                    Box::new(Expression::NumberLiteral(
-                        Loc::Codegen,
-                        Type::Uint(32),
-                        BigInt::from(4 * dyn_dims),
-                    )),
-                ),
-            },
-        );
-    }
-
     Expression::Variable(Loc::Codegen, Type::Uint(32), size_var)
 }
 
@@ -328,10 +309,24 @@ fn calculate_complex_array_size<T: AbiEncoding>(
     vartab: &mut Vartable,
     cfg: &mut ControlFlowGraph,
 ) {
+    if dims[dimension] == ArrayLength::Dynamic && !encoder.is_packed() {
+        cfg.add(
+            vartab,
+            Instr::Set {
+                loc: Loc::Codegen,
+                res: size_var_no,
+                expr: increment_four(Expression::Variable(
+                    Loc::Codegen,
+                    Type::Uint(32),
+                    size_var_no,
+                )),
+            },
+        )
+    }
     let for_loop = set_array_loop(arr, dims, dimension, indexes, vartab, cfg);
     cfg.set_basic_block(for_loop.body_block);
     if 0 == dimension {
-        let deref = load_array_item(arr, dims, indexes);
+        let deref = index_array(arr.clone(), dims, indexes, false);
         let elem_size = get_expr_size(encoder, arg_no, &deref, ns, vartab, cfg);
 
         cfg.add(
@@ -380,12 +375,7 @@ fn get_array_length(
     if let ArrayLength::Fixed(dim) = &dims[dimension] {
         Expression::NumberLiteral(Loc::Codegen, Type::Uint(32), dim.clone())
     } else {
-        let (sub_array, _) = load_sub_array(
-            arr.clone(),
-            &dims[(dimension + 1)..dims.len()],
-            indexes,
-            true,
-        );
+        let sub_array = index_array(arr.clone(), dims, &indexes[..indexes.len() - 1], false);
 
         Expression::Builtin(
             Loc::Codegen,
@@ -428,39 +418,57 @@ fn calculate_struct_size<T: AbiEncoding>(
     size
 }
 
-/// Loads an item from an array
-fn load_array_item(arr: &Expression, dims: &[ArrayLength], indexes: &[usize]) -> Expression {
-    let elem_ty = arr.ty().elem_ty();
-    let (deref, ty) = load_sub_array(arr.clone(), dims, indexes, false);
-    Expression::Subscript(
-        Loc::Codegen,
-        Type::Ref(Box::new(elem_ty)),
-        ty,
-        Box::new(deref),
-        Box::new(Expression::Variable(
-            Loc::Codegen,
-            Type::Uint(32),
-            *indexes.last().unwrap(),
-        )),
-    )
-}
-
-/// Dereferences a subarray. If we have 'int[3][][4] vec' and we need 'int[3][]',
-/// this function returns so.
-/// 'dims' should contain only the dimensions we want to index
-/// 'index' is the list of indexes to use
-/// 'index_first_dim' chooses whether to index the first dimension in dims
-fn load_sub_array(
+/// Indexes an array. If we have 'int[3][][4] vec' and we need 'int[3][]',
+/// 'int[3]' or 'int' (the array element) this function returns so.
+///
+/// * `arr` - The expression that represents the array
+/// * `dims` - is the vector containing the array's dimensions
+/// * `index` - is the list of indexes to use for each dimension
+/// * `coerce_pointer_return` - forces the return of a pointer in this function.
+///
+/// When applying Expression::Subscript to a fixed-sized array, like 'int[3][4] vec', we
+/// have a pointer to a 'int[3]'. If we would like to index it again, there is no need to load,
+/// because a pointer to 'int[3]' is what the LLVM GEP instruction requires.
+///
+/// The underlying representation of a dynamic array is a C struct called 'struct vector'. In this
+/// sense, a vector like 'uint16[][] vec is a 'struct vector', whose buffer elements are all pointers to
+/// other 'struct vector's. When we index the first dimension of 'vec', we have a pointer to a pointer
+/// to a 'struct vector', which is not compatible with LLVM GEP instruction for further indexing.
+/// Therefore, we need an Expression::Load to obtain a pointer to 'struct vector' to be able to index
+/// it again.
+///
+/// Even though all the types this function returns are pointers in the LLVM IR representation,
+/// the argument `coerce_pointer_return` must be true when we are dealing with dynamic arrays that are
+/// going to be the destination address of a store instruction.
+///
+/// In a case like this,
+///
+/// uint16[][] vec;
+/// uint16[] vec1;
+/// vec[0] = vec1;
+///
+/// 'vec[0]' must be a pointer to a pointer to a 'struct vector' so that the LLVM Store instruction
+/// can be executed properly, as the value we are trying to store there is a pointer to a 'struct vector'.
+/// In this case, we must coerce the return of a pointer. Everywhere else, the load is necessary.
+///
+/// `coerce_pointer_return` has not effect for fixed sized arrays.
+fn index_array(
     mut arr: Expression,
     dims: &[ArrayLength],
     indexes: &[usize],
-    index_first_dim: bool,
-) -> (Expression, Type) {
+    coerce_pointer_return: bool,
+) -> Expression {
     let mut ty = arr.ty();
     let elem_ty = ty.elem_ty();
-    let start = !index_first_dim as usize;
-    for i in (start..dims.len()).rev() {
-        let local_ty = Type::Array(Box::new(elem_ty.clone()), dims[0..i].to_vec());
+    let begin = dims.len() - indexes.len();
+
+    for i in (begin..dims.len()).rev() {
+        // If we are indexing the last dimension, the type should be that of the array element.
+        let local_ty = if i == 0 {
+            elem_ty.clone()
+        } else {
+            Type::Array(Box::new(elem_ty.clone()), dims[0..i].to_vec())
+        };
         arr = Expression::Subscript(
             Loc::Codegen,
             Type::Ref(Box::new(local_ty.clone())),
@@ -469,13 +477,27 @@ fn load_sub_array(
             Box::new(Expression::Variable(
                 Loc::Codegen,
                 Type::Uint(32),
-                indexes[indexes.len() - i - 1],
+                indexes[dims.len() - i - 1],
             )),
         );
+
+        // We should only load if the dimension is dynamic.
+        if i > 0 && dims[i - 1] == ArrayLength::Dynamic {
+            arr = Expression::Load(Loc::Codegen, local_ty.clone(), arr.into());
+        }
+
         ty = local_ty;
     }
 
-    (arr, ty)
+    if coerce_pointer_return && !matches!(arr.ty(), Type::Ref(_)) {
+        if let Expression::Load(_, _, expr) = arr {
+            return *expr;
+        } else {
+            unreachable!("Expression should be a load");
+        }
+    }
+
+    arr
 }
 
 /// This struct manages for-loops created when iterating over arrays

--- a/tests/codegen_testcases/solidity/borsh_encoding_simple_types.sol
+++ b/tests/codegen_testcases/solidity/borsh_encoding_simple_types.sol
@@ -155,8 +155,7 @@ contract EncodingTest {
         noPadStruct[2] memory str_vec = [noPadStruct(1,2), noPadStruct(3, 4)];
         bytes memory b1 = abi.encode(test_vec_1, mem_vec, str_vec);
         // CHECK: %temp.66 = load storage slot(uint32 16) ty:struct EncodingTest.noPadStruct[]
-	    // CHECK: ty:uint32 %temp.67 = ((builtin ArrayLength (%temp.66)) * uint32 8)
-	    // CHECK: ty:uint32 %temp.67 = (%temp.67 + uint32 4)
+	    // CHECK: ty:uint32 %temp.67 = (((builtin ArrayLength (%temp.66)) * uint32 8) + uint32 4)
 	    // CHECK: ty:uint32 %temp.68 = uint32 16
 	    // CHECK: ty:uint32 %temp.69 = uint32 16
 	    // CHECK: ty:bytes %abi_encoded.temp.70 = (alloc bytes len ((%temp.67 + uint32 16) + uint32 16))

--- a/tests/codegen_testcases/solidity/encode_decode_double_dynamic_array.sol
+++ b/tests/codegen_testcases/solidity/encode_decode_double_dynamic_array.sol
@@ -1,0 +1,161 @@
+// RUN: --target solana --emit cfg
+
+contract Testing {
+
+    // BEGIN-CHECK: Testing::Testing::function::testThis
+    function testThis() public pure returns (bytes) {
+        uint16[][] memory vec;
+        bytes b = abi.encode(vec);
+        return b;
+
+	    // CHECK: ty:uint32 %array_bytes_size_0.temp.7 = uint32 0
+	    // CHECK: ty:uint32 %array_bytes_size_0.temp.7 = uint32 4
+	    // CHECK: ty:uint32 %for_i_1.temp.8 = uint32 0
+	    // CHECK: branch block1
+
+        // CHECK: block1: # cond
+	    // CHECK: branchcond (unsigned less %for_i_1.temp.8 < (builtin ArrayLength (%vec))), block3, block4
+
+        // CHECK: block2: # next
+	    // CHECK: ty:uint32 %for_i_1.temp.8 = (%for_i_1.temp.8 + uint32 1)
+	    // CHECK: branch block1
+
+        // CHECK: block3: # body
+	    // CHECK: ty:uint32 %array_bytes_size_0.temp.7 = (%array_bytes_size_0.temp.7 + uint32 4)
+	    // CHECK: ty:uint32 %for_i_0.temp.9 = uint32 0
+	    // CHECK: branch block5
+
+        // CHECK: block4: # end_for
+	    // CHECK: ty:bytes %abi_encoded.temp.10 = (alloc bytes len %array_bytes_size_0.temp.7)
+	    // CHECK: ty:uint32 %temp.11 = uint32 0
+	    // CHECK: writebuffer buffer:%abi_encoded.temp.10 offset:uint32 0 value:(builtin ArrayLength (%vec))
+	    // CHECK: ty:uint32 %temp.11 = uint32 4
+	    // CHECK: ty:uint32 %for_i_1.temp.12 = uint32 0
+	    // CHECK: branch block9
+
+        // CHECK: block5: # cond
+		// CHECK:  branchcond (unsigned less %for_i_0.temp.9 < (builtin ArrayLength ((load (subscript uint16[][] %vec[%for_i_1.temp.8]))))), block7, block8
+
+        // CHECK: block6: # next
+	    // CHECK: ty:uint32 %for_i_0.temp.9 = (%for_i_0.temp.9 + uint32 1)
+        // CHECK: branch block5
+        
+        // CHECK: block7: # body
+	    // CHECK: ty:uint32 %array_bytes_size_0.temp.7 = (%array_bytes_size_0.temp.7 + uint32 2)
+	    // CHECK: branch block6
+
+        // CHECK: block8: # end_for
+	    // CHECK: branch block2
+
+        // CHECK: block9: # cond
+	    // CHECK: branchcond (unsigned less %for_i_1.temp.12 < (builtin ArrayLength (%vec))), block11, block12
+    
+        // CHECK: block10: # next
+	    // CHECK: ty:uint32 %for_i_1.temp.12 = (%for_i_1.temp.12 + uint32 1)
+	    // CHECK: branch block9
+        
+        // CHECK: block11: # body
+	    // CHECK: writebuffer buffer:%abi_encoded.temp.10 offset:%temp.11 value:(builtin ArrayLength ((load (subscript uint16[][] %vec[%for_i_1.temp.12]))))
+	    // CHECK: ty:uint32 %temp.11 = (%temp.11 + uint32 4)
+	    // CHECK: ty:uint32 %for_i_0.temp.13 = uint32 0
+	    // CHECK: branch block13
+
+        // CHECK: block12: # end_for
+	    // CHECK: ty:uint32 %temp.11 = (%temp.11 - uint32 0)
+        // CHECK: ty:bytes %b = %abi_encoded.temp.10
+	    // CHECK: return %b
+
+        // CHECK: block13: # cond
+	    // CHECK: branchcond (unsigned less %for_i_0.temp.13 < (builtin ArrayLength ((load (subscript uint16[][] %vec[%for_i_1.temp.12]))))), block15, block16
+
+        // CHECK: block14: # next
+	    // CHECK: ty:uint32 %for_i_0.temp.13 = (%for_i_0.temp.13 + uint32 1)
+	    // CHECK: branch block13
+
+        // CHECK: block15: # body
+	    // CHECK: writebuffer buffer:%abi_encoded.temp.10 offset:%temp.11 value:(load (subscript uint16[] (load (subscript uint16[][] %vec[%for_i_1.temp.12]))[%for_i_0.temp.13]))
+	    // CHECK: ty:uint32 %temp.11 = (uint32 2 + %temp.11)
+	    // CHECK: branch block14
+
+
+        // CHECK: block16: # end_for
+    	// CHECK: branch block10
+    }
+
+    // BEGIN-CHECK: Testing::Testing::function::testThat__bytes
+    function testThat(bytes memory bb) public pure returns (uint16[][] memory) {
+        uint16[][] memory vec = abi.decode(bb, uint16[][]);
+        return vec;
+
+	    // CHECK: ty:uint32 %temp.14 = (builtin ArrayLength ((arg #0)))
+	    // CHECK: ty:uint32 %temp.16 = uint32 0
+	    // CHECK: branchcond (uint32 4 <= %temp.14), block1, block2
+        
+        // CHECK: block1: # inbounds
+	    // CHECK: ty:uint32 %temp.17 = (builtin ReadFromBuffer ((arg #0), uint32 0))
+	    // CHECK: ty:uint32 %temp.16 = uint32 4
+	    // CHECK: ty:uint16[][] %temp.18 = (alloc uint16[][] len %temp.17)
+	    // CHECK: ty:uint16[][] %temp.15 = %temp.18
+	    // CHECK: ty:uint32 %for_i_1.temp.19 = uint32 0
+	    // CHECK: branch block3
+
+        // CHECK: block2: # out_of_bounds
+	    // CHECK: assert-failure
+
+        // CHECK: block3: # cond
+	    // CHECK: branchcond (unsigned less %for_i_1.temp.19 < (builtin ArrayLength (%temp.15))), block5, block6
+
+        // CHECK: block4: # next
+	    // CHECK: ty:uint32 %for_i_1.temp.19 = (%for_i_1.temp.19 + uint32 1)
+        // CHECK: branch block3
+
+        // CHECK: block5: # body
+	    // CHECK: ty:uint32 %1.cse_temp = (%temp.16 + uint32 4)
+	    // CHECK: branchcond (%1.cse_temp <= %temp.14), block7, block8
+
+        // CHECK: block6: # end_for
+	    // CHECK: ty:uint32 %temp.16 = (%temp.16 - uint32 0)
+	    // CHECK: branchcond (unsigned less (uint32 0 + %temp.16) < %temp.14), block15, block16
+
+        // CHECK: block7: # inbounds
+	    // CHECK: ty:uint32 %temp.20 = (builtin ReadFromBuffer ((arg #0), %temp.16))
+	    // CHECK: ty:uint32 %temp.16 = %1.cse_temp
+	    // CHECK: ty:uint16[] %temp.21 = (alloc uint16[] len %temp.20)
+	    // CHECK: store (subscript uint16[][] %temp.15[%for_i_1.temp.19]), %temp.21
+	    // CHECK: ty:uint32 %for_i_0.temp.22 = uint32 0
+	    // CHECK: branch block9
+
+        // CHECK: block8: # out_of_bounds
+	    // CHECK: assert-failure
+
+        // CHECK: block9: # cond
+	    // CHECK: branchcond (unsigned less %for_i_0.temp.22 < (builtin ArrayLength ((load (subscript uint16[][] %temp.15[%for_i_1.temp.19]))))), block11, block12
+
+        // CHECK: block10: # next
+	    // CHECK: ty:uint32 %for_i_0.temp.22 = (%for_i_0.temp.22 + uint32 1)
+	    // CHECK: branch block9
+
+        // CHECK: block11: # body
+	    // CHECK: ty:uint32 %2.cse_temp = (%temp.16 + uint32 2)
+	    // CHECK: branchcond (%2.cse_temp <= %temp.14), block13, block14
+
+        // CHECK: block12: # end_for
+	    // CHECK: branch block4
+
+        // CHECK: block13: # inbounds
+	    // CHECK: ty:uint16 %temp.23 = (builtin ReadFromBuffer ((arg #0), %temp.16))
+	    // CHECK: store (subscript uint16[] (load (subscript uint16[][] %temp.15[%for_i_1.temp.19]))[%for_i_0.temp.22]), %temp.23
+	    // CHECK: ty:uint32 %temp.16 = %2.cse_temp
+	    // CHECK: branch block10
+
+        // CHECK: block14: # out_of_bounds
+	    // CHECK: assert-failure
+        
+        // CHECK: block15: # not_all_bytes_read
+	    // CHECK: assert-failure
+
+        // CHECK: block16: # buffer_read
+	    // CHECK: ty:uint16[][] %vec = %temp.15
+	    // CHECK: return %vec
+    }
+}

--- a/tests/solana_tests/abi_decode.rs
+++ b/tests/solana_tests/abi_decode.rs
@@ -1215,3 +1215,38 @@ fn string_fixed_array() {
     let encoded = input.try_to_vec().unwrap();
     let _ = vm.function("testing", &[BorshToken::Bytes(encoded)]);
 }
+
+#[test]
+fn double_dynamic_array() {
+    let mut vm = build_solidity(
+        r#"
+    contract Testing {
+        function testThis(bytes memory bb) public pure {
+            (uint32 a, uint16[][] memory vec, int64 b) = abi.decode(bb, (uint32, uint16[][], int64));
+            assert(a == 99);
+            assert(vec[0][0] == 99);
+            assert(vec[0][1] == 20);
+            assert(vec[1][0] == 15);
+            assert(vec[1][1] == 88);
+            assert(b == -755);
+        }
+    }
+        "#,
+    );
+    vm.constructor(&[]);
+
+    #[derive(Debug, BorshSerialize)]
+    struct Input {
+        item_1: u32,
+        item_2: Vec<Vec<u16>>,
+        item_3: i64,
+    }
+
+    let input = Input {
+        item_1: 99,
+        item_2: vec![vec![99, 20], vec![15, 88]],
+        item_3: -755,
+    };
+    let encoded = input.try_to_vec().unwrap();
+    let _ = vm.function("testThis", &[BorshToken::Bytes(encoded)]);
+}


### PR DESCRIPTION
The example in the tests is the one of the cases I found in which we can use two dynamic dimensions in an array. The example helped me find various bugs in the way I was treating them in the encoder. This is also going to help @xermicus with his #1128 PR.

@xermicus You can decided whether to merge this PR or incorporate the change into your PR.