### PR TITLE
Bump solana_rbpf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ wasmi = "0.11"
 rand_07 = { package = "rand", version = "0.7" }
 sha2 = "0.10"
 # solana_rbpf makes api changes in patch versions
-solana_rbpf = "=0.2.33"
+solana_rbpf = "=0.2.35"
 byteorder = "1.4"
 assert_cmd = "2.0"
 bincode = "1.3"

--- a/tests/solana_tests/balance.rs
+++ b/tests/solana_tests/balance.rs
@@ -379,7 +379,7 @@ fn value_overflows() {
             },
         ],
     );
-    assert_eq!(res.ok(), Some(4294967296));
+    assert_eq!(res.unwrap(), 4294967296);
 
     let res = vm.function_must_fail(
         "send",
@@ -391,7 +391,8 @@ fn value_overflows() {
             },
         ],
     );
-    assert_eq!(res.ok(), Some(4294967296));
+
+    assert_eq!(res.unwrap(), 4294967296);
 
     let returns = vm
         .function(

--- a/tests/solana_tests/create_contract.rs
+++ b/tests/solana_tests/create_contract.rs
@@ -246,7 +246,7 @@ fn missing_contract() {
     let missing = account_new();
 
     let res = vm.function_must_fail("test_other", &[BorshToken::Address(missing)]);
-    assert_eq!(res, Ok(64424509440));
+    assert_eq!(res.unwrap(), 64424509440);
 }
 
 #[test]

--- a/tests/solana_tests/expressions.rs
+++ b/tests/solana_tests/expressions.rs
@@ -74,7 +74,7 @@ fn write_buffer() {
     assert_eq!(returns, BorshToken::Bytes(buf));
 
     let res = vm.function_must_fail("test3", &[]);
-    assert_eq!(res, Ok(4294967296));
+    assert_eq!(res.unwrap(), 4294967296);
 }
 
 #[test]
@@ -124,7 +124,7 @@ fn read_buffer() {
             [0xbc, 0xbc, 0xbd, 0xbe, 8, 7, 6, 5, 4, 3, 2].to_vec(),
         )],
     );
-    assert_eq!(res, Ok(4294967296));
+    assert_eq!(res.unwrap(), 4294967296);
 
     let mut buf = vec![0x42u8, 0x41u8];
     buf.extend_from_slice(&vm.origin);
@@ -148,7 +148,7 @@ fn read_buffer() {
     buf.pop();
 
     let res = vm.function_must_fail("test2", &[BorshToken::Bytes(buf)]);
-    assert_eq!(res, Ok(4294967296));
+    assert_eq!(res.unwrap(), 4294967296);
 }
 
 #[test]

--- a/tests/solana_tests/math.rs
+++ b/tests/solana_tests/math.rs
@@ -127,7 +127,7 @@ fn safe_math() {
         ],
     );
 
-    assert_ne!(res, Ok(0));
+    assert_ne!(res.unwrap(), 0);
 
     let res = vm.function_must_fail(
         "add_test",
@@ -143,7 +143,7 @@ fn safe_math() {
         ],
     );
 
-    assert_ne!(res, Ok(0));
+    assert_ne!(res.unwrap(), 0);
 
     let res = vm.function_must_fail(
         "sub_test",
@@ -159,5 +159,5 @@ fn safe_math() {
         ],
     );
 
-    assert_ne!(res, Ok(0));
+    assert_ne!(res.unwrap(), 0);
 }

--- a/tests/solana_tests/primitives.rs
+++ b/tests/solana_tests/primitives.rs
@@ -813,7 +813,7 @@ fn test_power_overflow_boundaries() {
             ],
         );
 
-        assert_ne!(sesa, Ok(0));
+        assert_ne!(sesa.unwrap(), 0);
     }
 }
 
@@ -911,7 +911,7 @@ fn test_overflow_boundaries() {
             ],
         );
 
-        assert_ne!(res, Ok(0));
+        assert_ne!(res.unwrap(), 0);
 
         let res = contract.function_must_fail(
             "mul",
@@ -927,7 +927,7 @@ fn test_overflow_boundaries() {
             ],
         );
 
-        assert_ne!(res, Ok(0));
+        assert_ne!(res.unwrap(), 0);
 
         let res = contract.function_must_fail(
             "mul",
@@ -943,7 +943,7 @@ fn test_overflow_boundaries() {
             ],
         );
 
-        assert_ne!(res, Ok(0));
+        assert_ne!(res.unwrap(), 0);
 
         let res = contract.function_must_fail(
             "mul",
@@ -959,7 +959,7 @@ fn test_overflow_boundaries() {
             ],
         );
 
-        assert_ne!(res, Ok(0));
+        assert_ne!(res.unwrap(), 0);
 
         let res = contract.function_must_fail(
             "mul",
@@ -975,7 +975,7 @@ fn test_overflow_boundaries() {
             ],
         );
 
-        assert_ne!(res, Ok(0));
+        assert_ne!(res.unwrap(), 0);
     }
 }
 
@@ -1124,7 +1124,7 @@ fn test_overflow_detect_signed() {
             ],
         );
 
-        assert_ne!(res, Ok(0));
+        assert_ne!(res.unwrap(), 0);
 
         // The range of values that can be held in signed N bits is [-2^(N-1), 2^(N-1)-1] .
         let mut lower_limit: BigInt = BigInt::from(2_u32).pow((width - 1) as u32);
@@ -1149,7 +1149,7 @@ fn test_overflow_detect_signed() {
             ],
         );
 
-        assert_ne!(res, Ok(0));
+        assert_ne!(res.unwrap(), 0);
     }
 }
 
@@ -1193,7 +1193,7 @@ fn test_overflow_detect_unsigned() {
                     },
                 ],
             );
-            assert_ne!(res, Ok(0));
+            assert_ne!(res.unwrap(), 0);
         }
     }
 }

--- a/tests/solana_tests/yul.rs
+++ b/tests/solana_tests/yul.rs
@@ -502,7 +502,12 @@ contract testing  {
     runtime.constructor(&[]);
     let returns = runtime.function("test_address", &[]).unwrap();
     let addr = returns.into_bigint().unwrap();
-    let b_vec = addr.to_bytes_be().1;
+    let mut b_vec = addr.to_bytes_be().1;
+    // test_address() returns address as uint256. If the highest bits are 0, then addr.to_bytes_be().1
+    // may not return 32 bytes.
+    while b_vec.len() < 32 {
+        b_vec.insert(0, 0);
+    }
     assert_eq!(&b_vec, runtime.stack[0].data.as_ref());
 
     runtime


### PR DESCRIPTION
- Bump solana_rbpf to 0.2.35. This makes it possible to use rust 1.67
- Fix sporadic test failure
Signed-off-by: Sean Young <sean@mess.org>