### PR TITLE
Fix CSE bug

### DIFF
--- a/tests/codegen_testcases/solidity/common_subexpression_elimination.sol
+++ b/tests/codegen_testcases/solidity/common_subexpression_elimination.sol
@@ -457,7 +457,6 @@ contract c1 {
             return (a << b) + 1;
         }
 
-        // CHECK: ty:uint256 %3.cse_temp = ((arg #0) & (arg #1))
         // CHECK: branchcond %2.cse_temp, block4, block3
         if(!b1 || c > 0) {
             // CHECK: = %b1
@@ -470,6 +469,7 @@ contract c1 {
             c++;
         }
 
+        // CHECK: ty:uint256 %3.cse_temp = ((arg #0) & (arg #1))
         // CHECK: branchcond (%3.cse_temp == uint256 0), block13, block14
         if (a & b == 0) {
             return c--;

--- a/tests/codegen_testcases/yul/cse_switch.sol
+++ b/tests/codegen_testcases/yul/cse_switch.sol
@@ -1,0 +1,42 @@
+// RUN: --target solana --emit cfg
+
+contract foo {
+    // BEGIN-CHECK: foo::foo::function::test
+    function test() public {
+        uint256 yy=0;
+        assembly {
+        // Ensure the CSE temp is not before the switch
+        // CHECK: ty:uint256 %x = uint256 54
+        // CHECK: ty:uint256 %y = uint256 5
+	    // CHECK: switch uint256 2:
+            let x := 54
+            let y := 5
+
+            switch and(x, 3)
+                case 0 {
+                    y := 5
+                    x := 5
+                }
+                case 1 {
+                    y := 7
+                    x := 9
+                }
+                case 3 {
+                    y := 10
+                    x := 80
+                }
+        
+            // CHECK: block1: # end_switch
+	        // CHECK: ty:uint256 %1.cse_temp = (unchecked %x + %y)
+	        // CHECK: branchcond (%1.cse_temp == uint256 90), block5, block6
+            if eq(add(x, y), 90) {
+                yy := 9
+            }
+
+            // CHECK: branchcond (%1.cse_temp == uint256 80), block7, block8
+            if eq(add(x, y), 80) {
+                yy := 90
+            }
+        }
+    }
+}


### PR DESCRIPTION
@xermicus found a bug in common subexpression elimination while working on the SCALE decoder. This PR fixes the bug, but the fix is only palliative for it might not cover all possible cases.

The problem would be best solved implementing a correct version of partial redundancy elimination, which leverages the available expressions analysis (already available) and an anticipated expression analysis not only to detect common subexpressions, but to know where exactly to evaluate them. This solution, nevertheless, is too time consuming to code and will be easier to implement when we have a new IR with SSA.

More information about partial redundancy elimination can be found in the Chapter 9.5 of the book `Compilers: Principles, Techniques & tools`, second edition, from Monica S. Lam.