### PR TITLE
Using for not permitted in interfaces

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -223,7 +223,7 @@ jobs:
       uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: '14'
+        node-version: '16'
     - name: Rust Stable
       run: rustup default stable
     - name: Setup yarn
@@ -270,7 +270,7 @@ jobs:
       uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: '14'
+        node-version: '16'
     - name: Rust Stable
       run: rustup default stable
     - uses: actions/download-artifact@v3
@@ -308,7 +308,7 @@ jobs:
       id: substrate
     - uses: actions/setup-node@v3
       with:
-        node-version: '14'
+        node-version: '16'
     - uses: actions/download-artifact@v3
       with:
         name: solang-linux-x86-64
@@ -348,7 +348,7 @@ jobs:
     - name: Install Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: '14'
+        node-version: '16'
     - run: npm install
       working-directory: ./vscode
     - run: npm run compile

--- a/src/sema/using.rs
+++ b/src/sema/using.rs
@@ -23,6 +23,16 @@ pub(crate) fn using_decl(
 ) -> Result<Using, ()> {
     let mut diagnostics = Diagnostics::default();
 
+    if let Some(contract_no) = contract_no {
+        if ns.contracts[contract_no].is_interface() {
+            ns.diagnostics.push(Diagnostic::error(
+                using.loc,
+                "using for not permitted in interface".into(),
+            ));
+            return Err(());
+        }
+    }
+
     let ty = if let Some(expr) = &using.ty {
         match ns.resolve_type(file_no, contract_no, false, expr, &mut diagnostics) {
             Ok(Type::Contract(contract_no)) if ns.contracts[contract_no].is_library() => {

--- a/tests/contract_testcases/solana/using_interface.sol
+++ b/tests/contract_testcases/solana/using_interface.sol
@@ -1,0 +1,8 @@
+function double(int x) pure returns (int) { return x * 2; }
+
+interface C {
+	using {double} for int;
+}
+
+// ---- Expect: diagnostics ----
+// error: 4:2-24: using for not permitted in interface


### PR DESCRIPTION
`using` does not make any sense in interfaces, as they contain no function bodies.