### PR TITLE
Upgrade Anchor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ solang-parser = { path = "solang-parser", version = "0.2.2" }
 codespan-reporting = "0.11"
 phf = { version = "0.11", features = ["macros"] }
 rust-lapper = "1.1"
-anchor-syn = { version = "0.26", features = ["idl"] }
+anchor-syn = { version = "0.27.0", features = ["idl"] }
 convert_case = "0.6"
 parse-display = "0.8.0"
 parity-scale-codec = "3.3"

--- a/integration/anchor/programs/anchor/Cargo.toml
+++ b/integration/anchor/programs/anchor/Cargo.toml
@@ -16,4 +16,4 @@ cpi = ["no-entrypoint"]
 default = []
 
 [dependencies]
-anchor-lang = "0.25.0"
+anchor-lang = "0.27.0"

--- a/integration/anchor/tests/anchor.ts
+++ b/integration/anchor/tests/anchor.ts
@@ -11,17 +11,14 @@ describe("Anchor", () => {
 
   anchor.setProvider(provider);
 
-  const program = anchor.workspace.Anchor as Program<Anchor>;
-
   it("test anchor program with anchor tests", async () => {
     // The Account to create.
     const seed = Buffer.from('ChiaSeeds', 'utf8');
 
-    const program = anchor.workspace.Anchor;
+    const program = anchor.workspace.Anchor as Program<Anchor>;
 
     const [myAccount, bump] = await anchor.web3.PublicKey.findProgramAddress([seed], program.programId);
 
-    const myPubkey = new anchor.web3.PublicKey("AddressLookupTab1e1111111111111111111111111");
 
     const { SystemProgram } = anchor.web3;
 

--- a/src/abi/anchor.rs
+++ b/src/abi/anchor.rs
@@ -58,7 +58,6 @@ pub fn generate_anchor_idl(contract_no: usize, ns: &Namespace) -> Idl {
         docs,
         constants: vec![],
         instructions,
-        state: None,
         accounts: vec![],
         types: type_manager.generate_custom_idl_types(),
         events,

--- a/src/abi/tests.rs
+++ b/src/abi/tests.rs
@@ -334,7 +334,6 @@ fn instructions_and_types() {
         Some(IdlType::Defined("multipleReturns_returns".to_string()))
     );
 
-    assert!(idl.state.is_none());
     assert!(idl.accounts.is_empty());
 
     assert_eq!(idl.types.len(), 1);
@@ -452,7 +451,6 @@ contract caller {
     );
     assert!(idl.instructions[1].returns.is_none());
 
-    assert!(idl.state.is_none());
     assert!(idl.accounts.is_empty());
 
     assert_eq!(idl.types.len(), 1);
@@ -606,7 +604,6 @@ fn types() {
         ]
     );
     assert!(idl.instructions[1].returns.is_none());
-    assert!(idl.state.is_none());
     assert!(idl.accounts.is_empty());
     assert!(idl.types.is_empty());
     assert_eq!(
@@ -695,7 +692,6 @@ fn constructor() {
     assert!(idl.instructions[1].args.is_empty());
     assert_eq!(idl.instructions[1].returns, Some(IdlType::U64));
 
-    assert!(idl.state.is_none());
     assert!(idl.accounts.is_empty());
     assert!(idl.types.is_empty());
     assert!(idl.events.is_none());


### PR DESCRIPTION
This PR upgrades the Anchor version to v0.27.0. The IDL does not have the `state` field anymore.

The container CI image needs to be updated in https://github.com/hyperledger/solang-llvm/pull/9.