### PR TITLE
External function type should not be a pointer in `llvm_type` function

### DIFF
--- a/src/emit/binary.rs
+++ b/src/emit/binary.rs
@@ -699,7 +699,11 @@ impl<'a> Binary<'a> {
     pub(crate) fn llvm_var_ty(&self, ty: &Type, ns: &Namespace) -> BasicTypeEnum<'a> {
         let llvm_ty = self.llvm_type(ty, ns);
         match ty.deref_memory() {
-            Type::Struct(_) | Type::Array(..) | Type::DynamicBytes | Type::String => llvm_ty
+            Type::Struct(_)
+            | Type::Array(..)
+            | Type::DynamicBytes
+            | Type::String
+            | Type::ExternalFunction { .. } => llvm_ty
                 .ptr_type(AddressSpace::default())
                 .as_basic_type_enum(),
             _ => llvm_ty,
@@ -825,11 +829,9 @@ impl<'a> Binary<'a> {
                     let address = self.llvm_type(&Type::Address(false), ns);
                     let selector = self.llvm_type(&Type::FunctionSelector, ns);
 
-                    BasicTypeEnum::PointerType(
-                        self.context
-                            .struct_type(&[selector, address], false)
-                            .ptr_type(AddressSpace::default()),
-                    )
+                    self.context
+                        .struct_type(&[selector, address], false)
+                        .as_basic_type_enum()
                 }
                 Type::Slice(ty) => BasicTypeEnum::StructType(
                     self.context.struct_type(

--- a/src/emit/substrate/mod.rs
+++ b/src/emit/substrate/mod.rs
@@ -836,9 +836,7 @@ impl SubstrateTarget {
                     .builder
                     .build_call(
                         binary.module.get_function("__malloc").unwrap(),
-                        &[ty.into_pointer_type()
-                            .get_element_type()
-                            .size_of()
+                        &[ty.size_of()
                             .unwrap()
                             .const_cast(binary.context.i32_type(), false)
                             .into()],
@@ -849,10 +847,11 @@ impl SubstrateTarget {
                     .unwrap()
                     .into_pointer_value();
 
-                let ef =
-                    binary
-                        .builder
-                        .build_pointer_cast(ef, ty.into_pointer_type(), "function_type");
+                let ef = binary.builder.build_pointer_cast(
+                    ef,
+                    ty.ptr_type(AddressSpace::default()),
+                    "function_type",
+                );
 
                 let address_member = unsafe {
                     binary.builder.build_gep(

--- a/src/emit/substrate/target.rs
+++ b/src/emit/substrate/target.rs
@@ -62,8 +62,6 @@ impl<'a> TargetRuntime<'a> for SubstrateTarget {
         );
 
         let len = ty
-            .into_pointer_type()
-            .get_element_type()
             .size_of()
             .unwrap()
             .const_cast(binary.context.i32_type(), false);
@@ -97,7 +95,7 @@ impl<'a> TargetRuntime<'a> for SubstrateTarget {
 
         binary
             .builder
-            .build_pointer_cast(ef, ty.into_pointer_type(), "function_type")
+            .build_pointer_cast(ef, ty.ptr_type(AddressSpace::default()), "function_type")
     }
 
     fn set_storage_string(


### PR DESCRIPTION
When we use the function `llvm_type`, it returns an llvm struct type for structs but a pointer for `Type::ExternalFunction`, which is also a struct in Solang emit. This behavior is inconsistent and gives us headaches when moving to LLVM 15.