### PR TITLE
Do not panic if variable accessor function has duplicate argument names

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,14 +41,14 @@ jobs:
   docs:
     name: Docs
     runs-on: solang-ubuntu-latest
-    container: ubuntu:20.04
+    container: ubuntu:22.04
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
       - name: Install Python and git
         run: |
           apt-get update
-          apt-get install -y python3-pip git
+          apt-get install -y python3-pip git pkg-config libcairo-dev
       - name: Install Docs requirements.txt
         run : |
           pip install -r requirements.txt

--- a/src/sema/variables.rs
+++ b/src/sema/variables.rs
@@ -457,7 +457,7 @@ pub fn variable_decl<'a>(
             let mut symtable = Symtable::new();
             let mut params = Vec::new();
             let param =
-                collect_parameters(&ty, &def.name, &mut symtable, &mut params, &mut expr, ns);
+                collect_parameters(&ty, &def.name, &mut symtable, &mut params, &mut expr, ns)?;
             let ty = param.ty.clone();
 
             if ty.contains_mapping(ns) {
@@ -532,7 +532,7 @@ fn collect_parameters(
     params: &mut Vec<Parameter>,
     expr: &mut Expression,
     ns: &mut Namespace,
-) -> Parameter {
+) -> Option<Parameter> {
     match ty {
         Type::Mapping(Mapping {
             key,
@@ -552,16 +552,14 @@ fn collect_parameters(
             };
             let arg_ty = key.as_ref().clone();
 
-            let arg_no = symtable
-                .add(
-                    &id,
-                    arg_ty.clone(),
-                    ns,
-                    VariableInitializer::Solidity(None),
-                    VariableUsage::Parameter,
-                    None,
-                )
-                .unwrap();
+            let arg_no = symtable.add(
+                &id,
+                arg_ty.clone(),
+                ns,
+                VariableInitializer::Solidity(None),
+                VariableUsage::Parameter,
+                None,
+            )?;
 
             symtable.arguments.push(Some(arg_no));
 
@@ -642,7 +640,7 @@ fn collect_parameters(
 
             collect_parameters(elem_ty, &None, symtable, params, expr, ns)
         }
-        _ => Parameter {
+        _ => Some(Parameter {
             id: name.clone(),
             loc: if let Some(name) = name {
                 name.loc
@@ -655,7 +653,7 @@ fn collect_parameters(
             readonly: false,
             infinite_size: false,
             recursive: false,
-        },
+        }),
     }
 }
 

--- a/tests/evm.rs
+++ b/tests/evm.rs
@@ -205,7 +205,6 @@ fn ethereum_solidity_tests() {
                 && !file_name.ends_with("two_stack_slot_access.sol")
                 && !file_name.ends_with("difficulty_disallowed_function_pre_paris.sol")
                 && !file_name.ends_with("difficulty_reserved_post_paris.sol")
-                && !file_name.ends_with("mapping_with_names_nested_7.sol")
                 && file_name.ends_with(".sol")
             {
                 Some(entry)


### PR DESCRIPTION
This can only arise with nested mapping:

```solidity
contract test {
    mapping(uint nameSame => mapping(uint name1 => mapping(uint nameSame => uint 
name3) name6) name4) public name5;
}
```