### PR TITLE
Fix wrong selector type in emit SCALE encoder

### DIFF
--- a/src/emit/substrate/mod.rs
+++ b/src/emit/substrate/mod.rs
@@ -1412,7 +1412,7 @@ impl SubstrateTarget {
                     false,
                     false,
                     function,
-                    &ast::Type::Uint(32),
+                    &ast::Type::Bytes(4),
                     selector,
                     data,
                 );


### PR DESCRIPTION
This was oversighted in #1128

Signed-off-by: Cyrill Leutwiler <cyrill@parity.io>