### PR TITLE
Adapt ink cross call test to new interface

### DIFF
--- a/integration/substrate/ink/caller/Cargo.toml
+++ b/integration/substrate/ink/caller/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Cyrill Leutwiler <cyrill@parity.io>"]
 edition = "2021"
 
 [dependencies]
-ink = { version = "4.0.0-beta", default-features = false }
+ink = { version = "4.0.0-beta.1", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2.3", default-features = false, features = ["derive"], optional = true }

--- a/integration/substrate/ink/caller/lib.rs
+++ b/integration/substrate/ink/caller/lib.rs
@@ -30,7 +30,7 @@ mod caller {
             max_gas: Option<u64>,
             transfer_value: Option<u128>,
         ) -> u32 {
-            let my_return_value = build_call::<DefaultEnvironment>()
+            build_call::<DefaultEnvironment>()
                 .call_type(
                     Call::new()
                         .callee(callee)
@@ -39,8 +39,7 @@ mod caller {
                 .transferred_value(transfer_value.unwrap_or_default())
                 .exec_input(ExecutionInput::new(Selector::new(selector)).push_arg(arg))
                 .returns::<u32>() // FIXME: This should be Result<u32, u8> to respect LanguageError
-                .fire();
-            my_return_value.unwrap()
+                .invoke()
         }
     }
 }

--- a/integration/substrate/inkee.sol
+++ b/integration/substrate/inkee.sol
@@ -1,6 +1,6 @@
 contract Inkee {
     @selector([1, 2, 3, 4])
-    function echo(uint32 v) public pure returns (uint32) {
-        return v;
+    function echo(uint32 v) public pure returns (bool, uint32) {
+        return (false, v);
     }
 }


### PR DESCRIPTION
Today a new ink! beta was released. For betas, the ink umbrella crate currently selects the latest version automatically, which introduces a breaking change. I fixed the integration test to fake a `Result<u32>` value, until we have a proper cross call interface.