### PR TITLE
Solve YUL panics for EVM semantic tests

### DIFF
--- a/src/sema/yul/ast.rs
+++ b/src/sema/yul/ast.rs
@@ -17,7 +17,7 @@ pub struct InlineAssembly {
     pub functions: std::ops::Range<usize>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct YulBlock {
     pub loc: pt::Loc,
     pub reachable: bool,
@@ -119,7 +119,7 @@ impl CodeLocation for YulExpression {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct YulFunction {
     pub loc: pt::Loc,
     pub name: String,

--- a/src/sema/yul/block.rs
+++ b/src/sema/yul/block.rs
@@ -75,10 +75,18 @@ pub(crate) fn process_statements(
 
     for item in statements {
         if let pt::YulStatement::FunctionDefinition(func_def) = item {
+            // If an error was generate while processing the function header, it is not added to the
+            // functions table, so we do not resolve its body.
+            let index = if let Some(index) = functions_table.function_index(&func_def.id.name) {
+                index
+            } else {
+                continue;
+            };
+
             if let Ok(resolved_func) =
                 resolve_function_definition(func_def, functions_table, context, ns)
             {
-                functions_table.resolved_functions.push(resolved_func);
+                functions_table.resolved_functions[index] = resolved_func;
             }
         }
     }

--- a/tests/evm.rs
+++ b/tests/evm.rs
@@ -193,18 +193,10 @@ fn ethereum_solidity_tests() {
             let file_name = entry.file_name().to_string_lossy();
 
             // FIXME: max_depth_reached_4.sol causes a stack overflow in resolve_expression.rs
-            // FIXNE: others listed explicitly cause panics and need fixing
+            // FIXME: others listed explicitly cause panics and need fixing
             if !file_name.ends_with("max_depth_reached_4.sol")
                 && !file_name.ends_with("invalid_utf8_sequence.sol")
-                && !file_name.ends_with("basefee_berlin_function.sol")
-                && !file_name.ends_with("inline_assembly_embedded_function_call.sol")
-                && !file_name.ends_with("linkersymbol_function.sol")
                 && !file_name.ends_with("370_shift_constant_left_excessive_rvalue.sol")
-                && !file_name.ends_with("use_msize_with_optimizer.sol")
-                && !file_name.ends_with("two_stack_slots.sol")
-                && !file_name.ends_with("two_stack_slot_access.sol")
-                && !file_name.ends_with("difficulty_disallowed_function_pre_paris.sol")
-                && !file_name.ends_with("difficulty_reserved_post_paris.sol")
                 && file_name.ends_with(".sol")
             {
                 Some(entry)
@@ -254,7 +246,7 @@ fn ethereum_solidity_tests() {
         })
         .sum();
 
-    assert_eq!(errors, 1093);
+    assert_eq!(errors, 1097);
 }
 
 fn set_file_contents(source: &str, path: &Path) -> (FileResolver, Vec<String>) {


### PR DESCRIPTION
I fixed a problem in which we were trying to fetch a function header that was not added to the set of processed headers, because there was an error in processing it.