### PR TITLE
Remove redundancies in `is_next_reachable()`

### DIFF
--- a/src/codegen/yul/mod.rs
+++ b/src/codegen/yul/mod.rs
@@ -108,7 +108,7 @@ fn yul_function_cfg(
         );
     }
 
-    if yul_func.body.statements.is_empty() || yul_func.body.next_reachable {
+    if yul_func.body.is_next_reachable() {
         cfg.add(&mut vartab, returns);
     }
 

--- a/src/sema/yul/ast.rs
+++ b/src/sema/yul/ast.rs
@@ -28,7 +28,7 @@ pub struct YulBlock {
 impl YulBlock {
     /// Returns if whatever follows the YulBlock is reachable
     pub fn is_next_reachable(&self) -> bool {
-        self.statements.is_empty() || (!self.statements.is_empty() && self.next_reachable)
+        self.statements.is_empty() || self.next_reachable
     }
 }
 


### PR DESCRIPTION
After merging #1260 , I noticed the checks in my code were redundant.