### PR TITLE
pin substrate node on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -297,7 +297,7 @@ jobs:
       # We can't run substrate as a github actions service, since it requires
       # command line arguments. See https://github.com/actions/runner/pull/1152
     - name: Start substrate
-      run: docker run -d -p 9944:9944 paritytech/contracts-ci-linux:latest substrate-contracts-node --dev --ws-external
+      run: docker run -d -p 9944:9944 paritytech/contracts-ci-linux@sha256:513518822f09eba6452ac14ba2a84d12529da86dff850c7c0f067dad6a58af70 substrate-contracts-node --dev --ws-external
     - uses: actions/setup-node@v3
       with:
         node-version: '14'


### PR DESCRIPTION
It is annoying to use `:latest` images for our CI (I still use todays `latest` image here but pinned it).