### PR TITLE
Use ethereum solidity v0.8.19 testdata

### DIFF
--- a/tests/evm.rs
+++ b/tests/evm.rs
@@ -200,6 +200,12 @@ fn ethereum_solidity_tests() {
                 && !file_name.ends_with("inline_assembly_embedded_function_call.sol")
                 && !file_name.ends_with("linkersymbol_function.sol")
                 && !file_name.ends_with("370_shift_constant_left_excessive_rvalue.sol")
+                && !file_name.ends_with("use_msize_with_optimizer.sol")
+                && !file_name.ends_with("two_stack_slots.sol")
+                && !file_name.ends_with("two_stack_slot_access.sol")
+                && !file_name.ends_with("difficulty_disallowed_function_pre_paris.sol")
+                && !file_name.ends_with("difficulty_reserved_post_paris.sol")
+                && !file_name.ends_with("mapping_with_names_nested_7.sol")
                 && file_name.ends_with(".sol")
             {
                 Some(entry)
@@ -249,7 +255,7 @@ fn ethereum_solidity_tests() {
         })
         .sum();
 
-    assert_eq!(errors, 1053);
+    assert_eq!(errors, 1155);
 }
 
 fn set_file_contents(source: &str, path: &Path) -> (FileResolver, Vec<String>) {


### PR DESCRIPTION
After the testdata directory was moved out of solang-parser, the submodule commit was changed somehow (did not show up in git diff).