### PR TITLE
Bugfix: Unwrap user types while processing WriteBuffer instructions

### DIFF
--- a/src/emit/instructions.rs
+++ b/src/emit/instructions.rs
@@ -1084,7 +1084,7 @@ pub(super) fn process_instruction<'a, T: TargetRuntime<'a> + ?Sized>(
                     .build_gep(bin.context.i8_type(), data, &[offset], "start")
             };
 
-            let is_bytes = if let Type::Bytes(n) = value.ty() {
+            let is_bytes = if let Type::Bytes(n) = value.ty().unwrap_user_type(ns) {
                 n
             } else if value.ty() == Type::FunctionSelector {
                 ns.target.selector_length()

--- a/tests/substrate_tests/builtins.rs
+++ b/tests/substrate_tests/builtins.rs
@@ -725,6 +725,11 @@ fn hash() {
             function get() public view returns (Hash) {
                 return Hash.wrap(current2);
             }
+
+            function test_encoding() public view {
+                Hash h = Hash.wrap(current2);
+                assert(abi.encode(current2) == abi.encode(h));
+            }
         }
         "##,
     );
@@ -743,4 +748,6 @@ fn hash() {
 
     runtime.function("get", vec![]);
     assert_eq!(&runtime.vm.output[..], &h.0[..]);
+
+    runtime.function("test_encoding", vec![]);
 }


### PR DESCRIPTION
User types can wrap `bytesN` which need an endianess swap during encoding.