### PR TITLE
Check for duplicate contract names on cli command line

### DIFF
--- a/src/bin/solang.rs
+++ b/src/bin/solang.rs
@@ -600,7 +600,7 @@ fn contract_results(
     }
 
     if ns.top_file_no() != resolved_contract.loc.file_no() {
-        // contracts which were imported should not be considered. For example, if we have a file
+        // contracts that were imported should not be considered. For example, if we have a file
         // a.sol which imports b.sol, and b.sol defines contract B, then:
         // solang compile a.sol
         // should not write the results for contract B

--- a/src/bin/solang.rs
+++ b/src/bin/solang.rs
@@ -499,9 +499,18 @@ fn compile(matches: &ArgMatches) {
     }
 
     if !errors {
+        let mut seen_contracts = HashMap::new();
+
         for ns in namespaces.iter_mut() {
             for contract_no in 0..ns.contracts.len() {
-                contract_results(contract_no, matches, ns, &mut json_contracts, &opt);
+                contract_results(
+                    contract_no,
+                    matches,
+                    ns,
+                    &mut json_contracts,
+                    &mut seen_contracts,
+                    &opt,
+                );
             }
         }
     }
@@ -578,6 +587,7 @@ fn contract_results(
     matches: &ArgMatches,
     ns: &mut Namespace,
     json_contracts: &mut HashMap<String, JsonContract>,
+    seen_contracts: &mut HashMap<String, String>,
     opt: &Options,
 ) {
     let verbose = *matches.get_one("VERBOSE").unwrap();
@@ -588,6 +598,26 @@ fn contract_results(
     if !resolved_contract.instantiable {
         return;
     }
+
+    if ns.top_file_no() != resolved_contract.loc.file_no() {
+        // contracts which were imported should not be considered. For example, if we have a file
+        // a.sol which imports b.sol, and b.sol defines contract B, then:
+        // solang compile a.sol
+        // should not write the results for contract B
+        return;
+    }
+
+    let loc = ns.loc_to_string(true, &resolved_contract.loc);
+
+    if let Some(other_loc) = seen_contracts.get(&resolved_contract.name) {
+        eprintln!(
+            "error: contract {} defined at {other_loc} and {}",
+            resolved_contract.name, loc
+        );
+        exit(1);
+    }
+
+    seen_contracts.insert(resolved_contract.name.to_string(), loc);
 
     if let Some("cfg") = matches.get_one::<String>("EMIT").map(|v| v.as_str()) {
         println!("{}", resolved_contract.print_cfg(ns));

--- a/tests/imports_testcases/imports/rel.sol
+++ b/tests/imports_testcases/imports/rel.sol
@@ -1,0 +1,2 @@
+
+contract rel {}


### PR DESCRIPTION
If we are compiling two files, and they define the same contract name from multiple locations, error out.