### PR TITLE
Do not build stdlib/bigint.c while it cannot be built with llvm 14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,8 +67,7 @@ jobs:
       working-directory: ./llvm-project/
     - run: cmake --build . --target install
       working-directory: ./llvm-project/
-      # compression takes a long time on linux-arm64, use multithreaded compression
-    - run: tar cf ./llvm14.0-linux-arm64.tar.xz -I 'xz -T 0' ./llvm14.0/
+    - run: tar Jcf ./llvm14.0-linux-arm64.tar.xz ./llvm14.0/
     - name: Upload llvm
       uses: svenstaro/upload-release-action@v2
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,9 @@
-# On Alpine linux, the build fails with:
-# error: cannot produce proc-macro for `serde_derive v1.0.102` as the target `x86_64-unknown-linux-musl` does not support these crate types
-# See https://github.com/rust-lang/cargo/issues/5266
-
-# Fedora 30 produces a builder image 2.01 GiB and solang image of 294 MiB
-# Ubuntu 18.04 produces a builder image 1.53 GiB and solang image of 84 MiB
-# Debian Buster produces a builder image 2.04 GiB
-
 FROM ghcr.io/hyperledger/solang:ci as builder
 
 COPY . src
-WORKDIR /src/stdlib/
-RUN make
+# TODO: bigint.c does not compile with llvm 14.0, disable for now
+# WORKDIR /src/stdlib/
+# RUN make
 
 RUN rustup default 1.64.0
 

--- a/integration/substrate/asserts.spec.ts
+++ b/integration/substrate/asserts.spec.ts
@@ -29,7 +29,7 @@ describe('Deploy asserts contract and test', () => {
         expect(res0.output?.toJSON()).toEqual(1);
 
         let res1 = await query(conn, alice, contract, "testAssertRpc");
-        expect(res1.result.toHuman()).toEqual({ "Err": { "Module": { "error": "0x0b000000", "index": "7" } } });
+        expect(res1.result.toHuman()).toEqual({ "Err": { "Module": { "error": "0x0b000000", "index": "8" } } });
 
         let gasLimit = await weight(conn, contract, "testAssert");
         let tx = contract.tx.testAssert({ gasLimit });
@@ -38,7 +38,7 @@ describe('Deploy asserts contract and test', () => {
             throw new Error("should not succeed");
         }, (res) => res);
 
-        expect(res2.dispatchError.toHuman()).toEqual({ "Module": { "error": "0x0b000000", "index": "7" } });
+        expect(res2.dispatchError.toHuman()).toEqual({ "Module": { "error": "0x0b000000", "index": "8" } });
 
         let res3 = await query(conn, alice, contract, "var");
 


### PR DESCRIPTION
This breaks the container build.

Signed-off-by: Sean Young <sean@mess.org>