### PR TITLE
update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ tiny-keccak = { version = "2.0", features = ["keccak"] }
 serde_json = "1.0"
 serde = "1.0"
 serde_derive = { version = "1.0" }
-inkwell = { version = "0.1.1", features = ["target-webassembly", "target-bpf", "no-libffi-linking", "llvm15-0"], optional = true }
+inkwell = { version = "0.2.0", features = ["target-webassembly", "target-bpf", "no-libffi-linking", "llvm15-0"], optional = true }
 blake2-rfc = "0.2.18"
 handlebars = "4.3"
 contract-metadata = "2.1"
@@ -58,8 +58,8 @@ ink_env = "=4.1.0"
 ink_metadata = "=4.1.0"
 scale-info = "2.4"
 petgraph = "0.6.3"
-wasmparser = "0.102.0"
-wasm-encoder = "0.25"
+wasmparser = "0.104.0"
+wasm-encoder = "0.26"
 
 [dev-dependencies]
 num-derive = "0.3"


### PR DESCRIPTION
Updates some dependencies.

Most notably inkwell 0.2.0 which now supports LLVM 16 :eyes: 