### PR TITLE
Remove unnecessary files from solang crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ description = "Solang Solidity Compiler"
 keywords = [ "solidity", "compiler", "solana", "substrate" ]
 rust-version = "1.64.0"
 edition = "2021"
+exclude = [ "/.*", "/docs",  "/examples", "/solana-library", "/tests", "/integration", "/vscode" ]
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
These files bloat the crate file without any function. The list of files can be seen with `cargo package --list`.