### PR TITLE
Run Ethereum Solidity semantic tests through sema

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "solang-parser/testdata/solidity"]
-	path = solang-parser/testdata/solidity
+	path = testdata/solidity
 	url = https://github.com/ethereum/solidity

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "Solang Solidity Compiler"
 keywords = [ "solidity", "compiler", "solana", "substrate" ]
 rust-version = "1.65.0"
 edition = "2021"
-exclude = [ "/.*", "/docs",  "/examples", "/solana-library", "/tests", "/integration", "/vscode" ]
+exclude = [ "/.*", "/docs",  "/examples", "/solana-library", "/tests", "/integration", "/vscode", "/testdata" ]
 
 [build-dependencies]
 cc = "1.0"
@@ -79,6 +79,7 @@ byte-slice-cast = "1.2"
 borsh = "0.10"
 tempfile = "3.3"
 rayon = "1"
+walkdir = "2.3.3"
 
 [package.metadata.docs.rs]
 no-default-features = true

--- a/solang-parser/Cargo.toml
+++ b/solang-parser/Cargo.toml
@@ -9,7 +9,6 @@ build = "build.rs"
 description = "Solang Solidity Parser"
 keywords = [ "solidity", "parser" ]
 edition = "2021"
-exclude = [ "/testdata" ]
 
 [build-dependencies]
 lalrpop = "0.19"

--- a/solang-parser/src/tests.rs
+++ b/solang-parser/src/tests.rs
@@ -1184,7 +1184,7 @@ fn test_libsolidity() {
 
     let semantic_tests = WalkDir::new(
         Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("testdata/solidity/test/libsolidity/semanticTests"),
+            .join("../testdata/solidity/test/libsolidity/semanticTests"),
     )
     .into_iter()
     .collect::<Result<Vec<_>, _>>()
@@ -1194,7 +1194,7 @@ fn test_libsolidity() {
 
     let syntax_tests = WalkDir::new(
         Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("testdata/solidity/test/libsolidity/syntaxTests"),
+            .join("../testdata/solidity/test/libsolidity/syntaxTests"),
     )
     .into_iter()
     .collect::<Result<Vec<_>, _>>()

--- a/src/file_resolver.rs
+++ b/src/file_resolver.rs
@@ -131,6 +131,12 @@ impl FileResolver {
     ) -> Result<ResolvedFile, String> {
         let path = PathBuf::from(filename);
 
+        let path = if let Ok(m) = path.strip_prefix("./") {
+            m.to_path_buf()
+        } else {
+            path
+        };
+
         // first check maps
         let mut iter = path.iter();
         if let Some(first_part) = iter.next() {
@@ -195,8 +201,7 @@ impl FileResolver {
             start_import_no = *import_no;
         }
 
-        if self.import_paths.is_empty() {
-            // we have no import paths, resolve by what's in the cache
+        if self.cached_paths.contains_key(&path) {
             let full_path = path;
             let base = full_path
                 .parent()


### PR DESCRIPTION
There are many failures. First there are some tests which cause panics in sema. These are explicitly excluded. There are a further 1062 failures. Note the line:

	assert_eq!(errors, 1062);

To see the failures, see:

	cargo test --test evm ethereum_solidity_tests -- --nocapture