### PR TITLE
v0.2.2 Alexandria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to [Solang](https://github.com/hyperledger/solang/)
 will be documented here.
 
-## v0.2.2 (unreleased)
+## v0.2.2 Alexandria
 
 ### Added
 - Solidity mappings can now have named key and named value types. [seanyoung](https://github.com/seanyoung)
@@ -11,15 +11,13 @@ will be documented here.
 - Solang now uses LLVM 15. [LucasSte](https://github.com/LucasSte)
 - Solidity on Solana now required the Anchor framework for the client code, and the `@solana/solidity.js`
   Typescript library is no longer compatible with Solidity.
-- When casting hex literal numbers into the `bytesN` type, the hex literal may use leading zeros to match the size 
+- When casting hex literal numbers into the `bytesN` type, the hex literal may use leading zeros to match the size
 with the according `bytesN`, which aligns solang with `solc`. [xermicus](https://github.com/xermicus)
 
 ### Fixed
 - Many bugs have been fixed by [seanyoung](https://github.com/seanyoung), [LucasSte](https://github.com/LucasSte)
   and [xermicus](https://github.com/xermicus)
 - Typos throughout the code have been fixed. [omahs](https://github.com/omahs)
-
-
 
 ## v0.2.1 Rio
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solang"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Sean Young <sean@mess.org>", "Lucas Steuernagel <lucas.tnagel@gmail.com>", "Cyrill Leutwiler <bigcyrill@hotmail.com>"]
 homepage = "https://github.com/hyperledger/solang"
 documentation = "https://solang.readthedocs.io/"

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -28,11 +28,11 @@ Option 2: Download binaries
 
 There are binaries available on github releases:
 
-- `Linux x86-64 <https://github.com/hyperledger/solang/releases/download/v0.2.1/solang-linux-x86-64>`_
-- `Linux arm64 <https://github.com/hyperledger/solang/releases/download/v0.2.1/solang-linux-arm64>`_
-- `Windows x64 <https://github.com/hyperledger/solang/releases/download/v0.2.1/solang.exe>`_
-- `MacOS intel <https://github.com/hyperledger/solang/releases/download/v0.2.1/solang-mac-intel>`_
-- `MacOS arm <https://github.com/hyperledger/solang/releases/download/v0.2.1/solang-mac-arm>`_
+- `Linux x86-64 <https://github.com/hyperledger/solang/releases/download/v0.2.2/solang-linux-x86-64>`_
+- `Linux arm64 <https://github.com/hyperledger/solang/releases/download/v0.2.2/solang-linux-arm64>`_
+- `Windows x64 <https://github.com/hyperledger/solang/releases/download/v0.2.2/solang.exe>`_
+- `MacOS intel <https://github.com/hyperledger/solang/releases/download/v0.2.2/solang-mac-intel>`_
+- `MacOS arm <https://github.com/hyperledger/solang/releases/download/v0.2.2/solang-mac-arm>`_
 
 Download the file and save it somewhere in your ``$PATH``, for example the bin directory in your home directory. If the
 path you use is not already in ``$PATH``, then you need to add it yourself.
@@ -56,7 +56,7 @@ Option 3: Use ghcr.io/hyperledger/solang containers
 
 New images are automatically made available on
 `solang containers <https://github.com/hyperledger/solang/pkgs/container/solang>`_.
-There is a release `v0.2.1` tag and a `latest` tag:
+There is a release `v0.2.2` tag and a `latest` tag:
 
 .. code-block:: bash
 
@@ -113,7 +113,7 @@ These patches make it possible to generate code for Solana, and fixes
 concurrency issues in the lld linker.
 
 You can either download the pre-built libraries from
-`github <https://github.com/hyperledger/solang/releases/tag/v0.2.1>`_
+`github <https://github.com/hyperledger/solang/releases/tag/v0.2.2>`_
 or :ref:`build your own from source <llvm-from-source>`. After that, you need to add the ``bin`` of your
 LLVM directory to your path, so that the build system of Solang can find the correct version of LLVM to use.
 


### PR DESCRIPTION
### Added
- Solidity mappings can now have named key and named value types. [seanyoung](https://github.com/seanyoung)

### Changed
- Solang now uses LLVM 15. [LucasSte](https://github.com/LucasSte)
- Solidity on Solana now required the Anchor framework for the client code, and the `@solana/solidity.js` Typescript library is no longer compatible with Solidity.
- When casting hex literal numbers into the `bytesN` type, the hex literal may use leading zeros to match the size with the according `bytesN`, which aligns solang with `solc`. [xermicus](https://github.com/xermicus)

### Fixed
- Many bugs have been fixed by [seanyoung](https://github.com/seanyoung), [LucasSte](https://github.com/LucasSte) and [xermicus](https://github.com/xermicus)
- Typos throughout the code have been fixed. [omahs](https://github.com/omahs)