### PR TITLE
Collect the accounts a contract needs

### DIFF
--- a/integration/solana/builtins.spec.ts
+++ b/integration/solana/builtins.spec.ts
@@ -10,7 +10,6 @@ describe('Testing builtins', function () {
     it('builtins', async function () {
         let { program, provider, storage } = await loadContract('builtins');
 
-        // call the constructor
         let res = await program.methods.hashRipemd160(Buffer.from('Call me Ishmael.', 'utf8')).view();
         expect(Buffer.from(res).toString("hex")).toBe("0c8b641c461e3c7abbdabd7f12a8905ee480dadf");
 
@@ -29,13 +28,8 @@ describe('Testing builtins', function () {
         expect(res['return0']).toEqual(new PublicKey("13wtuiEKKtsFgwPmwwtgnELMyK7E8s1bcA8wJi6hFn5A"));
         expect(res['return1']).toEqual([0xfe]);
 
-        let clock: AccountMeta[] = [{
-            pubkey: SYSVAR_CLOCK_PUBKEY, isSigner: false, isWritable: false
-        }];
-
         res = await program.methods.mrNow()
             .accounts({ dataAccount: storage.publicKey })
-            .remainingAccounts(clock)
             .view();
 
         let now = Math.floor(+new Date() / 1000);
@@ -47,7 +41,6 @@ describe('Testing builtins', function () {
 
         res = await program.methods.mrSlot()
             .accounts({ dataAccount: storage.publicKey })
-            .remainingAccounts(clock)
             .view();
 
         let sol_slot = Number(res);

--- a/integration/solana/simple_collectible.spec.ts
+++ b/integration/solana/simple_collectible.spec.ts
@@ -49,7 +49,6 @@ describe('Simple collectible', function () {
             owner_token_account.address)
             .accounts({ dataAccount: storage.publicKey })
             .remainingAccounts([
-                { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
                 { pubkey: mint, isSigner: false, isWritable: true },
                 { pubkey: owner_token_account.address, isSigner: false, isWritable: true },
                 { pubkey: mint_authority.publicKey, isSigner: true, isWritable: true },
@@ -75,7 +74,6 @@ describe('Simple collectible', function () {
             new_owner_token_account.address)
             .accounts({ dataAccount: storage.publicKey })
             .remainingAccounts([
-                { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
                 { pubkey: new_owner_token_account.address, isSigner: false, isWritable: true },
                 { pubkey: owner_token_account.address, isSigner: false, isWritable: true },
                 { pubkey: nft_owner.publicKey, isSigner: true, isWritable: true },

--- a/integration/solana/system_instruction.spec.ts
+++ b/integration/solana/system_instruction.spec.ts
@@ -24,7 +24,6 @@ describe('Test system instructions', function () {
             new BN(5),
             TOKEN_PROGRAM_ID)
             .remainingAccounts([
-                { pubkey: system_account, isSigner: false, isWritable: false },
                 { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
                 { pubkey: payer.publicKey, isSigner: true, isWritable: false },
                 { pubkey: to_key_pair.publicKey, isSigner: true, isWritable: true },
@@ -47,7 +46,6 @@ describe('Test system instructions', function () {
             new BN(5),
             TOKEN_PROGRAM_ID)
             .remainingAccounts([
-                { pubkey: system_account, isSigner: false, isWritable: false },
                 { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
                 { pubkey: payer.publicKey, isSigner: true, isWritable: false },
                 { pubkey: to_key_pair, isSigner: false, isWritable: true },
@@ -66,7 +64,6 @@ describe('Test system instructions', function () {
             to_key_pair.publicKey,
             assign_account)
             .remainingAccounts([
-                { pubkey: system_account, isSigner: false, isWritable: false },
                 { pubkey: payer.publicKey, isSigner: false, isWritable: false },
                 { pubkey: to_key_pair.publicKey, isSigner: true, isWritable: true },
             ])
@@ -85,7 +82,6 @@ describe('Test system instructions', function () {
             seed,
             assign_account)
             .remainingAccounts([
-                { pubkey: system_account, isSigner: false, isWritable: false },
                 { pubkey: assign_account, isSigner: false, isWritable: false },
                 { pubkey: payer.publicKey, isSigner: false, isWritable: false },
                 { pubkey: to_key_pair, isSigner: false, isWritable: true },
@@ -103,7 +99,6 @@ describe('Test system instructions', function () {
             dest.publicKey,
             new BN(100000000))
             .remainingAccounts([
-                { pubkey: system_account, isSigner: false, isWritable: false },
                 { pubkey: payer.publicKey, isSigner: false, isWritable: true },
                 { pubkey: dest.publicKey, isSigner: false, isWritable: true },
             ])

--- a/integration/solana/token.spec.ts
+++ b/integration/solana/token.spec.ts
@@ -56,7 +56,6 @@ describe('Create spl-token and use from solidity', function () {
             new BN(100000))
             .accounts({ dataAccount: storage.publicKey })
             .remainingAccounts([
-                { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
                 { pubkey: mint, isSigner: false, isWritable: true },
                 { pubkey: tokenAccount.address, isSigner: false, isWritable: true },
                 { pubkey: mintAuthority.publicKey, isSigner: true, isWritable: true },
@@ -95,7 +94,6 @@ describe('Create spl-token and use from solidity', function () {
             new BN(70000))
             .accounts({ dataAccount: storage.publicKey })
             .remainingAccounts([
-                { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
                 { pubkey: otherTokenAccount.address, isSigner: false, isWritable: true },
                 { pubkey: tokenAccount.address, isSigner: false, isWritable: true },
                 { pubkey: payer.publicKey, isSigner: true, isWritable: true },
@@ -130,7 +128,6 @@ describe('Create spl-token and use from solidity', function () {
             new BN(20000))
             .accounts({ dataAccount: storage.publicKey })
             .remainingAccounts([
-                { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
                 { pubkey: otherTokenAccount.address, isSigner: false, isWritable: true },
                 { pubkey: mint, isSigner: false, isWritable: true },
                 { pubkey: theOutsider.publicKey, isSigner: true, isWritable: true },

--- a/integration/solana/verify_sig.spec.ts
+++ b/integration/solana/verify_sig.spec.ts
@@ -30,8 +30,8 @@ describe('Signature Check', function () {
 
         const result = await program.methods.verify(payer.publicKey, message, Buffer.from(signature))
             .preInstructions([instr1])
-            .accounts({ dataAccount: storage.publicKey })
-            .remainingAccounts([{ pubkey: SYSVAR_INSTRUCTIONS_PUBKEY, isSigner: false, isWritable: false }])
+            .accounts({ dataAccount: storage.publicKey,
+                SysvarInstruction: SYSVAR_INSTRUCTIONS_PUBKEY})
             .view();
 
         expect(result).toEqual(true);
@@ -54,8 +54,8 @@ describe('Signature Check', function () {
 
         const result = await program.methods.verify(payer.publicKey, message, Buffer.from(broken_signature))
             .preInstructions([instr1])
-            .accounts({ dataAccount: storage.publicKey })
-            .remainingAccounts([{ pubkey: SYSVAR_INSTRUCTIONS_PUBKEY, isSigner: false, isWritable: false }])
+            .accounts({ dataAccount: storage.publicKey,
+                SysvarInstruction: SYSVAR_INSTRUCTIONS_PUBKEY})
             .view();
 
         expect(result).toEqual(false);

--- a/src/abi/mod.rs
+++ b/src/abi/mod.rs
@@ -5,6 +5,7 @@ use crate::Target;
 
 pub mod anchor;
 pub mod ethereum;
+mod solana_accounts;
 pub mod substrate;
 mod tests;
 

--- a/src/abi/solana_accounts.rs
+++ b/src/abi/solana_accounts.rs
@@ -1,0 +1,430 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::codegen::cfg::{ControlFlowGraph, Instr, InternalCallTy};
+use crate::codegen::{Builtin, Expression};
+use crate::sema::ast::Namespace;
+use crate::sema::Recurse;
+use base58::FromBase58;
+use indexmap::IndexSet;
+use num_bigint::{BigInt, Sign};
+use num_traits::Zero;
+use once_cell::sync::Lazy;
+use std::collections::hash_map::Entry;
+use std::collections::{HashMap, HashSet, VecDeque};
+
+/// These are the accounts that we can collect from a contract and that Anchor will populate
+/// automatically if their name matches the source code description:
+/// https://github.com/coral-xyz/anchor/blob/06c42327d4241e5f79c35bc5588ec0a6ad2fedeb/ts/packages/anchor/src/program/accounts-resolver.ts#L54-L60
+#[derive(Hash, Eq, PartialEq, Copy, Clone)]
+pub(super) enum SolanaAccount {
+    ClockAccount,
+    InstructionAccount,
+    SystemAccount,
+    AssociatedProgramId,
+    Rent,
+    TokenProgramId,
+}
+
+/// If the public keys available in AVAILABLE_ACCOUNTS are hardcoded in a Solidity contract
+/// for external calls, we can detect them and leverage Anchor's public key auto populate feature.
+static AVAILABLE_ACCOUNTS: Lazy<HashMap<BigInt, SolanaAccount>> = Lazy::new(|| {
+    HashMap::from([
+        (BigInt::zero(), SolanaAccount::SystemAccount),
+        (
+            BigInt::from_bytes_be(
+                Sign::Plus,
+                &"ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+                    .from_base58()
+                    .unwrap(),
+            ),
+            SolanaAccount::AssociatedProgramId,
+        ),
+        (
+            BigInt::from_bytes_be(
+                Sign::Plus,
+                &"SysvarRent111111111111111111111111111111111"
+                    .from_base58()
+                    .unwrap(),
+            ),
+            SolanaAccount::Rent,
+        ),
+        (
+            BigInt::from_bytes_be(
+                Sign::Plus,
+                &"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+                    .from_base58()
+                    .unwrap(),
+            ),
+            SolanaAccount::TokenProgramId,
+        ),
+        (
+            BigInt::from_bytes_be(
+                Sign::Plus,
+                &"SysvarC1ock11111111111111111111111111111111"
+                    .from_base58()
+                    .unwrap(),
+            ),
+            SolanaAccount::ClockAccount,
+        ),
+    ])
+});
+
+impl SolanaAccount {
+    /// Retrieve a name from an account, according to Anchor's constant accounts map
+    /// https://github.com/coral-xyz/anchor/blob/06c42327d4241e5f79c35bc5588ec0a6ad2fedeb/ts/packages/anchor/src/program/accounts-resolver.ts#L54-L60
+    pub(super) fn name(&self) -> &'static str {
+        match self {
+            SolanaAccount::AssociatedProgramId => "associatedTokenProgram",
+            SolanaAccount::Rent => "rent",
+            SolanaAccount::SystemAccount => "systemProgram",
+            SolanaAccount::TokenProgramId => "tokenProgram",
+            SolanaAccount::ClockAccount => "clock",
+            SolanaAccount::InstructionAccount => "SysvarInstruction",
+        }
+    }
+
+    fn from_number(num: &BigInt) -> Option<SolanaAccount> {
+        AVAILABLE_ACCOUNTS.get(num).cloned()
+    }
+}
+
+/// Struct to save the recursion data when traversing all the CFG instructions
+struct RecurseData<'a> {
+    /// Here we collect all accounts. It is a map between the cfg number of a functions and the
+    /// accounts it requires
+    accounts: HashMap<usize, IndexSet<SolanaAccount>>,
+    /// next_queue saves the set of functions we must check in the next iteration
+    next_queue: IndexSet<(usize, usize)>,
+    /// The number of the function we are currently traversing
+    cfg_func_no: usize,
+    /// The contract the function belongs to
+    contract_no: usize,
+    /// The quantity of accounts we have added the the hashmap 'accounts'
+    accounts_added: usize,
+    ns: &'a Namespace,
+}
+
+impl RecurseData<'_> {
+    /// Add an account to the hashmap
+    fn add_account(&mut self, account: SolanaAccount) {
+        let inserted = match self.accounts.entry(self.cfg_func_no) {
+            Entry::Occupied(mut val) => val.get_mut().insert(account),
+            Entry::Vacant(val) => {
+                val.insert(IndexSet::from([account]));
+                true
+            }
+        };
+
+        if inserted {
+            self.accounts_added += 1;
+        }
+    }
+}
+
+/// Collect the accounts this contract needs
+pub(super) fn collect_accounts_from_contract(
+    contract_no: usize,
+    ns: &Namespace,
+) -> HashMap<usize, IndexSet<SolanaAccount>> {
+    let mut visiting_queue: IndexSet<(usize, usize)> = IndexSet::from_iter(
+        ns.contracts[contract_no]
+            .functions
+            .iter()
+            .map(|ast_no| (contract_no, ns.contracts[contract_no].all_functions[ast_no])),
+    );
+
+    let mut recurse_data = RecurseData {
+        accounts: HashMap::new(),
+        next_queue: IndexSet::new(),
+        cfg_func_no: 0,
+        accounts_added: 0,
+        contract_no,
+        ns,
+    };
+
+    let mut old_size: usize = 0;
+    loop {
+        for (contract_no, func_no) in &visiting_queue {
+            if *func_no == usize::MAX {
+                continue;
+            }
+
+            recurse_data.contract_no = *contract_no;
+            recurse_data.cfg_func_no = *func_no;
+            check_function(&ns.contracts[*contract_no].cfg[*func_no], &mut recurse_data);
+        }
+
+        // This is the convergence condition for this loop.
+        // If we have not added new accounts to the map in this iteration and the queue for the
+        // next iteration does not have any new element, we can stop.
+        if old_size == recurse_data.accounts_added
+            && visiting_queue.len() == recurse_data.next_queue.len()
+        {
+            break;
+        }
+        old_size = recurse_data.accounts_added;
+        std::mem::swap(&mut visiting_queue, &mut recurse_data.next_queue);
+        recurse_data.next_queue.clear();
+    }
+
+    recurse_data.accounts
+}
+
+/// Collect the accounts in a function
+fn check_function(cfg: &ControlFlowGraph, data: &mut RecurseData) {
+    if cfg.blocks.is_empty() {
+        return;
+    }
+    let mut queue: VecDeque<usize> = VecDeque::new();
+    let mut visited: HashSet<usize> = HashSet::new();
+    queue.push_back(0);
+    visited.insert(0);
+
+    while let Some(cur_block) = queue.pop_front() {
+        for instr in &cfg.blocks[cur_block].instr {
+            check_instruction(instr, data);
+        }
+        // TODO: Block edges is an expensive function, we use it six times throughout the code,
+        // perhaps we can just use the dag I calculate during cse.
+        // Changes in constant folding would be necessary
+        for edge in cfg.blocks[cur_block].edges() {
+            if !visited.contains(&edge) {
+                queue.push_back(edge);
+                visited.insert(edge);
+            }
+        }
+    }
+}
+
+/// Collect the accounts in an instruction
+fn check_instruction(instr: &Instr, data: &mut RecurseData) {
+    match instr {
+        Instr::Print { expr }
+        | Instr::LoadStorage { storage: expr, .. }
+        | Instr::ClearStorage { storage: expr, .. }
+        | Instr::BranchCond { cond: expr, .. }
+        | Instr::PopStorage { storage: expr, .. }
+        | Instr::SelfDestruct { recipient: expr }
+        | Instr::Set { expr, .. } => {
+            expr.recurse(data, check_expression);
+        }
+        Instr::Call { call, args, .. } => {
+            if let InternalCallTy::Static { cfg_no } = call {
+                // When we have an internal call, we analyse the current function again and the
+                // function we are calling. This will guarantee convergence when there are
+                // recursive function calls
+                data.next_queue.insert((data.contract_no, *cfg_no));
+                data.next_queue.insert((data.contract_no, data.cfg_func_no));
+                if let Some(callee_accounts) = data.accounts.get(cfg_no).cloned() {
+                    for item in callee_accounts {
+                        data.add_account(item);
+                    }
+                }
+            } else if let InternalCallTy::Builtin { ast_func_no } = call {
+                let name = &data.ns.functions[*ast_func_no].name;
+                if name == "create_program_address" {
+                    data.add_account(SolanaAccount::SystemAccount);
+                }
+            }
+
+            for item in args {
+                item.recurse(data, check_expression);
+            }
+        }
+        Instr::Return { value } => {
+            for item in value {
+                item.recurse(data, check_expression);
+            }
+        }
+        Instr::Branch { .. }
+        | Instr::Nop
+        | Instr::ReturnCode { .. }
+        | Instr::PopMemory { .. }
+        | Instr::Unreachable => (),
+
+        Instr::Store {
+            dest,
+            data: store_data,
+        } => {
+            dest.recurse(data, check_expression);
+            store_data.recurse(data, check_expression);
+        }
+
+        Instr::AssertFailure { encoded_args } => {
+            if let Some(args) = encoded_args {
+                args.recurse(data, check_expression);
+            }
+        }
+
+        Instr::ValueTransfer {
+            address: expr1,
+            value: expr2,
+            ..
+        }
+        | Instr::ReturnData {
+            data: expr1,
+            data_len: expr2,
+        }
+        | Instr::SetStorage {
+            value: expr1,
+            storage: expr2,
+            ..
+        } => {
+            expr1.recurse(data, check_expression);
+            expr2.recurse(data, check_expression);
+        }
+        Instr::WriteBuffer {
+            buf: expr_1,
+            offset: expr_2,
+            value: expr_3,
+        }
+        | Instr::MemCopy {
+            source: expr_1,
+            destination: expr_2,
+            bytes: expr_3,
+        }
+        | Instr::SetStorageBytes {
+            value: expr_1,
+            storage: expr_2,
+            offset: expr_3,
+        } => {
+            expr_1.recurse(data, check_expression);
+            expr_2.recurse(data, check_expression);
+            expr_3.recurse(data, check_expression);
+        }
+
+        Instr::AbiDecode {
+            data: expr,
+            data_len: opt_expr,
+            ..
+        }
+        | Instr::PushStorage {
+            value: opt_expr,
+            storage: expr,
+            ..
+        } => {
+            if let Some(opt_expr) = opt_expr {
+                opt_expr.recurse(data, check_expression);
+            }
+            expr.recurse(data, check_expression);
+        }
+        Instr::PushMemory { value, .. } => {
+            value.recurse(data, check_expression);
+        }
+        Instr::Constructor {
+            encoded_args,
+            encoded_args_len,
+            value,
+            gas,
+            salt,
+            address,
+            seeds,
+            ..
+        } => {
+            encoded_args.recurse(data, check_expression);
+            encoded_args_len.recurse(data, check_expression);
+            if let Some(value) = value {
+                value.recurse(data, check_expression);
+            }
+            gas.recurse(data, check_expression);
+            if let Some(salt) = salt {
+                salt.recurse(data, check_expression);
+            }
+            if let Some(address) = address {
+                address.recurse(data, check_expression);
+            }
+            if let Some(seeds) = seeds {
+                seeds.recurse(data, check_expression);
+            }
+
+            data.add_account(SolanaAccount::SystemAccount);
+        }
+        Instr::ExternalCall {
+            address,
+            accounts,
+            seeds,
+            payload,
+            value,
+            gas,
+            contract_function_no,
+            ..
+        } => {
+            if let Some(address) = address {
+                address.recurse(data, check_expression);
+                if let Expression::NumberLiteral(_, _, num) = address {
+                    // Check if we can auto populate this account
+                    if let Some(account) = SolanaAccount::from_number(num) {
+                        data.add_account(account);
+                    }
+                }
+            }
+            if let Some(accounts) = accounts {
+                accounts.recurse(data, check_expression);
+            }
+            if let Some(seeds) = seeds {
+                seeds.recurse(data, check_expression);
+            }
+            payload.recurse(data, check_expression);
+            value.recurse(data, check_expression);
+            gas.recurse(data, check_expression);
+            // External calls always need the system account
+            data.add_account(SolanaAccount::SystemAccount);
+            if let Some((contract_no, function_no)) = contract_function_no {
+                let cfg_no = data.ns.contracts[*contract_no].all_functions[function_no];
+                if let Some(callee_accounts) = data.accounts.get(&cfg_no).cloned() {
+                    for item in callee_accounts {
+                        data.add_account(item);
+                    }
+                }
+                data.next_queue.insert((*contract_no, cfg_no));
+                data.next_queue.insert((data.contract_no, data.cfg_func_no));
+            }
+        }
+        Instr::EmitEvent {
+            data: data_,
+            topics,
+            ..
+        } => {
+            data_.recurse(data, check_expression);
+
+            for item in topics {
+                item.recurse(data, check_expression);
+            }
+        }
+        Instr::Switch { cond, cases, .. } => {
+            cond.recurse(data, check_expression);
+            for (expr, _) in cases {
+                expr.recurse(data, check_expression);
+            }
+        }
+    }
+}
+
+/// Collect accounts from this expression
+fn check_expression(expr: &Expression, data: &mut RecurseData) -> bool {
+    match expr {
+        Expression::Builtin(
+            _,
+            _,
+            Builtin::Timestamp | Builtin::BlockNumber | Builtin::Slot,
+            ..,
+        ) => {
+            data.add_account(SolanaAccount::ClockAccount);
+        }
+        Expression::Builtin(_, _, Builtin::SignatureVerify, ..) => {
+            data.add_account(SolanaAccount::InstructionAccount);
+        }
+        Expression::Builtin(
+            _,
+            _,
+            Builtin::Ripemd160 | Builtin::Keccak256 | Builtin::Sha256,
+            ..,
+        ) => {
+            data.add_account(SolanaAccount::SystemAccount);
+        }
+
+        _ => (),
+    }
+
+    true
+}

--- a/src/abi/tests.rs
+++ b/src/abi/tests.rs
@@ -3,7 +3,7 @@
 #![cfg(test)]
 
 use crate::abi::anchor::generate_anchor_idl;
-use crate::codegen::{OptimizationLevel, Options};
+use crate::codegen::{codegen, Options};
 use crate::file_resolver::FileResolver;
 use crate::sema::ast::Namespace;
 use crate::{codegen, parse_and_resolve, Target};
@@ -41,7 +41,8 @@ contract caller {
 }
     "#;
 
-    let ns = generate_namespace(src);
+    let mut ns = generate_namespace(src);
+    codegen(&mut ns, &Options::default());
     let idl = generate_anchor_idl(0, &ns);
     assert_eq!(
         idl.version,
@@ -75,7 +76,8 @@ fn constants_and_types() {
     enum Week {Monday, Tuesday, Wednesday}
 }
     "#;
-    let ns = generate_namespace(src);
+    let mut ns = generate_namespace(src);
+    codegen(&mut ns, &Options::default());
     let idl = generate_anchor_idl(0, &ns);
 
     assert!(idl.constants.is_empty());
@@ -177,7 +179,8 @@ fn instructions_and_types() {
 }
     "#;
 
-    let ns = generate_namespace(src);
+    let mut ns = generate_namespace(src);
+    codegen(&mut ns, &Options::default());
     let idl = generate_anchor_idl(0, &ns);
 
     assert_eq!(idl.instructions.len(), 7);
@@ -205,26 +208,15 @@ fn instructions_and_types() {
     assert!(idl.instructions[1].docs.is_none());
     assert_eq!(
         idl.instructions[1].accounts,
-        vec![
-            IdlAccountItem::IdlAccount(IdlAccount {
-                name: "dataAccount".to_string(),
-                is_mut: false,
-                is_signer: false,
-                is_optional: Some(false),
-                docs: None,
-                pda: None,
-                relations: vec![],
-            }),
-            IdlAccountItem::IdlAccount(IdlAccount {
-                name: "systemProgram".to_string(),
-                is_mut: false,
-                is_signer: false,
-                is_optional: Some(false),
-                docs: None,
-                pda: None,
-                relations: vec![],
-            })
-        ]
+        vec![IdlAccountItem::IdlAccount(IdlAccount {
+            name: "dataAccount".to_string(),
+            is_mut: false,
+            is_signer: false,
+            is_optional: Some(false),
+            docs: None,
+            pda: None,
+            relations: vec![],
+        }),]
     );
     assert!(idl.instructions[1].args.is_empty());
     assert_eq!(idl.instructions[1].returns, Some(IdlType::U64));
@@ -234,26 +226,15 @@ fn instructions_and_types() {
     assert!(idl.instructions[2].docs.is_none());
     assert_eq!(
         idl.instructions[2].accounts,
-        vec![
-            IdlAccountItem::IdlAccount(IdlAccount {
-                name: "dataAccount".to_string(),
-                is_mut: false,
-                is_signer: false,
-                is_optional: Some(false),
-                docs: None,
-                pda: None,
-                relations: vec![],
-            }),
-            IdlAccountItem::IdlAccount(IdlAccount {
-                name: "systemProgram".to_string(),
-                is_mut: false,
-                is_signer: false,
-                is_optional: Some(false),
-                docs: None,
-                pda: None,
-                relations: vec![],
-            })
-        ]
+        vec![IdlAccountItem::IdlAccount(IdlAccount {
+            name: "dataAccount".to_string(),
+            is_mut: false,
+            is_signer: false,
+            is_optional: Some(false),
+            docs: None,
+            pda: None,
+            relations: vec![],
+        }),]
     );
     assert_eq!(
         idl.instructions[2].args,
@@ -268,18 +249,7 @@ fn instructions_and_types() {
     // sum function
     assert_eq!(idl.instructions[3].name, "sum");
     assert!(idl.instructions[3].docs.is_none());
-    assert_eq!(
-        idl.instructions[3].accounts,
-        vec![IdlAccountItem::IdlAccount(IdlAccount {
-            name: "systemProgram".into(),
-            is_mut: false,
-            is_signer: false,
-            is_optional: Some(false),
-            docs: None,
-            pda: None,
-            relations: vec![]
-        })]
-    );
+    assert_eq!(idl.instructions[3].accounts, vec![]);
     assert_eq!(
         idl.instructions[3].args,
         vec![
@@ -304,26 +274,15 @@ fn instructions_and_types() {
     );
     assert_eq!(
         idl.instructions[4].accounts,
-        vec![
-            IdlAccountItem::IdlAccount(IdlAccount {
-                name: "dataAccount".to_string(),
-                is_mut: true,
-                is_signer: false,
-                is_optional: Some(false),
-                docs: None,
-                pda: None,
-                relations: vec![],
-            }),
-            IdlAccountItem::IdlAccount(IdlAccount {
-                name: "systemProgram".to_string(),
-                is_mut: false,
-                is_signer: false,
-                is_optional: Some(false),
-                docs: None,
-                pda: None,
-                relations: vec![],
-            })
-        ]
+        vec![IdlAccountItem::IdlAccount(IdlAccount {
+            name: "dataAccount".to_string(),
+            is_mut: true,
+            is_signer: false,
+            is_optional: Some(false),
+            docs: None,
+            pda: None,
+            relations: vec![],
+        }),]
     );
     assert_eq!(
         idl.instructions[4].args,
@@ -342,26 +301,15 @@ fn instructions_and_types() {
     );
     assert_eq!(
         idl.instructions[5].accounts,
-        vec![
-            IdlAccountItem::IdlAccount(IdlAccount {
-                name: "dataAccount".to_string(),
-                is_mut: false,
-                is_signer: false,
-                is_optional: Some(false),
-                docs: None,
-                pda: None,
-                relations: vec![],
-            }),
-            IdlAccountItem::IdlAccount(IdlAccount {
-                name: "systemProgram".to_string(),
-                is_mut: false,
-                is_signer: false,
-                is_optional: Some(false),
-                docs: None,
-                pda: None,
-                relations: vec![],
-            })
-        ]
+        vec![IdlAccountItem::IdlAccount(IdlAccount {
+            name: "dataAccount".to_string(),
+            is_mut: false,
+            is_signer: false,
+            is_optional: Some(false),
+            docs: None,
+            pda: None,
+            relations: vec![],
+        }),]
     );
     assert!(idl.instructions[5].args.is_empty());
     assert_eq!(idl.instructions[5].returns, Some(IdlType::String));
@@ -370,26 +318,15 @@ fn instructions_and_types() {
     assert!(idl.instructions[6].docs.is_none());
     assert_eq!(
         idl.instructions[6].accounts,
-        vec![
-            IdlAccountItem::IdlAccount(IdlAccount {
-                name: "dataAccount".to_string(),
-                is_mut: true,
-                is_signer: false,
-                is_optional: Some(false),
-                docs: None,
-                pda: None,
-                relations: vec![],
-            }),
-            IdlAccountItem::IdlAccount(IdlAccount {
-                name: "systemProgram".to_string(),
-                is_mut: false,
-                is_signer: false,
-                is_optional: Some(false),
-                docs: None,
-                pda: None,
-                relations: vec![],
-            })
-        ]
+        vec![IdlAccountItem::IdlAccount(IdlAccount {
+            name: "dataAccount".to_string(),
+            is_mut: true,
+            is_signer: false,
+            is_optional: Some(false),
+            docs: None,
+            pda: None,
+            relations: vec![],
+        }),]
     );
     assert!(idl.instructions[6].args.is_empty());
     assert_eq!(
@@ -450,21 +387,7 @@ contract caller {
 
     let mut ns = generate_namespace(src);
     // We need this to populate Contract.emit_events
-    codegen::codegen(
-        &mut ns,
-        &Options {
-            dead_storage: false,
-            constant_folding: false,
-            strength_reduce: false,
-            vector_to_slice: false,
-            math_overflow_check: false,
-            common_subexpression_elimination: false,
-            generate_debug_information: false,
-            opt_level: OptimizationLevel::None,
-            log_api_return_codes: false,
-            log_runtime_errors: false,
-        },
-    );
+    codegen::codegen(&mut ns, &Options::default());
 
     let idl = generate_anchor_idl(0, &ns);
 
@@ -492,26 +415,15 @@ contract caller {
     assert!(idl.instructions[1].docs.is_none());
     assert_eq!(
         idl.instructions[1].accounts,
-        vec![
-            IdlAccountItem::IdlAccount(IdlAccount {
-                name: "dataAccount".to_string(),
-                is_mut: true,
-                is_signer: false,
-                is_optional: Some(false),
-                docs: None,
-                pda: None,
-                relations: vec![],
-            }),
-            IdlAccountItem::IdlAccount(IdlAccount {
-                name: "systemProgram".to_string(),
-                is_mut: false,
-                is_signer: false,
-                is_optional: Some(false),
-                docs: None,
-                pda: None,
-                relations: vec![],
-            })
-        ]
+        vec![IdlAccountItem::IdlAccount(IdlAccount {
+            name: "dataAccount".to_string(),
+            is_mut: true,
+            is_signer: false,
+            is_optional: Some(false),
+            docs: None,
+            pda: None,
+            relations: vec![],
+        }),]
     );
     assert_eq!(
         idl.instructions[1].args,
@@ -631,7 +543,8 @@ fn types() {
 }
     "#;
 
-    let ns = generate_namespace(src);
+    let mut ns = generate_namespace(src);
+    codegen(&mut ns, &Options::default());
     let idl = generate_anchor_idl(0, &ns);
 
     assert_eq!(idl.instructions.len(), 2);
@@ -657,26 +570,15 @@ fn types() {
     assert_eq!(idl.instructions[1].name, "myFunc");
     assert_eq!(
         idl.instructions[1].accounts,
-        vec![
-            IdlAccountItem::IdlAccount(IdlAccount {
-                name: "dataAccount".to_string(),
-                is_mut: true,
-                is_signer: false,
-                is_optional: Some(false),
-                docs: None,
-                pda: None,
-                relations: vec![],
-            }),
-            IdlAccountItem::IdlAccount(IdlAccount {
-                name: "systemProgram".to_string(),
-                is_mut: false,
-                is_signer: false,
-                is_optional: Some(false),
-                docs: None,
-                pda: None,
-                relations: vec![],
-            })
-        ]
+        vec![IdlAccountItem::IdlAccount(IdlAccount {
+            name: "dataAccount".to_string(),
+            is_mut: true,
+            is_signer: false,
+            is_optional: Some(false),
+            docs: None,
+            pda: None,
+            relations: vec![],
+        }),]
     );
     assert_eq!(
         idl.instructions[1].args,
@@ -707,7 +609,24 @@ fn types() {
     assert!(idl.state.is_none());
     assert!(idl.accounts.is_empty());
     assert!(idl.types.is_empty());
-    assert!(idl.events.is_none());
+    assert_eq!(
+        idl.events.unwrap(),
+        vec![IdlEvent {
+            name: "Event1".to_string(),
+            fields: vec![
+                IdlEventField {
+                    name: "field_0".to_string(),
+                    ty: IdlType::I32,
+                    index: false,
+                },
+                IdlEventField {
+                    name: "field_1".to_string(),
+                    ty: IdlType::U32,
+                    index: false,
+                }
+            ]
+        }]
+    );
     assert!(idl.errors.is_none());
     assert!(idl.metadata.is_none());
 }
@@ -726,7 +645,8 @@ fn constructor() {
     }
 }
     "#;
-    let ns = generate_namespace(src);
+    let mut ns = generate_namespace(src);
+    codegen(&mut ns, &Options::default());
     let idl = generate_anchor_idl(0, &ns);
 
     assert_eq!(idl.name, "caller");
@@ -738,26 +658,15 @@ fn constructor() {
     assert!(idl.instructions[0].docs.is_none());
     assert_eq!(
         idl.instructions[0].accounts,
-        vec![
-            IdlAccountItem::IdlAccount(IdlAccount {
-                name: "dataAccount".to_string(),
-                is_mut: true,
-                is_signer: false,
-                is_optional: Some(false),
-                docs: None,
-                pda: None,
-                relations: vec![],
-            }),
-            IdlAccountItem::IdlAccount(IdlAccount {
-                name: "systemProgram".to_string(),
-                is_mut: false,
-                is_signer: false,
-                is_optional: Some(false),
-                docs: None,
-                pda: None,
-                relations: vec![],
-            })
-        ]
+        vec![IdlAccountItem::IdlAccount(IdlAccount {
+            name: "dataAccount".to_string(),
+            is_mut: true,
+            is_signer: false,
+            is_optional: Some(false),
+            docs: None,
+            pda: None,
+            relations: vec![],
+        }),]
     );
     assert_eq!(
         idl.instructions[0].args,
@@ -773,26 +682,15 @@ fn constructor() {
     assert!(idl.instructions[1].docs.is_none());
     assert_eq!(
         idl.instructions[1].accounts,
-        vec![
-            IdlAccountItem::IdlAccount(IdlAccount {
-                name: "dataAccount".to_string(),
-                is_mut: false,
-                is_signer: false,
-                is_optional: Some(false),
-                docs: None,
-                pda: None,
-                relations: vec![],
-            }),
-            IdlAccountItem::IdlAccount(IdlAccount {
-                name: "systemProgram".to_string(),
-                is_mut: false,
-                is_signer: false,
-                is_optional: Some(false),
-                docs: None,
-                pda: None,
-                relations: vec![],
-            })
-        ]
+        vec![IdlAccountItem::IdlAccount(IdlAccount {
+            name: "dataAccount".to_string(),
+            is_mut: false,
+            is_signer: false,
+            is_optional: Some(false),
+            docs: None,
+            pda: None,
+            relations: vec![],
+        }),]
     );
     assert!(idl.instructions[1].args.is_empty());
     assert_eq!(idl.instructions[1].returns, Some(IdlType::U64));
@@ -815,7 +713,8 @@ contract Testing {
     }
 }    "#;
 
-    let ns = generate_namespace(src);
+    let mut ns = generate_namespace(src);
+    codegen(&mut ns, &Options::default());
     let idl = generate_anchor_idl(0, &ns);
 
     assert_eq!(idl.instructions.len(), 2);
@@ -899,7 +798,8 @@ contract Testing {
 }
     "#;
 
-    let ns = generate_namespace(src);
+    let mut ns = generate_namespace(src);
+    codegen(&mut ns, &Options::default());
     let idl = generate_anchor_idl(0, &ns);
 
     assert_eq!(idl.instructions.len(), 3);
@@ -908,18 +808,7 @@ contract Testing {
 
     assert_eq!(idl.instructions[1].name, "getNum_uint64_uint64");
     assert!(idl.instructions[1].docs.is_none());
-    assert_eq!(
-        idl.instructions[1].accounts,
-        vec![IdlAccountItem::IdlAccount(IdlAccount {
-            name: "systemProgram".into(),
-            is_mut: false,
-            is_signer: false,
-            is_optional: Some(false),
-            docs: None,
-            pda: None,
-            relations: vec![]
-        })]
-    );
+    assert_eq!(idl.instructions[1].accounts, vec![]);
     assert_eq!(idl.instructions[1].args.len(), 2);
     assert_eq!(
         idl.instructions[1].args[0],
@@ -944,18 +833,7 @@ contract Testing {
 
     assert_eq!(idl.instructions[2].name, "getNum_int32_int32");
     assert!(idl.instructions[2].docs.is_none());
-    assert_eq!(
-        idl.instructions[1].accounts,
-        vec![IdlAccountItem::IdlAccount(IdlAccount {
-            name: "systemProgram".into(),
-            is_mut: false,
-            is_signer: false,
-            is_optional: Some(false),
-            docs: None,
-            pda: None,
-            relations: vec![]
-        })]
-    );
+    assert_eq!(idl.instructions[1].accounts, vec![]);
 
     assert_eq!(idl.instructions[2].args.len(), 2);
     assert_eq!(
@@ -1050,7 +928,8 @@ fn name_collision() {
 }
     "#;
 
-    let ns = generate_namespace(str);
+    let mut ns = generate_namespace(str);
+    codegen(&mut ns, &Options::default());
     let idl = generate_anchor_idl(0, &ns);
 
     assert_eq!(idl.types.len(), 3);
@@ -1143,7 +1022,8 @@ fn double_name_collision() {
 }
     "#;
 
-    let ns = generate_namespace(str);
+    let mut ns = generate_namespace(str);
+    codegen(&mut ns, &Options::default());
     let idl = generate_anchor_idl(0, &ns);
 
     assert_eq!(idl.types.len(), 4);
@@ -1243,21 +1123,7 @@ fn deduplication() {
 
     let mut ns = generate_namespace(src);
     // We need this to populate Contract.emit_events
-    codegen::codegen(
-        &mut ns,
-        &Options {
-            dead_storage: false,
-            constant_folding: false,
-            strength_reduce: false,
-            vector_to_slice: false,
-            math_overflow_check: false,
-            common_subexpression_elimination: false,
-            generate_debug_information: false,
-            opt_level: OptimizationLevel::None,
-            log_api_return_codes: false,
-            log_runtime_errors: false,
-        },
-    );
+    codegen::codegen(&mut ns, &Options::default());
 
     let idl = generate_anchor_idl(0, &ns);
 
@@ -1361,7 +1227,8 @@ contract C {
 }
     "#;
 
-    let ns = generate_namespace(src);
+    let mut ns = generate_namespace(src);
+    codegen(&mut ns, &Options::default());
     let idl = generate_anchor_idl(1, &ns);
 
     assert_eq!(idl.types.len(), 2);
@@ -1379,7 +1246,8 @@ contract C {
 }
     "#;
 
-    let ns = generate_namespace(src);
+    let mut ns = generate_namespace(src);
+    codegen(&mut ns, &Options::default());
     let idl = generate_anchor_idl(1, &ns);
 
     assert_eq!(idl.types.len(), 2);
@@ -1399,7 +1267,8 @@ contract C {
 }
     "#;
 
-    let ns = generate_namespace(src);
+    let mut ns = generate_namespace(src);
+    codegen(&mut ns, &Options::default());
     let idl = generate_anchor_idl(1, &ns);
     assert_eq!(idl.types.len(), 2);
     assert_eq!(idl.types[0].name, "Foo");
@@ -1418,7 +1287,8 @@ contract C {
 }
     "#;
 
-    let ns = generate_namespace(src);
+    let mut ns = generate_namespace(src);
+    codegen(&mut ns, &Options::default());
     let idl = generate_anchor_idl(1, &ns);
 
     assert_eq!(idl.types.len(), 2);
@@ -1441,7 +1311,8 @@ contract C {
 }
     "#;
 
-    let ns = generate_namespace(src);
+    let mut ns = generate_namespace(src);
+    codegen(&mut ns, &Options::default());
     let idl = generate_anchor_idl(1, &ns);
 
     assert_eq!(idl.types.len(), 3);
@@ -1464,7 +1335,8 @@ contract C {
         function f(Foo y,  D.Foo x, D_Foo z) public pure returns (int64) { return x.f1 + z.f2; }
 }
     "#;
-    let ns = generate_namespace(src);
+    let mut ns = generate_namespace(src);
+    codegen(&mut ns, &Options::default());
     let idl = generate_anchor_idl(1, &ns);
 
     assert_eq!(idl.types.len(), 3);
@@ -1487,7 +1359,8 @@ contract C {
         function f(D_Foo z, Foo y,  D.Foo x) public pure returns (int64) { return x.f1 + z.f2; }
 }
     "#;
-    let ns = generate_namespace(src);
+    let mut ns = generate_namespace(src);
+    codegen(&mut ns, &Options::default());
     let idl = generate_anchor_idl(1, &ns);
 
     assert_eq!(idl.types.len(), 3);
@@ -1515,7 +1388,8 @@ contract C {
 }
     "#;
 
-    let ns = generate_namespace(src);
+    let mut ns = generate_namespace(src);
+    codegen(&mut ns, &Options::default());
     let idl = generate_anchor_idl(1, &ns);
 
     assert_eq!(idl.types.len(), 4);
@@ -1544,7 +1418,8 @@ contract C {
 }
     "#;
 
-    let ns = generate_namespace(src);
+    let mut ns = generate_namespace(src);
+    codegen(&mut ns, &Options::default());
     let idl = generate_anchor_idl(1, &ns);
 
     assert_eq!(idl.types.len(), 4);
@@ -1573,7 +1448,8 @@ contract C {
 }
     "#;
 
-    let ns = generate_namespace(src);
+    let mut ns = generate_namespace(src);
+    codegen(&mut ns, &Options::default());
     let idl = generate_anchor_idl(1, &ns);
 
     assert_eq!(idl.types.len(), 4);
@@ -1602,7 +1478,8 @@ contract C {
 }
     "#;
 
-    let ns = generate_namespace(src);
+    let mut ns = generate_namespace(src);
+    codegen(&mut ns, &Options::default());
     let idl = generate_anchor_idl(1, &ns);
 
     assert_eq!(idl.types.len(), 4);
@@ -1629,7 +1506,8 @@ contract C {
 }
     "#;
 
-    let ns = generate_namespace(src);
+    let mut ns = generate_namespace(src);
+    codegen(&mut ns, &Options::default());
     let idl = generate_anchor_idl(0, &ns);
 
     assert!(idl.metadata.is_some());
@@ -1648,7 +1526,8 @@ fn data_account_signer() {
         constructor(address wallet) {}
     }"#;
 
-    let ns = generate_namespace(src);
+    let mut ns = generate_namespace(src);
+    codegen(&mut ns, &Options::default());
     let idl = generate_anchor_idl(0, &ns);
 
     assert_eq!(idl.instructions.len(), 1);
@@ -1699,7 +1578,8 @@ fn data_account_signer() {
         constructor(address wallet) {}
     }"#;
 
-    let ns = generate_namespace(src);
+    let mut ns = generate_namespace(src);
+    codegen(&mut ns, &Options::default());
     let idl = generate_anchor_idl(0, &ns);
 
     assert_eq!(idl.instructions.len(), 1);
@@ -1740,4 +1620,635 @@ fn data_account_signer() {
     );
     assert!(idl.instructions[0].args.len() == 1);
     assert!(idl.instructions[0].returns.is_none());
+}
+
+#[test]
+fn accounts_call_chain() {
+    let src = r#"
+    contract Test {
+    function call_1() public view returns (uint64) {
+        return call_2();
+    }
+
+    function call_2() public view returns (uint64) {
+        return call_3();
+    }
+
+    function call_3() public view returns (uint64) {
+        return block.timestamp;
+    }
+}
+    "#;
+    let mut ns = generate_namespace(src);
+    codegen(&mut ns, &Options::default());
+    let idl = generate_anchor_idl(0, &ns);
+
+    assert_eq!(idl.instructions[0].name, "new");
+    assert_eq!(
+        idl.instructions[0].accounts,
+        vec![IdlAccountItem::IdlAccount(IdlAccount {
+            name: "dataAccount".to_string(),
+            is_mut: true,
+            is_signer: false,
+            is_optional: Some(false),
+            docs: None,
+            pda: None,
+            relations: vec![],
+        })]
+    );
+
+    assert_eq!(idl.instructions[1].name, "call_1");
+    assert_eq!(
+        idl.instructions[1].accounts,
+        vec![
+            IdlAccountItem::IdlAccount(IdlAccount {
+                name: "dataAccount".to_string(),
+                is_mut: false,
+                is_signer: false,
+                is_optional: Some(false),
+                docs: None,
+                pda: None,
+                relations: vec![],
+            }),
+            IdlAccountItem::IdlAccount(IdlAccount {
+                name: "clock".to_string(),
+                is_mut: false,
+                is_signer: false,
+                is_optional: Some(false),
+                docs: None,
+                pda: None,
+                relations: vec![]
+            })
+        ]
+    );
+
+    assert_eq!(idl.instructions[2].name, "call_2");
+    assert_eq!(idl.instructions[2].accounts, idl.instructions[1].accounts);
+
+    assert_eq!(idl.instructions[3].name, "call_3");
+    assert_eq!(idl.instructions[3].accounts, idl.instructions[1].accounts);
+}
+
+#[test]
+fn accounts_on_recursion() {
+    let src = r#"
+        contract Test {
+    address addr;
+    bytes message;
+    bytes signature;
+
+    constructor(address addr_, bytes message_, bytes signature_) {
+        addr = addr_;
+        message = message_;
+        signature = signature_;
+    }
+
+
+    function call_1() public view returns (bool, uint64) {
+        return call_2();
+    }
+
+    function call_2() public view returns (bool, uint64) {
+        (bool a, uint64 b) = call_3();
+        return (signatureVerify(addr, message, signature), b);
+    }
+
+    function call_3() public view returns (bool, uint64) {
+        (bool a, uint64 b) = call_1();
+        return (a, block.timestamp);
+    }
+}
+    "#;
+
+    let mut ns = generate_namespace(src);
+    codegen(&mut ns, &Options::default());
+    let idl = generate_anchor_idl(0, &ns);
+
+    assert_eq!(idl.instructions[0].name, "new");
+    assert_eq!(
+        idl.instructions[0].accounts,
+        vec![IdlAccountItem::IdlAccount(IdlAccount {
+            name: "dataAccount".to_string(),
+            is_mut: true,
+            is_signer: false,
+            is_optional: Some(false),
+            docs: None,
+            pda: None,
+            relations: vec![],
+        })]
+    );
+
+    assert_eq!(idl.instructions[1].name, "call_1");
+    assert_eq!(
+        idl.instructions[1].accounts,
+        vec![
+            IdlAccountItem::IdlAccount(IdlAccount {
+                name: "dataAccount".to_string(),
+                is_mut: false,
+                is_signer: false,
+                is_optional: Some(false),
+                docs: None,
+                pda: None,
+                relations: vec![],
+            }),
+            IdlAccountItem::IdlAccount(IdlAccount {
+                name: "SysvarInstruction".to_string(),
+                is_mut: false,
+                is_signer: false,
+                is_optional: Some(false),
+                docs: None,
+                pda: None,
+                relations: vec![]
+            }),
+            IdlAccountItem::IdlAccount(IdlAccount {
+                name: "clock".to_string(),
+                is_mut: false,
+                is_signer: false,
+                is_optional: Some(false),
+                docs: None,
+                pda: None,
+                relations: vec![]
+            })
+        ]
+    );
+
+    assert_eq!(idl.instructions[2].name, "call_2");
+    assert_eq!(idl.instructions[2].accounts, idl.instructions[1].accounts);
+
+    assert_eq!(idl.instructions[3].name, "call_3");
+    assert_eq!(
+        idl.instructions[3].accounts[0],
+        idl.instructions[1].accounts[0]
+    );
+    assert_eq!(
+        idl.instructions[3].accounts[1],
+        idl.instructions[1].accounts[2]
+    );
+    assert_eq!(
+        idl.instructions[3].accounts[2],
+        idl.instructions[1].accounts[1]
+    );
+}
+
+#[test]
+fn system_account_for_payer_annotation() {
+    let src = r#"
+    contract Test {
+    address addr;
+    bytes message;
+    bytes signature;
+
+    @payer(addr_)
+    constructor(address addr_, bytes message_, bytes signature_) {
+        addr = addr_;
+        message = message_;
+        signature = signature_;
+    }
+
+    function call_3() public view returns (bool, uint64) {
+        return (true, block.timestamp);
+    }
+}
+    "#;
+    let mut ns = generate_namespace(src);
+    codegen(&mut ns, &Options::default());
+    let idl = generate_anchor_idl(0, &ns);
+
+    assert_eq!(idl.instructions[0].name, "new");
+    assert_eq!(
+        idl.instructions[0].accounts,
+        vec![
+            IdlAccountItem::IdlAccount(IdlAccount {
+                name: "dataAccount".to_string(),
+                is_mut: true,
+                is_signer: true,
+                is_optional: Some(false),
+                docs: None,
+                pda: None,
+                relations: vec![],
+            }),
+            IdlAccountItem::IdlAccount(IdlAccount {
+                name: "wallet".to_string(),
+                is_mut: false,
+                is_signer: true,
+                is_optional: Some(false),
+                docs: None,
+                pda: None,
+                relations: vec![]
+            }),
+            IdlAccountItem::IdlAccount(IdlAccount {
+                name: "systemProgram".to_string(),
+                is_mut: false,
+                is_signer: false,
+                is_optional: Some(false),
+                docs: None,
+                pda: None,
+                relations: vec![]
+            })
+        ]
+    );
+}
+
+#[test]
+fn calling_system_program() {
+    let src = r#"
+        import 'solana';
+
+library SystemInstruction {
+    address constant systemAddress = address"11111111111111111111111111111111";
+    enum Instruction {
+        CreateAccount,
+        Assign
+    }
+
+    function create_account(address from, address to, uint64 lamports, uint64 space, address owner) internal {
+        AccountMeta[2] metas = [
+            AccountMeta({pubkey: from, is_signer: true, is_writable: true}),
+            AccountMeta({pubkey: to, is_signer: true, is_writable: true})
+        ];
+        bytes bincode = abi.encode(uint32(Instruction.CreateAccount), lamports, space, owner);
+        systemAddress.call{accounts: metas}(bincode);
+    }
+}
+
+contract Test {
+
+    function call_1(address from, address to, uint64 lamports, uint64 space, address owner) public {
+        SystemInstruction.create_account(from, to, lamports, space, owner);
+    }
+}
+    "#;
+
+    let mut ns = generate_namespace(src);
+    codegen(&mut ns, &Options::default());
+    let idl = generate_anchor_idl(1, &ns);
+
+    assert_eq!(idl.instructions[0].name, "new");
+
+    assert_eq!(idl.instructions[1].name, "call_1");
+    assert_eq!(
+        idl.instructions[1].accounts,
+        vec![
+            IdlAccountItem::IdlAccount(IdlAccount {
+                name: "dataAccount".to_string(),
+                is_mut: true,
+                is_signer: false,
+                is_optional: Some(false),
+                docs: None,
+                pda: None,
+                relations: vec![],
+            }),
+            IdlAccountItem::IdlAccount(IdlAccount {
+                name: "systemProgram".to_string(),
+                is_mut: false,
+                is_signer: false,
+                is_optional: Some(false),
+                docs: None,
+                pda: None,
+                relations: vec![]
+            })
+        ]
+    );
+}
+
+#[test]
+fn call_token_program() {
+    let src = r#"
+    import 'solana';
+
+library TokenProgram {
+    address constant systemAddress = address"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+    enum Instruction {
+        CreateAccount,
+        Assign
+    }
+
+    function create_account(address from, address to, uint64 lamports, uint64 space, address owner) internal {
+        AccountMeta[2] metas = [
+            AccountMeta({pubkey: from, is_signer: true, is_writable: true}),
+            AccountMeta({pubkey: to, is_signer: true, is_writable: true})
+        ];
+        bytes bincode = abi.encode(uint32(Instruction.CreateAccount), lamports, space, owner);
+        systemAddress.call{accounts: metas}(bincode);
+    }
+}
+
+contract Test {
+
+    function call_1(address from, address to, uint64 lamports, uint64 space, address owner) public {
+        TokenProgram.create_account(from, to, lamports, space, owner);
+    }
+}
+    "#;
+    let mut ns = generate_namespace(src);
+    codegen(&mut ns, &Options::default());
+    let idl = generate_anchor_idl(1, &ns);
+
+    assert_eq!(idl.instructions[0].name, "new");
+
+    assert_eq!(idl.instructions[1].name, "call_1");
+    assert_eq!(
+        idl.instructions[1].accounts,
+        vec![
+            IdlAccountItem::IdlAccount(IdlAccount {
+                name: "dataAccount".to_string(),
+                is_mut: true,
+                is_signer: false,
+                is_optional: Some(false),
+                docs: None,
+                pda: None,
+                relations: vec![],
+            }),
+            IdlAccountItem::IdlAccount(IdlAccount {
+                name: "tokenProgram".to_string(),
+                is_mut: false,
+                is_signer: false,
+                is_optional: Some(false),
+                docs: None,
+                pda: None,
+                relations: vec![],
+            }),
+            IdlAccountItem::IdlAccount(IdlAccount {
+                name: "systemProgram".to_string(),
+                is_mut: false,
+                is_signer: false,
+                is_optional: Some(false),
+                docs: None,
+                pda: None,
+                relations: vec![]
+            })
+        ]
+    );
+}
+
+#[test]
+fn other_collected_public_keys() {
+    let src = r#"
+    import 'solana';
+
+anchor_anchor constant anchor = anchor_anchor(address'SysvarRent111111111111111111111111111111111');
+
+interface anchor_anchor {
+	@selector([0xaf,0xaf,0x6d,0x1f,0x0d,0x98,0x9b,0xed])
+	function initialize(bool data1) view external;
+}
+
+associated constant ass = associated(address'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL');
+
+interface associated {
+	@selector([0xaf,0xaf,0x6d,0x1f,0x0d,0x98,0x9b,0xed])
+	function initialize(bool data1) view external;
+}
+
+
+clock_interface constant my_clock = clock_interface(address'SysvarC1ock11111111111111111111111111111111');
+
+interface clock_interface {
+	@selector([0xaf,0xaf,0x6d,0x1f,0x0d,0x98,0x9b,0xed])
+	function initialize(bool data1) view external;
+}
+
+other_interface constant other_inter = other_interface(address'z7FbDfQDfucxJz5o8jrGLgvSbdoeSqX5VrxBb5TVjHq');
+
+interface other_interface {
+	@selector([0xaf,0xaf,0x6d,0x1f,0x0d,0x98,0x9b,0xed])
+	function initialize(bool data1) view external;
+}
+
+contract Test {
+    function call_1() public {
+        anchor.initialize(true);
+    }
+
+    function call_2() public {
+        ass.initialize(false);
+    }
+
+    function call_3() public {
+        my_clock.initialize(true);
+    }
+
+    function call_4() public {
+        other_inter.initialize(false);
+    }
+}
+    "#;
+
+    let mut ns = generate_namespace(src);
+    codegen(&mut ns, &Options::default());
+    let idl = generate_anchor_idl(4, &ns);
+
+    assert_eq!(idl.instructions[0].name, "new");
+    assert_eq!(
+        idl.instructions[0].accounts,
+        vec![IdlAccountItem::IdlAccount(IdlAccount {
+            name: "dataAccount".to_string(),
+            is_mut: true,
+            is_signer: false,
+            is_optional: Some(false),
+            docs: None,
+            pda: None,
+            relations: vec![],
+        }),]
+    );
+
+    assert_eq!(idl.instructions[1].name, "call_1");
+    assert_eq!(
+        idl.instructions[1].accounts,
+        vec![
+            IdlAccountItem::IdlAccount(IdlAccount {
+                name: "dataAccount".to_string(),
+                is_mut: true,
+                is_signer: false,
+                is_optional: Some(false),
+                docs: None,
+                pda: None,
+                relations: vec![],
+            }),
+            IdlAccountItem::IdlAccount(IdlAccount {
+                name: "rent".to_string(),
+                is_mut: false,
+                is_signer: false,
+                is_optional: Some(false),
+                docs: None,
+                pda: None,
+                relations: vec![],
+            }),
+            IdlAccountItem::IdlAccount(IdlAccount {
+                name: "systemProgram".to_string(),
+                is_mut: false,
+                is_signer: false,
+                is_optional: Some(false),
+                docs: None,
+                pda: None,
+                relations: vec![]
+            })
+        ]
+    );
+
+    assert_eq!(idl.instructions[2].name, "call_2");
+    assert_eq!(
+        idl.instructions[2].accounts,
+        vec![
+            IdlAccountItem::IdlAccount(IdlAccount {
+                name: "dataAccount".to_string(),
+                is_mut: true,
+                is_signer: false,
+                is_optional: Some(false),
+                docs: None,
+                pda: None,
+                relations: vec![],
+            }),
+            IdlAccountItem::IdlAccount(IdlAccount {
+                name: "associatedTokenProgram".to_string(),
+                is_mut: false,
+                is_signer: false,
+                is_optional: Some(false),
+                docs: None,
+                pda: None,
+                relations: vec![],
+            }),
+            IdlAccountItem::IdlAccount(IdlAccount {
+                name: "systemProgram".to_string(),
+                is_mut: false,
+                is_signer: false,
+                is_optional: Some(false),
+                docs: None,
+                pda: None,
+                relations: vec![]
+            })
+        ]
+    );
+
+    assert_eq!(idl.instructions[3].name, "call_3");
+    assert_eq!(
+        idl.instructions[3].accounts,
+        vec![
+            IdlAccountItem::IdlAccount(IdlAccount {
+                name: "dataAccount".to_string(),
+                is_mut: true,
+                is_signer: false,
+                is_optional: Some(false),
+                docs: None,
+                pda: None,
+                relations: vec![],
+            }),
+            IdlAccountItem::IdlAccount(IdlAccount {
+                name: "clock".to_string(),
+                is_mut: false,
+                is_signer: false,
+                is_optional: Some(false),
+                docs: None,
+                pda: None,
+                relations: vec![],
+            }),
+            IdlAccountItem::IdlAccount(IdlAccount {
+                name: "systemProgram".to_string(),
+                is_mut: false,
+                is_signer: false,
+                is_optional: Some(false),
+                docs: None,
+                pda: None,
+                relations: vec![]
+            })
+        ]
+    );
+
+    assert_eq!(idl.instructions[4].name, "call_4");
+    assert_eq!(
+        idl.instructions[4].accounts,
+        vec![
+            IdlAccountItem::IdlAccount(IdlAccount {
+                name: "dataAccount".to_string(),
+                is_mut: true,
+                is_signer: false,
+                is_optional: Some(false),
+                docs: None,
+                pda: None,
+                relations: vec![],
+            }),
+            IdlAccountItem::IdlAccount(IdlAccount {
+                name: "systemProgram".to_string(),
+                is_mut: false,
+                is_signer: false,
+                is_optional: Some(false),
+                docs: None,
+                pda: None,
+                relations: vec![]
+            })
+        ]
+    );
+}
+
+#[test]
+fn multiple_contracts() {
+    let src = r#"
+    import 'solana';
+
+contract creator {
+    Child public c;
+
+    function create_child(address child, address payer) public returns (uint64) {
+        print("Going to create child");
+        c = new Child{address: child}(payer);
+
+        return c.say_hello();
+    }
+}
+
+@program_id("Chi1d5XD6nTAp2EyaNGqMxZzUjh6NvhXRxbGHP3D1RaT")
+contract Child {
+    @payer(payer)
+    @space(511 + 7)
+    constructor(address payer) {
+        print("In child constructor");
+    }
+
+    function say_hello() public view returns (uint64) {
+        print("Hello there");
+        return block.slot;
+    }
+}
+    "#;
+
+    let mut ns = generate_namespace(src);
+    codegen(&mut ns, &Options::default());
+    let idl = generate_anchor_idl(0, &ns);
+
+    assert_eq!(idl.instructions[0].name, "new");
+    assert_eq!(idl.instructions[1].name, "c");
+    assert_eq!(idl.instructions[2].name, "create_child");
+
+    assert_eq!(
+        idl.instructions[2].accounts,
+        vec![
+            IdlAccountItem::IdlAccount(IdlAccount {
+                name: "dataAccount".to_string(),
+                is_mut: true,
+                is_signer: false,
+                is_optional: Some(false),
+                docs: None,
+                pda: None,
+                relations: vec![],
+            }),
+            IdlAccountItem::IdlAccount(IdlAccount {
+                name: "systemProgram".to_string(),
+                is_mut: false,
+                is_signer: false,
+                is_optional: Some(false),
+                docs: None,
+                pda: None,
+                relations: vec![],
+            }),
+            IdlAccountItem::IdlAccount(IdlAccount {
+                name: "clock".to_string(),
+                is_mut: false,
+                is_signer: false,
+                is_optional: Some(false),
+                docs: None,
+                pda: None,
+                relations: vec![]
+            })
+        ]
+    );
 }

--- a/src/codegen/constant_folding.rs
+++ b/src/codegen/constant_folding.rs
@@ -237,6 +237,7 @@ pub fn constant_folding(cfg: &mut ControlFlowGraph, ns: &mut Namespace) {
                     accounts,
                     callty,
                     seeds,
+                    contract_function_no,
                 } => {
                     let value = expression(value, Some(&vars), cfg, ns).0;
                     let gas = expression(gas, Some(&vars), cfg, ns).0;
@@ -260,6 +261,7 @@ pub fn constant_folding(cfg: &mut ControlFlowGraph, ns: &mut Namespace) {
                         value,
                         gas,
                         callty: callty.clone(),
+                        contract_function_no: *contract_function_no,
                     };
                 }
                 Instr::AbiDecode {

--- a/src/codegen/dead_storage.rs
+++ b/src/codegen/dead_storage.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::cfg::{BasicBlock, ControlFlowGraph, Instr};
-use crate::codegen::reaching_definitions::block_edges;
 use crate::codegen::Expression;
 use crate::sema::ast::{Namespace, RetrieveType, Type};
 use solang_parser::pt::Loc;
@@ -141,7 +140,7 @@ fn reaching_definitions(cfg: &mut ControlFlowGraph) -> (Vec<Vec<Vec<Transfer>>>,
             &mut block_vars,
         );
 
-        for edge in block_edges(&cfg.blocks[block_no]) {
+        for edge in cfg.blocks[block_no].edges() {
             if !block_vars.contains_key(&edge) {
                 blocks_todo.insert(edge);
                 block_vars.insert(edge, vec![vars.clone()]);

--- a/src/codegen/reaching_definitions.rs
+++ b/src/codegen/reaching_definitions.rs
@@ -63,7 +63,7 @@ pub fn find(cfg: &mut ControlFlowGraph) {
             apply_transfers(transfers, &mut vars);
         }
 
-        for edge in block_edges(&cfg.blocks[block_no]) {
+        for edge in cfg.blocks[block_no].edges() {
             if cfg.blocks[edge].defs != vars {
                 blocks_todo.insert(edge);
                 // merge incoming set
@@ -221,42 +221,4 @@ pub fn apply_transfers(transfers: &[Transfer], vars: &mut IndexMap<usize, IndexM
             }
         }
     }
-}
-
-/// Fetch the blocks that can be executed after the block passed as argument
-pub(super) fn block_edges(block: &BasicBlock) -> Vec<usize> {
-    let mut out = Vec::new();
-
-    // out cfg has edge as the last instruction in a block; EXCEPT
-    // Instr::AbiDecode() which has an edge when decoding fails
-    for instr in &block.instr {
-        match instr {
-            Instr::Branch { block } => {
-                out.push(*block);
-            }
-            Instr::BranchCond {
-                true_block,
-                false_block,
-                ..
-            } => {
-                out.push(*true_block);
-                out.push(*false_block);
-            }
-            Instr::AbiDecode {
-                exception_block: Some(block),
-                ..
-            } => {
-                out.push(*block);
-            }
-            Instr::Switch { default, cases, .. } => {
-                out.push(*default);
-                for (_, goto) in cases {
-                    out.push(*goto);
-                }
-            }
-            _ => (),
-        }
-    }
-
-    out
 }

--- a/src/codegen/solana_deploy.rs
+++ b/src/codegen/solana_deploy.rs
@@ -474,6 +474,7 @@ pub(super) fn solana_deploy(
                 value: Expression::NumberLiteral(Loc::Codegen, Type::Uint(64), BigInt::from(0)),
                 gas: Expression::NumberLiteral(Loc::Codegen, Type::Uint(64), BigInt::from(0)),
                 callty: CallTy::Regular,
+                contract_function_no: None,
             },
         );
 

--- a/src/codegen/statements.rs
+++ b/src/codegen/statements.rs
@@ -1072,6 +1072,7 @@ fn try_catch(
                         value,
                         gas,
                         callty: CallTy::Regular,
+                        contract_function_no: None,
                     },
                 );
 

--- a/src/codegen/subexpression_elimination/instruction.rs
+++ b/src/codegen/subexpression_elimination/instruction.rs
@@ -375,6 +375,7 @@ impl<'a, 'b: 'a> AvailableExpressionSet<'a> {
                 gas,
                 callty,
                 seeds,
+                contract_function_no,
             } => {
                 let new_address = address
                     .as_ref()
@@ -397,6 +398,7 @@ impl<'a, 'b: 'a> AvailableExpressionSet<'a> {
                     value: self.regenerate_expression(value, ave, cst).1,
                     gas: self.regenerate_expression(gas, ave, cst).1,
                     callty: callty.clone(),
+                    contract_function_no: *contract_function_no,
                 }
             }
 

--- a/src/codegen/subexpression_elimination/mod.rs
+++ b/src/codegen/subexpression_elimination/mod.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::codegen::cfg::{BasicBlock, ControlFlowGraph, Instr};
-use crate::codegen::reaching_definitions::block_edges;
 use crate::codegen::subexpression_elimination::anticipated_expressions::AnticipatedExpressions;
 use crate::codegen::subexpression_elimination::available_variable::AvailableVariable;
 use crate::codegen::subexpression_elimination::common_subexpression_tracker::CommonSubExpressionTracker;
@@ -239,7 +238,7 @@ fn find_visiting_order(cfg: &ControlFlowGraph) -> CfgAsDag {
 
     while let Some(block_no) = queue.pop_front() {
         order.push((block_no, has_cycle[block_no]));
-        for edge in block_edges(&cfg.blocks[block_no]) {
+        for edge in cfg.blocks[block_no].edges() {
             degrees[edge] -= 1;
             if degrees[edge] == 0 {
                 queue.push_back(edge);
@@ -280,7 +279,7 @@ fn cfg_dfs(
 
     stack.insert(block_no);
 
-    for edge in block_edges(&cfg.blocks[block_no]) {
+    for edge in cfg.blocks[block_no].edges() {
         degrees[edge] += 1;
         if cfg_dfs(
             edge,

--- a/src/emit/instructions.rs
+++ b/src/emit/instructions.rs
@@ -790,6 +790,7 @@ pub(super) fn process_instruction<'a, T: TargetRuntime<'a> + ?Sized>(
             callty,
             accounts,
             seeds,
+            ..
         } => {
             let loc = payload.loc();
             let gas = expression(target, bin, gas, &w.vars, function, ns).into_int_value();


### PR DESCRIPTION
In this PR, we collect all accounts we can from a Solidity contract and insert them into the accounts vector for an instruction, so developers do not have to input them manually.

Closes #1191.