### PR TITLE
Pass by value types narrower than 8-bytes as suggested by `clippy::pedantic`

### DIFF
--- a/src/abi/substrate.rs
+++ b/src/abi/substrate.rs
@@ -236,7 +236,7 @@ fn resolve_ast(ty: &ast::Type, ns: &ast::Namespace, registry: &mut PortableRegis
 /// Recursively build the storage layout after all types are registered
 fn type_to_storage_layout(
     key: u32,
-    root: &LayoutKey,
+    root: LayoutKey,
     registry: &PortableRegistryBuilder,
 ) -> Layout<PortableForm> {
     let ty = registry.get(key).unwrap();
@@ -250,7 +250,7 @@ fn type_to_storage_layout(
                 )
             }),
         )),
-        _ => Layout::Leaf(LeafLayout::new(*root, key.into())),
+        _ => Layout::Leaf(LeafLayout::new(root, key.into())),
     }
 }
 
@@ -271,7 +271,7 @@ pub fn gen_project(contract_no: usize, ns: &ast::Namespace) -> InkProject {
                 let layout_key = LayoutKey::new(slot);
                 let root = RootLayout::new(
                     layout_key,
-                    type_to_storage_layout(ty, &layout_key, &registry),
+                    type_to_storage_layout(ty, layout_key, &registry),
                 );
                 Some(FieldLayout::new(var.name.clone(), root))
             } else {

--- a/src/codegen/array_boundary.rs
+++ b/src/codegen/array_boundary.rs
@@ -16,7 +16,7 @@ pub(crate) fn handle_array_assign(
     right: Expression,
     cfg: &mut ControlFlowGraph,
     vartab: &mut Vartable,
-    pos: &usize,
+    pos: usize,
 ) -> Expression {
     if let Expression::AllocDynamicBytes(loc, ty @ Type::Array(..), size, option) = right {
         // If we re-allocate the pointer, create a new temp variable to hold the new array length
@@ -31,7 +31,7 @@ pub(crate) fn handle_array_assign(
             },
         );
 
-        cfg.array_lengths_temps.insert(*pos, temp_res);
+        cfg.array_lengths_temps.insert(pos, temp_res);
 
         Expression::AllocDynamicBytes(
             loc,
@@ -45,10 +45,10 @@ pub(crate) fn handle_array_assign(
             if cfg.array_lengths_temps.contains_key(right_res) {
                 let to_update = cfg.array_lengths_temps[right_res];
 
-                cfg.array_lengths_temps.insert(*pos, to_update);
+                cfg.array_lengths_temps.insert(pos, to_update);
             } else {
                 // If the right hand side doesn't have a temp, it must be a function parameter or a struct member.
-                cfg.array_lengths_temps.remove(pos);
+                cfg.array_lengths_temps.remove(&pos);
             }
         }
 

--- a/src/codegen/constructor.rs
+++ b/src/codegen/constructor.rs
@@ -16,7 +16,7 @@ use super::encoding::abi_encode;
 /// call the constructor of a contract.
 pub(super) fn call_constructor(
     loc: &Loc,
-    contract_no: &usize,
+    contract_no: usize,
     callee_contract_no: usize,
     constructor_no: &Option<usize>,
     constructor_args: &[ast::Expression],
@@ -59,13 +59,13 @@ pub(super) fn call_constructor(
         .collect::<Vec<Expression>>();
 
     let selector = match constructor_no {
-        Some(func_no) => ns.functions[*func_no].selector(ns, contract_no),
-        None => ns.contracts[*contract_no]
+        Some(func_no) => ns.functions[*func_no].selector(ns, &contract_no),
+        None => ns.contracts[contract_no]
             .default_constructor
             .as_ref()
             .unwrap()
             .0
-            .selector(ns, contract_no),
+            .selector(ns, &contract_no),
     };
 
     let mut args = vec![Expression::BytesLiteral(
@@ -83,7 +83,7 @@ pub(super) fn call_constructor(
         Instr::Constructor {
             success,
             res: address_res,
-            contract_no: *contract_no,
+            contract_no,
             encoded_args,
             encoded_args_len,
             value,

--- a/src/codegen/statements.rs
+++ b/src/codegen/statements.rs
@@ -58,7 +58,7 @@ pub(crate) fn statement(
             }
         }
         Statement::VariableDecl(loc, pos, _, Some(init)) => {
-            if should_remove_variable(pos, func, opt) {
+            if should_remove_variable(*pos, func, opt) {
                 let mut params = SideEffectsCheckParameters {
                     cfg,
                     contract_no,
@@ -119,7 +119,7 @@ pub(crate) fn statement(
             );
         }
         Statement::VariableDecl(loc, pos, param, None) => {
-            if should_remove_variable(pos, func, opt) {
+            if should_remove_variable(*pos, func, opt) {
                 return;
             }
 
@@ -920,7 +920,7 @@ fn destructure(
             DestructureField::VariableDecl(res, param) => {
                 let expr = try_load_and_cast(&param.loc, &right, &param.ty, ns, cfg, vartab);
 
-                if should_remove_variable(res, func, opt) {
+                if should_remove_variable(*res, func, opt) {
                     continue;
                 }
 
@@ -1142,7 +1142,7 @@ fn try_catch(
 
             call_constructor(
                 loc,
-                contract_no,
+                *contract_no,
                 callee_contract_no,
                 constructor_no,
                 args,

--- a/src/codegen/strength_reduce/expression_values.rs
+++ b/src/codegen/strength_reduce/expression_values.rs
@@ -17,7 +17,7 @@ pub(super) fn expression_values(
 ) -> HashSet<Value> {
     match expr {
         Expression::NumberLiteral(_, ty, v) => number_literal_values(ty, v, ns),
-        Expression::BoolLiteral(_, v) => bool_literal_values(v),
+        Expression::BoolLiteral(_, v) => bool_literal_values(*v),
         Expression::ZeroExt(_, ty, expr) => zero_ext_values(ty, expr, vars, ns),
         Expression::SignExt(_, ty, expr) => sign_ext_values(ty, expr, vars, ns),
         Expression::Trunc(_, ty, expr) => trunc_values(ty, expr, vars, ns),
@@ -59,7 +59,7 @@ pub(super) fn expression_values(
         }
         Expression::Not(_, expr) => not_values(expr, vars, ns),
         Expression::Complement(_, _, expr) => complement_values(expr, vars, ns),
-        Expression::Variable(_, _, var_no) => variable_values(var_no, vars),
+        Expression::Variable(_, _, var_no) => variable_values(*var_no, vars),
         Expression::InternalFunctionCfg(_) => {
             // reference to a function; ignore
             HashSet::new()
@@ -110,11 +110,11 @@ fn number_literal_values(ty: &Type, v: &BigInt, ns: &Namespace) -> HashSet<Value
     set
 }
 
-fn bool_literal_values(v: &bool) -> HashSet<Value> {
+fn bool_literal_values(v: bool) -> HashSet<Value> {
     let mut set = HashSet::new();
 
     let mut value = BitArray::new([0u8; 32]);
-    value.set(0, *v);
+    value.set(0, v);
     let mut known_bits = BitArray::new([0u8; 32]);
     known_bits.set(0, true);
 
@@ -802,8 +802,8 @@ fn complement_values(expr: &Expression, vars: &Variables, ns: &Namespace) -> Has
         .collect()
 }
 
-fn variable_values(var_no: &usize, vars: &Variables) -> HashSet<Value> {
-    if let Some(v) = vars.get(var_no) {
+fn variable_values(var_no: usize, vars: &Variables) -> HashSet<Value> {
+    if let Some(v) = vars.get(&var_no) {
         v.clone()
     } else {
         HashSet::new()

--- a/src/codegen/strength_reduce/reaching_values.rs
+++ b/src/codegen/strength_reduce/reaching_values.rs
@@ -25,7 +25,7 @@ pub(super) fn reaching_values(
         let mut changes = false;
 
         for (var_no, set) in vars.iter() {
-            changes |= update_map(var_no, set, map);
+            changes |= update_map(*var_no, set, map);
         }
 
         if !changes {
@@ -97,8 +97,8 @@ pub(super) fn reaching_values(
 /// Update the Variable's map based on the incoming set of values. Returns true if there was any
 /// changes in the set.
 /// There is a discussion to improve this function: https://github.com/hyperledger/solang/issues/934
-fn update_map(var_no: &usize, set: &HashSet<Value>, map: &mut Variables) -> bool {
-    return if let Some(existing) = map.get_mut(var_no) {
+fn update_map(var_no: usize, set: &HashSet<Value>, map: &mut Variables) -> bool {
+    return if let Some(existing) = map.get_mut(&var_no) {
         if existing.iter().next().map_or(false, |v| v.all_unknown()) {
             // If we already think it is unknown, nothing can improve on that
             false
@@ -108,7 +108,7 @@ fn update_map(var_no: &usize, set: &HashSet<Value>, map: &mut Variables) -> bool
 
             set.insert(v.clone());
 
-            map.insert(*var_no, set);
+            map.insert(var_no, set);
             true
         } else {
             let mut changes = false;
@@ -127,7 +127,7 @@ fn update_map(var_no: &usize, set: &HashSet<Value>, map: &mut Variables) -> bool
                 set.insert(Value::unknown(bits));
 
                 changes = true;
-                map.insert(*var_no, set);
+                map.insert(var_no, set);
             }
             changes
         }
@@ -141,9 +141,9 @@ fn update_map(var_no: &usize, set: &HashSet<Value>, map: &mut Variables) -> bool
 
             set.insert(Value::unknown(bits));
 
-            map.insert(*var_no, set);
+            map.insert(var_no, set);
         } else {
-            map.insert(*var_no, set.clone());
+            map.insert(var_no, set.clone());
         }
 
         true

--- a/src/codegen/subexpression_elimination/common_subexpression_tracker.rs
+++ b/src/codegen/subexpression_elimination/common_subexpression_tracker.rs
@@ -92,8 +92,8 @@ impl<'a> CommonSubExpressionTracker<'a> {
     }
 
     /// Invalidate a mapped variable
-    pub fn invalidate_mapped_variable(&mut self, var_no: &usize) {
-        if let Some(expr_id) = self.mapped_variables.remove(var_no) {
+    pub fn invalidate_mapped_variable(&mut self, var_no: usize) {
+        if let Some(expr_id) = self.mapped_variables.remove(&var_no) {
             self.common_subexpressions[expr_id].var_loc = None;
             self.common_subexpressions[expr_id].in_cfg = false;
             self.common_subexpressions[expr_id].var_no = None;

--- a/src/codegen/subexpression_elimination/instruction.rs
+++ b/src/codegen/subexpression_elimination/instruction.rs
@@ -56,7 +56,7 @@ impl<'a, 'b: 'a> AvailableExpressionSet<'a> {
                     // x = x + y -> make x+y available, than make kill x, which also kills x+y
                     // -- x + y is not available here, because x has a new definition
                     self.kill(*res);
-                    tracker.invalidate_mapped_variable(res);
+                    tracker.invalidate_mapped_variable(*res);
                 }
             }
 

--- a/src/codegen/undefined_variable.rs
+++ b/src/codegen/undefined_variable.rs
@@ -101,7 +101,7 @@ pub fn find_undefined_variables_in_expression(
                             && !*modified
                             && !matches!(var.ty, Type::Array(..))
                         {
-                            add_diagnostic(var, pos, &exp.loc(), ctx.diagnostics);
+                            add_diagnostic(var, *pos, &exp.loc(), ctx.diagnostics);
                         }
                     }
                 }
@@ -120,7 +120,7 @@ pub fn find_undefined_variables_in_expression(
 /// error messages in Diagnotics
 fn add_diagnostic(
     var: &symtable::Variable,
-    var_no: &usize,
+    var_no: usize,
     expr_loc: &Loc,
     diagnostics: &mut HashMap<usize, Diagnostic>,
 ) {
@@ -130,20 +130,15 @@ fn add_diagnostic(
         return;
     }
 
-    if !diagnostics.contains_key(var_no) {
-        diagnostics.insert(
-            *var_no,
-            Diagnostic {
-                level: Level::Error,
-                ty: ErrorType::TypeError,
-                loc: var.id.loc,
-                message: format!("Variable '{}' is undefined", var.id.name),
-                notes: vec![],
-            },
-        );
-    }
+    diagnostics.entry(var_no).or_insert(Diagnostic {
+        level: Level::Error,
+        ty: ErrorType::TypeError,
+        loc: var.id.loc,
+        message: format!("Variable '{}' is undefined", var.id.name),
+        notes: vec![],
+    });
 
-    let diag = diagnostics.get_mut(var_no).unwrap();
+    let diag = diagnostics.get_mut(&var_no).unwrap();
     diag.notes.push(Note {
         loc: *expr_loc,
         message: "Variable read before being defined".to_string(),

--- a/src/codegen/unused_variable.rs
+++ b/src/codegen/unused_variable.rs
@@ -38,7 +38,7 @@ pub fn should_remove_assignment(
             !var.read
         }
 
-        Expression::Variable { var_no, .. } => should_remove_variable(var_no, func, opt),
+        Expression::Variable { var_no, .. } => should_remove_variable(*var_no, func, opt),
 
         Expression::StructMember { expr, .. } => should_remove_assignment(ns, expr, func, opt),
 
@@ -55,12 +55,12 @@ pub fn should_remove_assignment(
 }
 
 /// Checks if we should remove a variable
-pub fn should_remove_variable(pos: &usize, func: &Function, opt: &Options) -> bool {
+pub fn should_remove_variable(pos: usize, func: &Function, opt: &Options) -> bool {
     if opt.opt_level == OptimizationLevel::None {
         return false;
     }
 
-    let var = &func.symtable.vars[pos];
+    let var = &func.symtable.vars[&pos];
 
     //If the variable has never been read nor assigned, we can remove it right away.
     if !var.read && !var.assigned {

--- a/src/codegen/yul/builtin.rs
+++ b/src/codegen/yul/builtin.rs
@@ -36,7 +36,7 @@ impl Expression {
 /// Transfrom YUL builtin functions into CFG instructions
 pub(crate) fn process_builtin(
     loc: &pt::Loc,
-    builtin_ty: &YulBuiltInFunction,
+    builtin_ty: YulBuiltInFunction,
     args: &[ast::YulExpression],
     contract_no: usize,
     ns: &Namespace,
@@ -214,7 +214,7 @@ pub(crate) fn process_builtin(
 /// Process arithmetic operations
 fn process_arithmetic(
     loc: &pt::Loc,
-    builtin_ty: &YulBuiltInFunction,
+    builtin_ty: YulBuiltInFunction,
     args: &[ast::YulExpression],
     contract_no: usize,
     ns: &Namespace,
@@ -319,7 +319,7 @@ fn process_arithmetic(
         YulBuiltInFunction::AddMod | YulBuiltInFunction::MulMod => {
             let modulo_operand = expression(&args[2], contract_no, ns, vartab, cfg, opt);
             let (_, equalized_modulo) = equalize_types(left.clone(), modulo_operand.clone(), ns);
-            let builtin = if builtin_ty == &YulBuiltInFunction::AddMod {
+            let builtin = if builtin_ty == YulBuiltInFunction::AddMod {
                 Builtin::AddMod
             } else {
                 Builtin::MulMod

--- a/src/codegen/yul/expression.rs
+++ b/src/codegen/yul/expression.rs
@@ -86,7 +86,7 @@ pub(crate) fn expression(
         }
 
         ast::YulExpression::BuiltInCall(loc, builtin_ty, args) => {
-            process_builtin(loc, builtin_ty, args, contract_no, ns, vartab, cfg, opt)
+            process_builtin(loc, *builtin_ty, args, contract_no, ns, vartab, cfg, opt)
         }
     }
 }

--- a/src/codegen/yul/statements.rs
+++ b/src/codegen/yul/statements.rs
@@ -37,7 +37,7 @@ pub(crate) fn statement(
         }
 
         YulStatement::BuiltInCall(loc, _, builtin_ty, args) => {
-            let expr = process_builtin(loc, builtin_ty, args, contract_no, ns, vartab, cfg, opt);
+            let expr = process_builtin(loc, *builtin_ty, args, contract_no, ns, vartab, cfg, opt);
             assert_eq!(expr, Expression::Poison);
         }
 

--- a/src/sema/dotgraphviz.rs
+++ b/src/sema/dotgraphviz.rs
@@ -612,7 +612,7 @@ impl Dot {
                 contract_no,
                 var_no,
             } => {
-                self.add_constant_variable(loc, ty, contract_no, var_no, parent, parent_rel, ns);
+                self.add_constant_variable(loc, ty, contract_no, *var_no, parent, parent_rel, ns);
             }
             Expression::Variable { loc, ty, var_no } => {
                 let labels = vec![
@@ -633,7 +633,7 @@ impl Dot {
                 contract_no,
                 var_no,
             } => {
-                self.add_storage_variable(loc, ty, contract_no, var_no, parent, parent_rel, ns);
+                self.add_storage_variable(loc, ty, *contract_no, *var_no, parent, parent_rel, ns);
             }
             Expression::Load { loc, ty, expr } => {
                 let node = self.add_node(
@@ -1904,16 +1904,16 @@ impl Dot {
                 );
             }
             YulExpression::ConstantVariable(loc, ty, contract, var_no) => {
-                self.add_constant_variable(loc, ty, contract, var_no, parent, parent_rel, ns);
+                self.add_constant_variable(loc, ty, contract, *var_no, parent, parent_rel, ns);
             }
             YulExpression::StorageVariable(loc, ty, contract, var_no) => {
-                self.add_storage_variable(loc, ty, contract, var_no, parent, parent_rel, ns);
+                self.add_storage_variable(loc, ty, *contract, *var_no, parent, parent_rel, ns);
             }
             YulExpression::BuiltInCall(loc, builtin_ty, args) => {
-                self.add_yul_builtin_call(loc, builtin_ty, args, parent, parent_rel, symtable, ns);
+                self.add_yul_builtin_call(loc, *builtin_ty, args, parent, parent_rel, symtable, ns);
             }
             YulExpression::FunctionCall(loc, func_no, args, _) => {
-                self.add_yul_function_call(loc, func_no, args, parent, parent_rel, symtable, ns);
+                self.add_yul_function_call(loc, *func_no, args, parent, parent_rel, symtable, ns);
             }
             YulExpression::SuffixAccess(loc, member, suffix) => {
                 let labels = vec![
@@ -1937,7 +1937,7 @@ impl Dot {
         loc: &Loc,
         ty: &Type,
         contract: &Option<usize>,
-        var_no: &usize,
+        var_no: usize,
         parent: usize,
         parent_rel: String,
         ns: &Namespace,
@@ -1953,11 +1953,11 @@ impl Dot {
                 1,
                 format!(
                     "{}.{}",
-                    ns.contracts[*contract].name, ns.contracts[*contract].variables[*var_no].name
+                    ns.contracts[*contract].name, ns.contracts[*contract].variables[var_no].name
                 ),
             );
         } else {
-            labels.insert(1, ns.constants[*var_no].name.to_string());
+            labels.insert(1, ns.constants[var_no].name.to_string());
         }
 
         self.add_node(
@@ -1971,8 +1971,8 @@ impl Dot {
         &mut self,
         loc: &Loc,
         ty: &Type,
-        contract: &usize,
-        var_no: &usize,
+        contract: usize,
+        var_no: usize,
         parent: usize,
         parent_rel: String,
         ns: &Namespace,
@@ -1981,7 +1981,7 @@ impl Dot {
             String::from("storage variable"),
             format!(
                 "{}.{}",
-                ns.contracts[*contract].name, ns.contracts[*contract].variables[*var_no].name
+                ns.contracts[contract].name, ns.contracts[contract].variables[var_no].name
             ),
             ty.to_string(ns),
             ns.loc_to_string(true, loc),
@@ -2004,10 +2004,10 @@ impl Dot {
     ) -> usize {
         match statement {
             YulStatement::FunctionCall(loc, _, func_no, args) => {
-                self.add_yul_function_call(loc, func_no, args, parent, parent_rel, symtable, ns)
+                self.add_yul_function_call(loc, *func_no, args, parent, parent_rel, symtable, ns)
             }
             YulStatement::BuiltInCall(loc, _, builtin_ty, args) => {
-                self.add_yul_builtin_call(loc, builtin_ty, args, parent, parent_rel, symtable, ns)
+                self.add_yul_builtin_call(loc, *builtin_ty, args, parent, parent_rel, symtable, ns)
             }
             YulStatement::Block(block) => {
                 self.add_yul_block(block, parent, parent_rel, symtable, ns)
@@ -2217,7 +2217,7 @@ impl Dot {
     fn add_yul_function_call(
         &mut self,
         loc: &Loc,
-        func_no: &usize,
+        func_no: usize,
         args: &[YulExpression],
         parent: usize,
         parent_rel: String,
@@ -2225,7 +2225,7 @@ impl Dot {
         ns: &Namespace,
     ) -> usize {
         let labels = vec![
-            format!("yul function call '{}'", ns.yul_functions[*func_no].name),
+            format!("yul function call '{}'", ns.yul_functions[func_no].name),
             ns.loc_to_string(true, loc),
         ];
 
@@ -2245,7 +2245,7 @@ impl Dot {
     fn add_yul_builtin_call(
         &mut self,
         loc: &Loc,
-        builtin_ty: &YulBuiltInFunction,
+        builtin_ty: YulBuiltInFunction,
         args: &[YulExpression],
         parent: usize,
         parent_rel: String,

--- a/src/sema/yul/builtin.rs
+++ b/src/sema/yul/builtin.rs
@@ -208,7 +208,7 @@ impl YulBuiltInFunction {
         &YUL_BUILTIN[index]
     }
 
-    pub(crate) fn modify_state(&self) -> bool {
+    pub(crate) fn modify_state(self) -> bool {
         matches!(
             self,
             YulBuiltInFunction::SStore
@@ -226,7 +226,7 @@ impl YulBuiltInFunction {
         )
     }
 
-    pub(crate) fn read_state(&self) -> bool {
+    pub(crate) fn read_state(self) -> bool {
         matches!(
             self,
             YulBuiltInFunction::Address


### PR DESCRIPTION
Clippy pedantic suggests that we pass by value types narrower than 8 bytes.