### PR TITLE
Allow this.function.selector as bytesN and in pure mutability

### DIFF
--- a/src/sema/expression/integers.rs
+++ b/src/sema/expression/integers.rs
@@ -51,6 +51,7 @@ pub(super) fn get_int_length(
         Type::Uint(n) => Ok((*n, false)),
         Type::Int(n) => Ok((*n, true)),
         Type::Value => Ok((ns.value_length as u16 * 8, false)),
+        Type::FunctionSelector => Ok((ns.target.selector_length() as u16 * 8, false)),
         Type::Bytes(n) if allow_bytes => Ok((*n as u16 * 8, false)),
         Type::Enum(n) => {
             diagnostics.push(Diagnostic::error(
@@ -124,6 +125,9 @@ pub fn coerce_number(
         }
         (_, Type::Bytes(_)) if allow_bytes => {
             return Ok(r.clone());
+        }
+        (Type::FunctionSelector, _) | (_, Type::FunctionSelector) if allow_bytes => {
+            return Ok(Type::Bytes(ns.target.selector_length()));
         }
         (Type::Rational, Type::Int(_)) => {
             return Ok(Type::Rational);

--- a/src/sema/mutability.rs
+++ b/src/sema/mutability.rs
@@ -253,6 +253,18 @@ fn read_expression(expr: &Expression, state: &mut StateCheck) -> bool {
             state.read(loc)
         }
         Expression::Builtin {
+            kind: Builtin::FunctionSelector,
+            args,
+            ..
+        } => {
+            if let Expression::ExternalFunction { .. } = &args[0] {
+                // in the case of `this.func.selector`, the address of this is not used and
+                // therefore does not read state. Do not recurse down the `address` field of
+                // Expression::ExternalFunction
+                return false;
+            }
+        }
+        Expression::Builtin {
             loc,
             kind:
                 Builtin::GetAddress

--- a/tests/evm.rs
+++ b/tests/evm.rs
@@ -258,7 +258,7 @@ fn ethereum_solidity_tests() {
         })
         .sum();
 
-    assert_eq!(errors, 1062);
+    assert_eq!(errors, 1056);
 }
 
 fn set_file_contents(source: &str, path: &Path) -> (FileResolver, Vec<String>) {


### PR DESCRIPTION
Improve compatibility with solc.