### PR TITLE
Disallow dynamic arrays for account metas

### DIFF
--- a/src/sema/expression/function_call.rs
+++ b/src/sema/expression/function_call.rs
@@ -2170,6 +2170,11 @@ pub(super) fn parse_call_args(
                         ),
                     ));
                     return Err(());
+                } else if expr_ty.is_dynamic(ns) {
+                    diagnostics.push(Diagnostic::error(
+                        arg.loc,
+                        "dynamic array is not supported for the 'accounts' argument".to_string(),
+                    ));
                 }
 
                 res.accounts = Some(Box::new(expr));


### PR DESCRIPTION
Account metas do not support dynamic arrays and we do not inform that to the user.