### PR TITLE
Fix new clippy 1.69 lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,8 @@ anchor-syn = { version = "0.27.0", features = ["idl"] }
 convert_case = "0.6"
 parse-display = "0.8.0"
 parity-scale-codec = "3.4"
-ink = "=4.1.0"
+ink_env = "=4.1.0"
+ink_metadata = "=4.1.0"
 scale-info = "2.4"
 petgraph = "0.6.3"
 wasmparser = "0.102.0"
@@ -80,6 +81,7 @@ borsh = "0.10"
 tempfile = "3.3"
 rayon = "1"
 walkdir = "2.3.3"
+ink_primitives = "=4.1.0"
 
 [package.metadata.docs.rs]
 no-default-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ anchor-syn = { version = "0.27.0", features = ["idl"] }
 convert_case = "0.6"
 parse-display = "0.8.0"
 parity-scale-codec = "3.4"
-ink = "4.1.0"
+ink = "=4.1.0"
 scale-info = "2.4"
 petgraph = "0.6.3"
 wasmparser = "0.102.0"

--- a/solang-parser/src/helpers/ord.rs
+++ b/solang-parser/src/helpers/ord.rs
@@ -13,7 +13,7 @@ macro_rules! impl_with_cast {
         $(
             impl $t {
                 #[inline]
-                const fn as_discriminant<'a>(&'a self) -> &'a u8 {
+                const fn as_discriminant(&self) -> &u8 {
                     // SAFETY: See <https://doc.rust-lang.org/stable/std/mem/fn.discriminant.html#accessing-the-numeric-value-of-the-discriminant>
                     // and <https://doc.rust-lang.org/reference/items/enumerations.html#pointer-casting>
                     //

--- a/src/abi/substrate.rs
+++ b/src/abi/substrate.rs
@@ -3,7 +3,7 @@ use contract_metadata::{
     CodeHash, Compiler, Contract, ContractMetadata, Language, Source, SourceCompiler,
     SourceLanguage, SourceWasm,
 };
-use ink::metadata::{
+use ink_metadata::{
     layout::{FieldLayout, Layout, LayoutKey, LeafLayout, RootLayout, StructLayout},
     ConstructorSpec, ContractSpec, EventParamSpec, EventSpec, InkProject, MessageParamSpec,
     MessageSpec, ReturnTypeSpec, TypeSpec,
@@ -437,7 +437,7 @@ pub fn gen_project(contract_no: usize, ns: &ast::Namespace) -> InkProject {
             .collect::<Vec<_>>();
         EventSpec::new(e.name.clone())
             .args(args)
-            .docs(vec![render(&e.tags).as_str()])
+            .docs(vec![render(&e.tags)])
             .done()
     };
 

--- a/src/abi/substrate.rs
+++ b/src/abi/substrate.rs
@@ -437,7 +437,7 @@ pub fn gen_project(contract_no: usize, ns: &ast::Namespace) -> InkProject {
             .collect::<Vec<_>>();
         EventSpec::new(e.name.clone())
             .args(args)
-            .docs(vec![render(&e.tags)])
+            .docs(vec![render(&e.tags).as_str()])
             .done()
     };
 

--- a/src/codegen/events/substrate.rs
+++ b/src/codegen/events/substrate.rs
@@ -10,7 +10,7 @@ use crate::codegen::expression::expression;
 use crate::codegen::vartable::Vartable;
 use crate::codegen::{Builtin, Expression, Options};
 use crate::sema::ast::{self, Function, Namespace, RetrieveType, StringLocation, Type};
-use ink::env::hash::{Blake2x256, CryptoHash};
+use ink_env::hash::{Blake2x256, CryptoHash};
 use parity_scale_codec::Encode;
 use solang_parser::pt;
 

--- a/tests/substrate.rs
+++ b/tests/substrate.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use contract_metadata::ContractMetadata;
-use ink::metadata::InkProject;
+use ink_metadata::InkProject;
 // Create WASM virtual machine like substrate
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;

--- a/tests/substrate_tests/events.rs
+++ b/tests/substrate_tests/events.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::build_solidity;
-use ink::env::{
+use ink_env::{
     hash::{Blake2x256, CryptoHash},
     topics::PrefixedValue,
 };
-use ink::primitives::AccountId;
+use ink_primitives::AccountId;
 use parity_scale_codec::Encode;
 use solang::{file_resolver::FileResolver, Target};
 use std::ffi::OsStr;


### PR DESCRIPTION
Contains a drive by fix for the build. My guess is that the `ink` umbrella crate doesn't pin it's dependencies, which results in various `ink_* 4.2.0` dependencies being pulled in, despite explicitly pinning `ink = "=4.1.0"` in our `Cargo .toml`