### PR TITLE
Update LLVM compilation steps

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -175,7 +175,8 @@ Now run cmake to create the makefiles. Replace the *installdir* argument to ``CM
 
 	cmake -G Ninja -DLLVM_ENABLE_ASSERTIONS=On '-DLLVM_ENABLE_PROJECTS=clang;lld'  \
 		-DLLVM_ENABLE_TERMINFO=Off -DCMAKE_BUILD_TYPE=Release \
-		-DCMAKE_INSTALL_PREFIX=installdir -B build llvm
+        -DLLVM_ENABLE_ZSTD=Off \
+        -DCMAKE_INSTALL_PREFIX=installdir -B build llvm
 	cmake --build build --target install
 
 Once the build has succeeded, the *installdir*/bin has to be added to your path so the


### PR DESCRIPTION
We must disable ZSTD to build LLVM, so the docs must contain the correct cmake command.