### PR TITLE
Use solc v0.8.20 testdata

### DIFF
--- a/solang-parser/README.md
+++ b/solang-parser/README.md
@@ -3,7 +3,7 @@
 This crate is part of [Hyperledger Solang](https://solang.readthedocs.io/). It contains the
 parser for Solidity, including the dialects used by Solang for Solana and Substrate.
 
-This parser is compatible with Ethereum Solidity v0.8.19.
+This parser is compatible with Ethereum Solidity v0.8.20.
 
 `solang-parser` is still `0.*.*`, so breaking changes [may occur at any time](https://semver.org/#spec-item-4). If you must depend on `solang-parser`, we recommend pinning to a specific version, i.e., `=0.y.z`.
 

--- a/src/sema/expression/resolve_expression.rs
+++ b/src/sema/expression/resolve_expression.rs
@@ -439,6 +439,13 @@ pub fn expression(
                 } else {
                     get_int_length(&expr_type, loc, false, ns, diagnostics)?;
 
+                    if !expr_type.is_signed_int(ns) {
+                        diagnostics.push(Diagnostic::error(
+                            *loc,
+                            "negate not allowed on unsigned".to_string(),
+                        ));
+                    }
+
                     Ok(Expression::Negate {
                         loc: *loc,
                         ty: expr_type,
@@ -453,6 +460,11 @@ pub fn expression(
             let expr_type = expr.ty();
 
             get_int_length(&expr_type, loc, false, ns, diagnostics)?;
+
+            diagnostics.push(Diagnostic::error(
+                *loc,
+                "unary plus not permitted".to_string(),
+            ));
 
             Ok(expr)
         }

--- a/tests/contract_testcases/evm/standalone_call.sol
+++ b/tests/contract_testcases/evm/standalone_call.sol
@@ -14,7 +14,7 @@ contract BABYLINK {
         return (1, c + 2, 3);
     }
 
-    function singleReturn() private pure returns (int) {
+    function singleReturn() private pure returns (uint) {
         return 3;
     }
 
@@ -57,3 +57,5 @@ contract BABYLINK {
     }
 }
 // ---- Expect: diagnostics ----
+// error: 39:9-24: unary plus not permitted
+// error: 40:9-24: negate not allowed on unsigned

--- a/tests/evm.rs
+++ b/tests/evm.rs
@@ -171,7 +171,8 @@ contract testing  {
 
 #[test]
 fn ethereum_solidity_tests() {
-    let error_matcher = regex::Regex::new(r"// ----\r?\n// \w+Error( \d+)?: (.*)").unwrap();
+    let error_matcher =
+        regex::Regex::new(r"// ----\r?\n(// Warning \d+: .*\n)*// \w+Error( \d+)?: (.*)").unwrap();
 
     let entries = WalkDir::new(
         Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -211,7 +212,7 @@ fn ethereum_solidity_tests() {
 
             let expect_error = error_matcher
                 .captures(&source)
-                .map(|captures| captures.get(2).unwrap().as_str());
+                .map(|captures| captures.get(3).unwrap().as_str());
 
             let (mut cache, names) = set_file_contents(&source, path);
 


### PR DESCRIPTION
Ethereum Solidity 0.8.20 has been released. Update our tests to use their latest test files.