### PR TITLE
Bugfix: Struct with fields of BytesN types can not be encoded linear

### DIFF
--- a/src/codegen/cfg.rs
+++ b/src/codegen/cfg.rs
@@ -2067,7 +2067,8 @@ impl Namespace {
     pub fn calculate_struct_non_padded_size(&self, struct_type: &StructType) -> Option<BigInt> {
         let mut size = BigInt::from(0u8);
         for field in &struct_type.definition(self).fields {
-            if !field.ty.is_primitive() {
+            let ty = field.ty.clone().unwrap_user_type(&self);
+            if !ty.is_primitive() || matches!(ty, Type::Bytes(_)) {
                 // If a struct contains a non-primitive type, we cannot calculate its
                 // size during compile time
                 if let Type::Struct(struct_ty) = &field.ty {
@@ -2078,7 +2079,7 @@ impl Namespace {
                 }
                 return None;
             } else {
-                size.add_assign(field.ty.memory_size_of(self));
+                size.add_assign(ty.memory_size_of(self));
             }
         }
 

--- a/tests/substrate_tests/structs.rs
+++ b/tests/substrate_tests/structs.rs
@@ -593,3 +593,24 @@ fn struct_struct_in_init_and_return() {
 
     runtime.function("test", Vec::new());
 }
+
+#[test]
+fn encode_decode_bytes_in_field() {
+    #[derive(Debug, PartialEq, Eq, Encode, Decode)]
+    struct Foo([u8; 3]);
+
+    let mut runtime = build_solidity(
+        r##"
+        contract encode_decode_bytes_in_field {
+            struct foo { bytes3 f1; }
+            function test() public pure returns(foo) {
+                foo f = abi.decode(hex"414243", (foo));
+                assert(abi.encode(f) == hex"414243");
+                return f;
+            }
+        }"##,
+    );
+
+    runtime.function("test", vec![]);
+    assert_eq!(runtime.vm.output, Foo([0x41, 0x42, 0x43]).encode())
+}


### PR DESCRIPTION
Fixes an encoding bug: When a struct has any field with `BytesN` type, this field requires an endianess swap and can't be encoded or decoded directly (e.g. with a `MemCopy`).