### PR TITLE
Fix CSE unchecked operations bug

### DIFF
--- a/src/codegen/subexpression_elimination/operator.rs
+++ b/src/codegen/subexpression_elimination/operator.rs
@@ -7,14 +7,18 @@ use crate::sema::ast::Type;
 #[derive(PartialEq, Eq, Hash, Clone, Debug)]
 pub enum Operator {
     Add,
+    UncheckedAdd,
     Subtract,
+    UncheckedSubtract,
     Multiply,
+    UncheckedMultiply,
     SignedDivide,
     UnsignedDivide,
     Modulo,
     SignedModulo,
     UnsignedModulo,
     Power,
+    UncheckedPower,
     BitwiseOr,
     BitwiseAnd,
     BitwiseXor,
@@ -49,14 +53,38 @@ impl Expression {
     /// Get the respective Operator from an Expression
     pub fn get_ave_operator(&self) -> Operator {
         match self {
-            Expression::Add(..) => Operator::Add,
-            Expression::Subtract(..) => Operator::Subtract,
-            Expression::Multiply(..) => Operator::Multiply,
+            Expression::Add(_, _, unchecked, _, _) => {
+                if *unchecked {
+                    Operator::UncheckedAdd
+                } else {
+                    Operator::Add
+                }
+            }
+            Expression::Subtract(_, _, unchecked, _, _) => {
+                if *unchecked {
+                    Operator::UncheckedSubtract
+                } else {
+                    Operator::Subtract
+                }
+            }
+            Expression::Multiply(_, _, unchecked, _, _) => {
+                if *unchecked {
+                    Operator::UncheckedMultiply
+                } else {
+                    Operator::Multiply
+                }
+            }
             Expression::SignedDivide(..) => Operator::SignedDivide,
             Expression::UnsignedDivide(..) => Operator::UnsignedDivide,
             Expression::SignedModulo(..) => Operator::SignedModulo,
             Expression::UnsignedModulo(..) => Operator::UnsignedModulo,
-            Expression::Power(..) => Operator::Power,
+            Expression::Power(_, _, unchecked, _, _) => {
+                if *unchecked {
+                    Operator::UncheckedPower
+                } else {
+                    Operator::Power
+                }
+            }
             Expression::BitwiseOr(..) => Operator::BitwiseOr,
             Expression::BitwiseAnd(..) => Operator::BitwiseAnd,
             Expression::BitwiseXor(..) => Operator::BitwiseXor,

--- a/tests/codegen_testcases/solidity/unchecked_cse.sol
+++ b/tests/codegen_testcases/solidity/unchecked_cse.sol
@@ -1,0 +1,48 @@
+// RUN: --target solana --emit cfg
+
+contract foo {
+    int64 public var;
+    uint64 public var2;
+
+//BEGIN-CHECK: foo::foo::function::mul__int64_int64
+    function mul(int64 a, int64 b) public returns (int64) {
+        unchecked {
+            // CHECK: ty:int64 storage %temp.14 = (unchecked (arg #0) * (arg #1))
+            var = a * b;
+        }
+
+        // CHECK: return ((arg #0) * (arg #1))
+        return a * b;
+    }
+
+//BEGIN-CHECK: foo::foo::function::add__int64_int64
+    function add(int64 a, int64 b) public returns (int64) {
+        unchecked {
+            // CHECK: ty:int64 storage %temp.15 = (unchecked (arg #0) + (arg #1))
+            var = a + b;
+        }
+        // CHECK: return ((arg #0) + (arg #1))
+        return a + b;
+    }
+
+//BEGIN-CHECK: foo::foo::function::sub__int64_int64
+    function sub(int64 a, int64 b) public returns (int64) {
+        unchecked {
+            // CHECK: ty:int64 storage %temp.16 = (unchecked (arg #0) - (arg #1))
+            var = a - b;
+        }
+        // CHECK: return ((arg #0) - (arg #1))
+        return a - b;
+    }
+
+//BEGIN-CHECK: foo::foo::function::power__uint64_uint64
+    function power(uint64 a, uint64 b) public returns (uint64) {
+        unchecked {
+            // CHECK: ty:uint64 storage %temp.17 = (unchecked (arg #0) ** (arg #1))
+            var2 = a ** b;
+        }
+
+        // CHECK: return ((arg #0) ** (arg #1))
+        return a ** b;
+    }
+}


### PR DESCRIPTION
@seanyoung found that the CSE pass was not differentiating checked and unchecked arithmetic expressions. This PR fixes this issue.