### PR TITLE
Refactor accounts collection to maintain proper ordering

### DIFF
--- a/src/abi/anchor.rs
+++ b/src/abi/anchor.rs
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::sema::ast::{
-    ArrayLength, Contract, Function, Mutability, Namespace, Parameter, StructDecl, StructType, Tag,
-    Type,
+    ArrayLength, Contract, Function, Namespace, Parameter, StructDecl, StructType, Tag, Type,
 };
 use anchor_syn::idl::{
     Idl, IdlAccount, IdlAccountItem, IdlEnumVariant, IdlEvent, IdlEventField, IdlField,
@@ -13,9 +12,7 @@ use num_traits::ToPrimitive;
 use semver::Version;
 use std::collections::{HashMap, HashSet};
 
-use crate::abi::solana_accounts::{collect_accounts_from_contract, SolanaAccount};
 use convert_case::{Boundary, Case, Casing};
-use indexmap::IndexSet;
 use serde_json::json;
 use sha2::{Digest, Sha256};
 use solang_parser::pt::FunctionTy;
@@ -126,7 +123,6 @@ fn idl_instructions(
         })
     }
 
-    let mut remaining_accounts = collect_accounts_from_contract(contract_no, ns);
     for func_no in contract.all_functions.keys() {
         if !ns.functions[*func_no].is_public()
             || matches!(
@@ -139,41 +135,6 @@ fn idl_instructions(
 
         let func = &ns.functions[*func_no];
         let tags = idl_docs(&func.tags);
-
-        let mut accounts = match &func.mutability {
-            Mutability::Pure(_) => {
-                vec![]
-            }
-            Mutability::View(_) => {
-                vec![IdlAccountItem::IdlAccount(IdlAccount {
-                    name: "dataAccount".to_string(),
-                    is_mut: false,
-                    is_signer: false,
-                    is_optional: Some(false),
-                    docs: None,
-                    pda: None,
-                    relations: vec![],
-                })]
-            }
-            _ => {
-                vec![IdlAccountItem::IdlAccount(IdlAccount {
-                    name: "dataAccount".to_string(),
-                    is_mut: true,
-                    /// With a @payer annotation, the account is created on-chain and needs a signer. The client
-                    /// provides an address that does not exist yet, so SystemProgram.CreateAccount is called
-                    /// on-chain.
-                    ///
-                    /// However, if a @seed is also provided, the program can sign for the account
-                    /// with the seed using program derived address (pda) when SystemProgram.CreateAccount is called,
-                    /// so no signer is required from the client.
-                    is_signer: func.has_payer_annotation() && !func.has_seed_annotation(),
-                    is_optional: Some(false),
-                    docs: None,
-                    pda: None,
-                    relations: vec![],
-                })]
-            }
-        };
 
         let mut args: Vec<IdlField> = Vec::with_capacity(func.params.len());
         let mut dedup = Deduplicate::new("arg".to_owned());
@@ -191,29 +152,7 @@ fn idl_instructions(
             });
         }
 
-        let cfg_no = contract.all_functions[func_no];
-
         let name = if func.is_constructor() {
-            if func.has_payer_annotation() {
-                accounts.push(IdlAccountItem::IdlAccount(IdlAccount {
-                    name: "wallet".to_string(),
-                    is_mut: false,
-                    is_signer: true,
-                    is_optional: Some(false),
-                    docs: None,
-                    pda: None,
-                    relations: vec![],
-                }));
-
-                // Constructors with the payer annotation need the system account
-                if let Some(set) = remaining_accounts.get_mut(&cfg_no) {
-                    set.insert(SolanaAccount::SystemAccount);
-                } else {
-                    remaining_accounts
-                        .insert(cfg_no, IndexSet::from([SolanaAccount::SystemAccount]));
-                }
-            }
-
             "new".to_string()
         } else if func.mangled_name_contracts.contains(&contract_no) {
             func.mangled_name.clone()
@@ -221,19 +160,22 @@ fn idl_instructions(
             func.name.clone()
         };
 
-        if let Some(other_accounts) = remaining_accounts.get(&cfg_no) {
-            for account in other_accounts {
-                accounts.push(IdlAccountItem::IdlAccount(IdlAccount {
-                    name: account.name().to_string(),
-                    is_mut: false,
-                    is_signer: false,
+        let accounts = func
+            .solana_accounts
+            .borrow()
+            .iter()
+            .map(|(account_name, account)| {
+                IdlAccountItem::IdlAccount(IdlAccount {
+                    name: account_name.clone(),
+                    is_mut: account.is_writer,
+                    is_signer: account.is_signer,
                     is_optional: Some(false),
                     docs: None,
                     pda: None,
                     relations: vec![],
-                }));
-            }
-        }
+                })
+            })
+            .collect::<Vec<IdlAccountItem>>();
 
         let returns = if func.returns.is_empty() {
             None

--- a/src/abi/mod.rs
+++ b/src/abi/mod.rs
@@ -5,7 +5,6 @@ use crate::Target;
 
 pub mod anchor;
 pub mod ethereum;
-mod solana_accounts;
 pub mod substrate;
 mod tests;
 

--- a/src/abi/tests.rs
+++ b/src/abi/tests.rs
@@ -157,7 +157,7 @@ fn instructions_and_types() {
     }
 
     function notInIdl(uint256 c, MetaData dd) private pure returns (int256) {
-        if (dd.a && dd.b) {
+        if (dd.c && dd.b) {
             return 0;
         }
         return int256(c);

--- a/src/bin/solang.rs
+++ b/src/bin/solang.rs
@@ -499,7 +499,7 @@ fn compile(matches: &ArgMatches) {
     }
 
     if !errors {
-        for ns in &namespaces {
+        for ns in namespaces.iter_mut() {
             for contract_no in 0..ns.contracts.len() {
                 contract_results(contract_no, matches, ns, &mut json_contracts, &opt);
             }
@@ -576,7 +576,7 @@ fn process_file(
 fn contract_results(
     contract_no: usize,
     matches: &ArgMatches,
-    ns: &Namespace,
+    ns: &mut Namespace,
     json_contracts: &mut HashMap<String, JsonContract>,
     opt: &Options,
 ) {

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -11,6 +11,7 @@ mod events;
 mod expression;
 mod external_functions;
 mod reaching_definitions;
+mod solana_accounts;
 mod solana_deploy;
 mod statements;
 mod storage;
@@ -36,6 +37,7 @@ use std::cmp::Ordering;
 
 use crate::codegen::cfg::ASTFunction;
 use crate::codegen::dispatch::function_dispatch;
+use crate::codegen::solana_accounts::collect_accounts_from_contract;
 use crate::codegen::yul::generate_yul_function_cfg;
 use crate::sema::Recurse;
 use num_bigint::{BigInt, Sign};
@@ -148,6 +150,14 @@ pub fn codegen(ns: &mut Namespace, opt: &Options) {
             }
 
             contracts_done[contract_no] = true;
+        }
+    }
+
+    if ns.target == Target::Solana {
+        for contract_no in 0..ns.contracts.len() {
+            if ns.contracts[contract_no].instantiable {
+                collect_accounts_from_contract(contract_no, ns);
+            }
         }
     }
 }

--- a/src/sema/ast.rs
+++ b/src/sema/ast.rs
@@ -14,6 +14,7 @@ use once_cell::unsync::OnceCell;
 pub use solang_parser::diagnostics::*;
 use solang_parser::pt;
 use solang_parser::pt::{CodeLocation, FunctionTy, OptionalCodeLocation};
+use std::cell::RefCell;
 use std::{
     collections::HashSet,
     collections::{BTreeMap, HashMap},
@@ -305,6 +306,17 @@ pub struct Function {
     pub annotations: Vec<ConstructorAnnotation>,
     /// Which contracts should we use the mangled name in?
     pub mangled_name_contracts: HashSet<usize>,
+    /// This indexmap stores the accounts this functions needs to be called on Solana
+    /// The string is the account's name
+    pub solana_accounts: RefCell<IndexMap<String, SolanaAccount>>,
+}
+
+/// This struct represents a Solana account. There is no name field, because
+/// it is stored in a IndexMap<String, SolanaAccount> (see above)
+#[derive(Clone, Copy, Debug)]
+pub struct SolanaAccount {
+    pub is_signer: bool,
+    pub is_writer: bool,
 }
 
 pub enum ConstructorAnnotation {
@@ -406,6 +418,7 @@ impl Function {
             mangled_name,
             annotations: Vec::new(),
             mangled_name_contracts: HashSet::new(),
+            solana_accounts: IndexMap::new().into(),
         }
     }
 


### PR DESCRIPTION
We are going to introduce new syntax of Solidty on Solana, that allows developers to declare account names within `@signer` and `@writer` annotations. These accounts will be accessible through `tx.accounts.account_name`, which relies on the deserialization order of accounts. 

For serialization consistency, we must care about the order in which we place accounts in the IDL file, so a refactor was necessary in `solana_accounts.rs` to account for a proper ordering.