### PR TITLE
Forbid encoding and decoding of recursive types in sema

### DIFF
--- a/src/sema/builtin.rs
+++ b/src/sema/builtin.rs
@@ -1106,8 +1106,8 @@ pub(super) fn resolve_namespace_call(
                         if ty.is_mapping() || ty.is_recursive(ns) {
                             diagnostics.push(Diagnostic::error(
                                 *loc,
-                                format!("'{}' cannot be abi decoded or encoded", ty.to_string(ns)),
-                            ));
+                        format!("Invalid type '{}': mappings and recursive types cannot be abi decoded or encoded", ty.to_string(ns)))
+                            );
                             broken = true;
                         }
 
@@ -1131,7 +1131,7 @@ pub(super) fn resolve_namespace_call(
                 if ty.is_mapping() || ty.is_recursive(ns) {
                     diagnostics.push(Diagnostic::error(
                         *loc,
-                        format!("'{}' cannot be abi decoded or encoded", ty.to_string(ns)),
+                        format!("Invalid type '{}': mappings and recursive types cannot be abi decoded or encoded", ty.to_string(ns))
                     ));
                     broken = true;
                 }
@@ -1304,7 +1304,7 @@ pub(super) fn resolve_namespace_call(
         if ty.is_mapping() || ty.is_recursive(ns) {
             diagnostics.push(Diagnostic::error(
                 arg.loc(),
-                format!("'{}' cannot be abi decoded or encoded", ty.to_string(ns)),
+                format!("Invalid type '{}': mappings and recursive types cannot be abi decoded or encoded", ty.to_string(ns)),
             ));
 
             return Err(());

--- a/src/sema/builtin.rs
+++ b/src/sema/builtin.rs
@@ -1103,10 +1103,10 @@ pub(super) fn resolve_namespace_call(
                             broken = true;
                         }
 
-                        if ty.is_mapping() {
+                        if ty.is_mapping() || ty.is_recursive(ns) {
                             diagnostics.push(Diagnostic::error(
                                 *loc,
-                                "mapping cannot be abi decoded or encoded".to_string(),
+                                format!("'{}' cannot be abi decoded or encoded", ty.to_string(ns)),
                             ));
                             broken = true;
                         }
@@ -1128,10 +1128,10 @@ pub(super) fn resolve_namespace_call(
                     diagnostics,
                 )?;
 
-                if ty.is_mapping() {
+                if ty.is_mapping() || ty.is_recursive(ns) {
                     diagnostics.push(Diagnostic::error(
                         *loc,
-                        "mapping cannot be abi decoded or encoded".to_string(),
+                        format!("'{}' cannot be abi decoded or encoded", ty.to_string(ns)),
                     ));
                     broken = true;
                 }
@@ -1301,10 +1301,10 @@ pub(super) fn resolve_namespace_call(
         let mut expr = expression(arg, context, ns, symtable, diagnostics, ResolveTo::Unknown)?;
         let ty = expr.ty();
 
-        if ty.is_mapping() {
+        if ty.is_mapping() || ty.is_recursive(ns) {
             diagnostics.push(Diagnostic::error(
                 arg.loc(),
-                "mapping type not permitted".to_string(),
+                format!("'{}' cannot be abi decoded or encoded", ty.to_string(ns)),
             ));
 
             return Err(());

--- a/tests/contract_testcases/substrate/builtins/abi_decode_05.dot
+++ b/tests/contract_testcases/substrate/builtins/abi_decode_05.dot
@@ -1,0 +1,18 @@
+strict digraph "tests/contract_testcases/substrate/builtins/abi_decode_05.sol" {
+	S [label="name:S\ncontract: Foo\ntests/contract_testcases/substrate/builtins/abi_decode_05.sol:2:9-10\nfield name:s ty:struct Foo.S[]"]
+	contract [label="contract Foo\ntests/contract_testcases/substrate/builtins/abi_decode_05.sol:1:1-9:2"]
+	decode [label="function decode\ncontract: Foo\ntests/contract_testcases/substrate/builtins/abi_decode_05.sol:3:2-38\nsignature decode(bytes)\nvisibility public\nmutability pure"]
+	parameters [label="parameters\nbytes b"]
+	encode [label="function encode\ncontract: Foo\ntests/contract_testcases/substrate/builtins/abi_decode_05.sol:6:2-31\nsignature encode()\nvisibility public\nmutability pure"]
+	diagnostic [label="found contract 'Foo'\nlevel Debug\ntests/contract_testcases/substrate/builtins/abi_decode_05.sol:1:1-9:2"]
+	diagnostic_9 [label="'struct Foo.S' cannot be abi decoded or encoded\nlevel Error\ntests/contract_testcases/substrate/builtins/abi_decode_05.sol:4:3-21"]
+	diagnostic_10 [label="'struct Foo.S' cannot be abi decoded or encoded\nlevel Error\ntests/contract_testcases/substrate/builtins/abi_decode_05.sol:7:14-34"]
+	structs -> S
+	contracts -> contract
+	contract -> decode [label="function"]
+	decode -> parameters [label="parameters"]
+	contract -> encode [label="function"]
+	diagnostics -> diagnostic [label="Debug"]
+	diagnostics -> diagnostic_9 [label="Error"]
+	diagnostics -> diagnostic_10 [label="Error"]
+}

--- a/tests/contract_testcases/substrate/builtins/abi_decode_05.dot
+++ b/tests/contract_testcases/substrate/builtins/abi_decode_05.dot
@@ -5,8 +5,8 @@ strict digraph "tests/contract_testcases/substrate/builtins/abi_decode_05.sol" {
 	parameters [label="parameters\nbytes b"]
 	encode [label="function encode\ncontract: Foo\ntests/contract_testcases/substrate/builtins/abi_decode_05.sol:6:2-31\nsignature encode()\nvisibility public\nmutability pure"]
 	diagnostic [label="found contract 'Foo'\nlevel Debug\ntests/contract_testcases/substrate/builtins/abi_decode_05.sol:1:1-9:2"]
-	diagnostic_9 [label="'struct Foo.S' cannot be abi decoded or encoded\nlevel Error\ntests/contract_testcases/substrate/builtins/abi_decode_05.sol:4:3-21"]
-	diagnostic_10 [label="'struct Foo.S' cannot be abi decoded or encoded\nlevel Error\ntests/contract_testcases/substrate/builtins/abi_decode_05.sol:7:14-34"]
+	diagnostic_9 [label="Invalid type 'struct Foo.S': mappings and recursive types cannot be abi decoded or encoded\nlevel Error\ntests/contract_testcases/substrate/builtins/abi_decode_05.sol:4:3-21"]
+	diagnostic_10 [label="Invalid type 'struct Foo.S': mappings and recursive types cannot be abi decoded or encoded\nlevel Error\ntests/contract_testcases/substrate/builtins/abi_decode_05.sol:7:14-34"]
 	structs -> S
 	contracts -> contract
 	contract -> decode [label="function"]

--- a/tests/contract_testcases/substrate/builtins/abi_decode_05.sol
+++ b/tests/contract_testcases/substrate/builtins/abi_decode_05.sol
@@ -1,0 +1,9 @@
+contract Foo {
+	struct S { S[] s; }
+	function decode(bytes b) public pure {
+		abi.decode(b, (S));
+	}
+	function encode() public pure {
+		abi.encode(S({ s: new S[](0) }));
+	}
+}


### PR DESCRIPTION
This aligns Solang with solc. Also on our `main` branch, `solang compile` crashes on the added test case.