### PR TITLE
Bump MSRV to 1.65

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         submodules: recursive
     - name: Rust stable
-      run: rustup default 1.64.0
+      run: rustup default 1.65.0
     - name: Build
       run: cargo build --verbose --release
     - name: Run tests
@@ -40,7 +40,7 @@ jobs:
       with:
         submodules: recursive
     - name: Rust stable
-      run: rustup default 1.64.0
+      run: rustup default 1.65.0
     - name: Build
       run: cargo build --verbose --release
     - name: Run tests
@@ -67,7 +67,7 @@ jobs:
       run: unzip c:\llvm.zip -d c:/
     - name: Add LLVM to Path
       run: echo "c:\llvm15.0\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
-    - uses: dtolnay/rust-toolchain@1.64.0
+    - uses: dtolnay/rust-toolchain@1.65.0
       with:
         components: clippy
     - name: Build
@@ -91,7 +91,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: recursive
-    - uses: dtolnay/rust-toolchain@1.64.0
+    - uses: dtolnay/rust-toolchain@1.65.0
     - name: Get LLVM
       run: curl -L --output llvm15.0-mac-arm.tar.xz https://github.com/hyperledger/solang-llvm/releases/download/llvm15-0/llvm15.0-mac-arm.tar.xz
     - name: Extract LLVM
@@ -121,7 +121,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: recursive
-    - uses: dtolnay/rust-toolchain@1.64.0
+    - uses: dtolnay/rust-toolchain@1.65.0
     - name: Get LLVM
       run: wget -q -O llvm15.0-mac-intel.tar.xz https://github.com/hyperledger/solang-llvm/releases/download/llvm15-0/llvm15.0-mac-intel.tar.xz
     - name: Extract LLVM

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
       with:
         submodules: recursive
     - name: Rust stable
-      run: rustup default 1.64.0
+      run: rustup default 1.65.0
     - name: Build
       run: cargo build --verbose
     - name: Run tests
@@ -87,7 +87,7 @@ jobs:
       with:
         submodules: recursive
     - name: Rust stable
-      run: rustup default 1.64.0
+      run: rustup default 1.65.0
     - name: Build
       run: cargo build --verbose
     - name: Run tests
@@ -111,7 +111,7 @@ jobs:
       run: unzip c:\llvm.zip -d c:/
     - name: Add LLVM to Path
       run: echo "c:\llvm15.0\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
-    - uses: dtolnay/rust-toolchain@1.64.0
+    - uses: dtolnay/rust-toolchain@1.65.0
       with:
         components: clippy
     # We run clippy on Linux in the lint job above, but this does not check #[cfg(windows)] items
@@ -135,7 +135,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: recursive
-    - uses: dtolnay/rust-toolchain@1.64.0
+    - uses: dtolnay/rust-toolchain@1.65.0
     - name: Get LLVM
       run: curl -L --output llvm15.0-mac-arm.tar.xz https://github.com/hyperledger/solang-llvm/releases/download/llvm15-0/llvm15.0-mac-arm.tar.xz
     - name: Extract LLVM
@@ -159,7 +159,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: recursive
-    - uses: dtolnay/rust-toolchain@1.64.0
+    - uses: dtolnay/rust-toolchain@1.65.0
     - name: Get LLVM
       run: wget -q -O llvm15.0-mac-intel.tar.xz https://github.com/hyperledger/solang-llvm/releases/download/llvm15-0/llvm15.0-mac-intel.tar.xz
     - name: Extract LLVM

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 build = "build.rs"
 description = "Solang Solidity Compiler"
 keywords = [ "solidity", "compiler", "solana", "substrate" ]
-rust-version = "1.64.0"
+rust-version = "1.65.0"
 edition = "2021"
 exclude = [ "/.*", "/docs",  "/examples", "/solana-library", "/tests", "/integration", "/vscode" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . src
 WORKDIR /src/stdlib/
 RUN make
 
-RUN rustup default 1.64.0
+RUN rustup default 1.65.0
 
 WORKDIR /src
 RUN cargo build --release

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -87,7 +87,7 @@ Then you can build the image using:
 Option 5: Build Solang from source
 ----------------------------------
 
-In order to build Solang from source, you will need rust 1.64.0 or higher,
+In order to build Solang from source, you will need rust 1.65.0 or higher,
 and a build of LLVM based on the Solana LLVM tree. There are a few LLVM patches required that are not upstream yet.
 First, follow the steps below for installing LLVM and then proceed from there.
 


### PR DESCRIPTION
The latest `scale-info` release requires Rust 1.65, but we are still on 1.64. I think it is fair to bump our MSRV to 1.65 since latest release is 1.68 already.