### PR TITLE
v0.2.3 Geneva

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,36 @@
 All notable changes to [Solang](https://github.com/hyperledger/solang/)
 will be documented here.
 
-## Unreleased
+## v0.2.3 Geneva
 
 ### Added
 - The Solana units `sol` and `lamports` are now supported, e.g. `10 sol` and `100 lamports`.
   [seanyoung](https://github.com/seanyoung)
 - User defined operators are now supported. This is a feature in Ethereum Solidity v0.8.19.
   [seanyoung](https://github.com/seanyoung)
+- **Solana**: if a contract uses the `SystemAccount`, `ClockAccount`, or other standard builtin
+  accounts, then this is automatically added to the IDL. [LucasSte](https://github.com/LucasSte)
+- **Substrate**: The content of the debug buffer is formatted in a human readable way. This vastly improves it's readability, allowing to spot API runtime return codes, runtime errors and debug prints much easier. [salaheldinsoliman](https://github.com/salaheldinsoliman) 
 
 ### Fixed
 - Solana: contracts with a seed for the constructor do not require a signer in the Anchor IDL
   [seanyoung](https://github.com/seanyoung)
+- Fix panic when lexing ".9" at the beginning of a file. [seanyoung](https://github.com/seanyoung)
+- Forbid ABI encoding and decoding of recursive types. [xermicus](https://github.com/xermicus)
+- Treat enums as 8bit uint in constant hashing. [xermicus](https://github.com/xermicus)
+- Fix compilation failure with -g for the substrate target. [salaheldinsoliman](https://github.com/salaheldinsoliman)
+- Fixed incorrect ABI encoding for user defined types. [xermicus](https://github.com/xermicus)  [seanyoung](https://github.com/seanyoung)
+- Fixed incorrect ABI encoding for struct with fields of type `bytesN` [xermicus](https://github.com/xermicus)
+- Fixed incorrect handling of recursive struct fields. [xermicus](https://github.com/xermicus)
+- Fixed a bug in our Common Subexpression Elimination optimization pass [LucasSte](https://github.com/LucasSte)
+### Changed
+- Math overflow is now always enabled, unless the math happens with an `unchecked { .. }` block.
+  The `--math-overflow` command line option has been removed. [seanyoung](https://github.com/seanyoung)
+- **Substrate**: the SCALE encoder and decoder now uses a much better implementation written in our
+  CFG intermediate format. [xermicus](https://github.com/xermicus)
+- **Substrate**: When instantiating a new contract without providing a salt, the salt we be derived from the output of the new `instantiation_nonce` runtime API. [xermicus](https://github.com/xermicus)
+- Minimal Supported Rust Version is `1.65.0`
+- No longer silently overwrite contract artifacts, if the same contract is defined more than once in different locations [seanyoung](https://github.com/seanyoung)
 
 ## v0.2.2 Alexandria
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solang"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Sean Young <sean@mess.org>", "Lucas Steuernagel <lucas.tnagel@gmail.com>", "Cyrill Leutwiler <bigcyrill@hotmail.com>"]
 homepage = "https://github.com/hyperledger/solang"
 documentation = "https://solang.readthedocs.io/"
@@ -46,7 +46,7 @@ itertools = "0.10"
 num-rational = "0.4"
 indexmap = "1.9"
 once_cell = "1.17"
-solang-parser = { path = "solang-parser", version = "0.2.2" }
+solang-parser = { path = "solang-parser", version = "0.2.4" }
 codespan-reporting = "0.11"
 phf = { version = "0.11", features = ["macros"] }
 rust-lapper = "1.1"

--- a/README.md
+++ b/README.md
@@ -135,14 +135,14 @@ Here is a brief description of what we envision for the next versions.
 
 ### V0.3
 
-| Milestone                                    | Status      |
+| Feature                                      | Status      |
 |----------------------------------------------|-------------|
 | Specify values as "1 sol" and "1e9 lamports" | Completed   |
 | Call Solana's Rust contracts from Solidity   | Completed   |
 | Improvements in overflow checking            | Completed   |
 | Support Solana's Program Derived Addresses   | Completed   |
 | Call Solidity from Solana's Rust contracts   | Not started |
-| Improve developer experience for Substrate   | In progress |
+| Improve developer experience for Substrate   | Complete    |
 | Tooling for calls between ink! <> solidity   | In progress |
 | Support chain extensions for Substrate       | Not started |
 | Provide CLI for node interactions            | Not started |
@@ -150,7 +150,7 @@ Here is a brief description of what we envision for the next versions.
 
 ### V0.4
 
-| Milestone                                          | Status      |
+| Feature                                            | Status      |
 |----------------------------------------------------|-------------|
 | Improve management over optimization passes        | Not started |
 | Adopt single static assignment for code generation | Not started |

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -28,11 +28,11 @@ Option 2: Download binaries
 
 There are binaries available on github releases:
 
-- `Linux x86-64 <https://github.com/hyperledger/solang/releases/download/v0.2.2/solang-linux-x86-64>`_
-- `Linux arm64 <https://github.com/hyperledger/solang/releases/download/v0.2.2/solang-linux-arm64>`_
-- `Windows x64 <https://github.com/hyperledger/solang/releases/download/v0.2.2/solang.exe>`_
-- `MacOS intel <https://github.com/hyperledger/solang/releases/download/v0.2.2/solang-mac-intel>`_
-- `MacOS arm <https://github.com/hyperledger/solang/releases/download/v0.2.2/solang-mac-arm>`_
+- `Linux x86-64 <https://github.com/hyperledger/solang/releases/download/v0.2.3/solang-linux-x86-64>`_
+- `Linux arm64 <https://github.com/hyperledger/solang/releases/download/v0.2.3/solang-linux-arm64>`_
+- `Windows x64 <https://github.com/hyperledger/solang/releases/download/v0.2.3/solang.exe>`_
+- `MacOS intel <https://github.com/hyperledger/solang/releases/download/v0.2.3/solang-mac-intel>`_
+- `MacOS arm <https://github.com/hyperledger/solang/releases/download/v0.2.3/solang-mac-arm>`_
 
 Download the file and save it somewhere in your ``$PATH``, for example the bin directory in your home directory. If the
 path you use is not already in ``$PATH``, then you need to add it yourself.
@@ -56,7 +56,7 @@ Option 3: Use ghcr.io/hyperledger/solang containers
 
 New images are automatically made available on
 `solang containers <https://github.com/hyperledger/solang/pkgs/container/solang>`_.
-There is a release `v0.2.2` tag and a `latest` tag:
+There is a release `v0.2.3` tag and a `latest` tag:
 
 .. code-block:: bash
 
@@ -113,7 +113,7 @@ These patches make it possible to generate code for Solana, and fixes
 concurrency issues in the lld linker.
 
 You can either download the pre-built libraries from
-`github <https://github.com/hyperledger/solang/releases/tag/v0.2.2>`_
+`github <https://github.com/hyperledger/solang/releases/tag/v0.2.3>`_
 or :ref:`build your own from source <llvm-from-source>`. After that, you need to add the ``bin`` of your
 LLVM directory to your path, so that the build system of Solang can find the correct version of LLVM to use.
 

--- a/solang-parser/Cargo.toml
+++ b/solang-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solang-parser"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Sean Young <sean@mess.org>", "Lucas Steuernagel <lucas.tnagel@gmail.com>", "Cyrill Leutwiler <bigcyrill@hotmail.com>"]
 homepage = "https://github.com/hyperledger/solang"
 documentation = "https://solang.readthedocs.io/"


### PR DESCRIPTION
### Added
- The Solana units `sol` and `lamports` are now supported, e.g. `10 sol` and `100 lamports`.
  [seanyoung](https://github.com/seanyoung)
- User defined operators are now supported. This is a feature in Ethereum Solidity v0.8.19.
  [seanyoung](https://github.com/seanyoung)
- **Solana**: if a contract uses the `SystemAccount`, `ClockAccount`, or other standard builtin
  accounts, then this is automatically added to the IDL. [LucasSte](https://github.com/LucasSte)
- **Substrate**: The content of the debug buffer is formatted in a human readable way. This vastly improves it's readability, allowing to spot API runtime return codes, runtime errors and debug prints much easier. [salaheldinsoliman](https://github.com/salaheldinsoliman) 

### Fixed
- Solana: contracts with a seed for the constructor do not require a signer in the Anchor IDL
  [seanyoung](https://github.com/seanyoung)
- Fix panic when lexing ".9" at the beginning of a file. [seanyoung](https://github.com/seanyoung)
- Forbid ABI encoding and decoding of recursive types. [xermicus](https://github.com/xermicus)
- Treat enums as 8bit uint in constant hashing. [xermicus](https://github.com/xermicus)
- Fix compilation failure with -g for the substrate target. [salaheldinsoliman](https://github.com/salaheldinsoliman)
- Fixed incorrect ABI encoding for user defined types. [xermicus](https://github.com/xermicus)  [seanyoung](https://github.com/seanyoung)
- Fixed incorrect ABI encoding for struct with fields of type `bytesN` [xermicus](https://github.com/xermicus)
- Fixed incorrect handling of recursive struct fields. [xermicus](https://github.com/xermicus)
- Fixed a bug in our Common Subexpression Elimination optimization pass [LucasSte](https://github.com/LucasSte)
### Changed
- Math overflow is now always enabled, unless the math happens with an `unchecked { .. }` block.
  The `--math-overflow` command line option has been removed. [seanyoung](https://github.com/seanyoung)
- **Substrate**: the SCALE encoder and decoder now uses a much better implementation written in our
  CFG intermediate format. [xermicus](https://github.com/xermicus)
- **Substrate**: When instantiating a new contract without providing a salt, the salt we be derived from the output of the new `instantiation_nonce` runtime API. [xermicus](https://github.com/xermicus)
- Minimal Supported Rust Version is `1.65.0`
- No longer silently overwrite contract artifacts, if the same contract is defined more than once in different locations [seanyoung](https://github.com/seanyoung)