### PR TITLE
Expand list of solang code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Solang Committers
-* @hyperledger/solang-committers
+* @seanyoung
+* @xermicus
+* @LucasSte


### PR DESCRIPTION
When creating a pull request, the users in this files are used to populate the reviewers. If it lists @hyperledger/solang-committers then we can't see who those users are and as soon as one of the members of @hyperledger/solang-committers leaves a review, then the pull request is marked as approved while we really want *all* the maintainers to approve.

Signed-off-by: Sean Young <sean@mess.org>