### PR TITLE
Update substrate contracts-ci-linux docker image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -304,7 +304,7 @@ jobs:
       # We can't run substrate as a github actions service, since it requires
       # command line arguments. See https://github.com/actions/runner/pull/1152
     - name: Start substrate
-      run: echo id=$(docker run -d -p 9944:9944 paritytech/contracts-ci-linux@sha256:2eaa0869c562adabcfc011a2f3ad6b2289cdd0b3a8923e24d29efd4452b397de substrate-contracts-node --dev --ws-external) >> $GITHUB_OUTPUT
+      run: echo id=$(docker run -d -p 9944:9944 paritytech/contracts-ci-linux@sha256:52b9324054778e6de0ddf210b821014daa8c8ac0468644fcc4141040f0c8d1df substrate-contracts-node --dev --ws-external) >> $GITHUB_OUTPUT
       id: substrate
     - uses: actions/setup-node@v3
       with:

--- a/integration/substrate/package.json
+++ b/integration/substrate/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "tsc; ts-mocha -t 20000 *.spec.ts",
     "build": "./build.sh",
-    "build-ink": "docker run --rm -v $(pwd)/ink/caller:/opt/contract paritytech/contracts-ci-linux@sha256:2eaa0869c562adabcfc011a2f3ad6b2289cdd0b3a8923e24d29efd4452b397de cargo contract build --manifest-path /opt/contract/Cargo.toml"
+    "build-ink": "docker run --rm -v $(pwd)/ink/caller:/opt/contract paritytech/contracts-ci-linux@sha256:52b9324054778e6de0ddf210b821014daa8c8ac0468644fcc4141040f0c8d1df cargo contract build --manifest-path /opt/contract/Cargo.toml"
   },
   "contributors": [
     {


### PR DESCRIPTION
They were deleted from docker hub (it was not known we still use them)