### PR TITLE
Remove seal prefixes

### DIFF
--- a/src/emit/substrate/mod.rs
+++ b/src/emit/substrate/mod.rs
@@ -174,7 +174,7 @@ impl SubstrateTarget {
             "seal_gas_price",
             "seal_gas_left",
             "seal_caller",
-            "seal_terminate",
+            "terminate",
             "seal_deposit_event",
             "seal_transfer",
         ]);
@@ -302,7 +302,7 @@ impl SubstrateTarget {
         external!("seal_weight_to_fee", void_type, u64_val, u8_ptr, u32_ptr);
         external!("seal_gas_left", void_type, u8_ptr, u32_ptr);
         external!("seal_caller", void_type, u8_ptr, u32_ptr);
-        external!("seal_terminate", void_type, u8_ptr);
+        external!("terminate", void_type, u8_ptr);
         external!(
             "seal_deposit_event",
             void_type,

--- a/src/emit/substrate/mod.rs
+++ b/src/emit/substrate/mod.rs
@@ -154,14 +154,14 @@ impl SubstrateTarget {
             "seal_input",
             "set_storage",
             "get_storage",
-            "seal_clear_storage",
+            "clear_storage",
             "seal_hash_keccak_256",
             "seal_hash_sha2_256",
             "seal_hash_blake2_128",
             "seal_hash_blake2_256",
             "seal_return",
             "seal_debug_message",
-            "seal_instantiate",
+            "instantiate",
             "seal_call",
             "seal_value_transferred",
             "seal_minimum_balance",
@@ -262,11 +262,11 @@ impl SubstrateTarget {
         external!("instantiation_nonce", i64_type,);
         external!("set_storage", i32_type, u8_ptr, u32_val, u8_ptr, u32_val);
         external!("seal_debug_message", i32_type, u8_ptr, u32_val);
-        external!("seal_clear_storage", i32_type, u8_ptr, u32_val);
+        external!("clear_storage", i32_type, u8_ptr, u32_val);
         external!("get_storage", i32_type, u8_ptr, u32_val, u8_ptr, u32_ptr);
         external!("seal_return", void_type, u32_val, u8_ptr, u32_val);
         external!(
-            "seal_instantiate",
+            "instantiate",
             i32_type,
             u8_ptr,
             u64_val,

--- a/src/emit/substrate/mod.rs
+++ b/src/emit/substrate/mod.rs
@@ -279,7 +279,7 @@ impl SubstrateTarget {
             u8_ptr,
             u32_val
         );
-        // We still use prefixed seal_call because it would collide with the expored call function.
+        // We still use prefixed seal_call because it would collide with the exported call function.
         // TODO: Refactor emit to use a dedicated module for the externals to avoid any collisions.
         external!(
             "seal_call",

--- a/src/emit/substrate/mod.rs
+++ b/src/emit/substrate/mod.rs
@@ -169,7 +169,7 @@ impl SubstrateTarget {
             "instantiation_nonce",
             "seal_address",
             "seal_balance",
-            "seal_block_number",
+            "block_number",
             "seal_now",
             "seal_gas_price",
             "seal_gas_left",
@@ -297,7 +297,7 @@ impl SubstrateTarget {
         external!("seal_address", void_type, u8_ptr, u32_ptr);
         external!("seal_balance", void_type, u8_ptr, u32_ptr);
         external!("minimum_balance", void_type, u8_ptr, u32_ptr);
-        external!("seal_block_number", void_type, u8_ptr, u32_ptr);
+        external!("block_number", void_type, u8_ptr, u32_ptr);
         external!("seal_now", void_type, u8_ptr, u32_ptr);
         external!("seal_weight_to_fee", void_type, u64_val, u8_ptr, u32_ptr);
         external!("seal_gas_left", void_type, u8_ptr, u32_ptr);

--- a/src/emit/substrate/mod.rs
+++ b/src/emit/substrate/mod.rs
@@ -163,7 +163,7 @@ impl SubstrateTarget {
             "debug_message",
             "instantiate",
             "seal_call",
-            "seal_value_transferred",
+            "value_transferred",
             "seal_minimum_balance",
             "seal_weight_to_fee",
             "instantiation_nonce",
@@ -293,7 +293,7 @@ impl SubstrateTarget {
             u32_ptr
         );
         external!("seal_transfer", i32_type, u8_ptr, u32_val, u8_ptr, u32_val);
-        external!("seal_value_transferred", void_type, u8_ptr, u32_ptr);
+        external!("value_transferred", void_type, u8_ptr, u32_ptr);
         external!("seal_address", void_type, u8_ptr, u32_ptr);
         external!("seal_balance", void_type, u8_ptr, u32_ptr);
         external!("seal_minimum_balance", void_type, u8_ptr, u32_ptr);

--- a/src/emit/substrate/mod.rs
+++ b/src/emit/substrate/mod.rs
@@ -165,18 +165,17 @@ impl SubstrateTarget {
             "seal_call",
             "value_transferred",
             "minimum_balance",
-            "seal_weight_to_fee",
+            "weight_to_fee",
             "instantiation_nonce",
             "address",
             "balance",
             "block_number",
-            "seal_now",
-            "seal_gas_price",
-            "seal_gas_left",
-            "seal_caller",
+            "now",
+            "gas_left",
+            "caller",
             "terminate",
-            "seal_deposit_event",
-            "seal_transfer",
+            "deposit_event",
+            "transfer",
         ]);
 
         binary
@@ -292,25 +291,18 @@ impl SubstrateTarget {
             u8_ptr,
             u32_ptr
         );
-        external!("seal_transfer", i32_type, u8_ptr, u32_val, u8_ptr, u32_val);
+        external!("transfer", i32_type, u8_ptr, u32_val, u8_ptr, u32_val);
         external!("value_transferred", void_type, u8_ptr, u32_ptr);
         external!("address", void_type, u8_ptr, u32_ptr);
         external!("balance", void_type, u8_ptr, u32_ptr);
         external!("minimum_balance", void_type, u8_ptr, u32_ptr);
         external!("block_number", void_type, u8_ptr, u32_ptr);
-        external!("seal_now", void_type, u8_ptr, u32_ptr);
-        external!("seal_weight_to_fee", void_type, u64_val, u8_ptr, u32_ptr);
-        external!("seal_gas_left", void_type, u8_ptr, u32_ptr);
-        external!("seal_caller", void_type, u8_ptr, u32_ptr);
+        external!("now", void_type, u8_ptr, u32_ptr);
+        external!("weight_to_fee", void_type, u64_val, u8_ptr, u32_ptr);
+        external!("gas_left", void_type, u8_ptr, u32_ptr);
+        external!("caller", void_type, u8_ptr, u32_ptr);
         external!("terminate", void_type, u8_ptr);
-        external!(
-            "seal_deposit_event",
-            void_type,
-            u8_ptr,
-            u32_val,
-            u8_ptr,
-            u32_val
-        );
+        external!("deposit_event", void_type, u8_ptr, u32_val, u8_ptr, u32_val);
     }
 
     /// Emits the "deploy" function if `init` is `Some`, otherwise emits the "call" function.

--- a/src/emit/substrate/mod.rs
+++ b/src/emit/substrate/mod.rs
@@ -73,14 +73,11 @@ macro_rules! emit_context {
         #[allow(unused_macros)]
         macro_rules! seal_set_storage {
             ($key_ptr:expr, $key_len:expr, $value_ptr:expr, $value_len:expr) => {
-                call!(
-                    "seal_set_storage",
-                    &[$key_ptr, $key_len, $value_ptr, $value_len]
-                )
-                .try_as_basic_value()
-                .left()
-                .unwrap()
-                .into_int_value()
+                call!("set_storage", &[$key_ptr, $key_len, $value_ptr, $value_len])
+                    .try_as_basic_value()
+                    .left()
+                    .unwrap()
+                    .into_int_value()
             };
         }
 
@@ -158,7 +155,7 @@ impl SubstrateTarget {
             "call",
             "call_chain_extension",
             "seal_input",
-            "seal_set_storage",
+            "set_storage",
             "seal_get_storage",
             "seal_clear_storage",
             "seal_hash_keccak_256",
@@ -266,14 +263,7 @@ impl SubstrateTarget {
         external!("seal_hash_blake2_128", void_type, u8_ptr, u32_val, u8_ptr);
         external!("seal_hash_blake2_256", void_type, u8_ptr, u32_val, u8_ptr);
         external!("instantiation_nonce", i64_type,);
-        external!(
-            "seal_set_storage",
-            i32_type,
-            u8_ptr,
-            u32_val,
-            u8_ptr,
-            u32_val
-        );
+        external!("set_storage", i32_type, u8_ptr, u32_val, u8_ptr, u32_val);
         external!("seal_debug_message", i32_type, u8_ptr, u32_val);
         external!("seal_clear_storage", i32_type, u8_ptr, u32_val);
         external!(

--- a/src/emit/substrate/mod.rs
+++ b/src/emit/substrate/mod.rs
@@ -164,7 +164,7 @@ impl SubstrateTarget {
             "instantiate",
             "seal_call",
             "value_transferred",
-            "seal_minimum_balance",
+            "minimum_balance",
             "seal_weight_to_fee",
             "instantiation_nonce",
             "seal_address",
@@ -296,7 +296,7 @@ impl SubstrateTarget {
         external!("value_transferred", void_type, u8_ptr, u32_ptr);
         external!("seal_address", void_type, u8_ptr, u32_ptr);
         external!("seal_balance", void_type, u8_ptr, u32_ptr);
-        external!("seal_minimum_balance", void_type, u8_ptr, u32_ptr);
+        external!("minimum_balance", void_type, u8_ptr, u32_ptr);
         external!("seal_block_number", void_type, u8_ptr, u32_ptr);
         external!("seal_now", void_type, u8_ptr, u32_ptr);
         external!("seal_weight_to_fee", void_type, u64_val, u8_ptr, u32_ptr);

--- a/src/emit/substrate/mod.rs
+++ b/src/emit/substrate/mod.rs
@@ -167,8 +167,8 @@ impl SubstrateTarget {
             "minimum_balance",
             "seal_weight_to_fee",
             "instantiation_nonce",
-            "seal_address",
-            "seal_balance",
+            "address",
+            "balance",
             "block_number",
             "seal_now",
             "seal_gas_price",
@@ -294,8 +294,8 @@ impl SubstrateTarget {
         );
         external!("seal_transfer", i32_type, u8_ptr, u32_val, u8_ptr, u32_val);
         external!("value_transferred", void_type, u8_ptr, u32_ptr);
-        external!("seal_address", void_type, u8_ptr, u32_ptr);
-        external!("seal_balance", void_type, u8_ptr, u32_ptr);
+        external!("address", void_type, u8_ptr, u32_ptr);
+        external!("balance", void_type, u8_ptr, u32_ptr);
         external!("minimum_balance", void_type, u8_ptr, u32_ptr);
         external!("block_number", void_type, u8_ptr, u32_ptr);
         external!("seal_now", void_type, u8_ptr, u32_ptr);

--- a/src/emit/substrate/mod.rs
+++ b/src/emit/substrate/mod.rs
@@ -151,14 +151,14 @@ impl SubstrateTarget {
             "deploy",
             "call",
             "call_chain_extension",
-            "seal_input",
+            "input",
             "set_storage",
             "get_storage",
             "clear_storage",
-            "seal_hash_keccak_256",
-            "seal_hash_sha2_256",
-            "seal_hash_blake2_128",
-            "seal_hash_blake2_256",
+            "hash_keccak_256",
+            "hash_sha2_256",
+            "hash_blake2_128",
+            "hash_blake2_256",
             "seal_return",
             "seal_debug_message",
             "instantiate",
@@ -209,7 +209,7 @@ impl SubstrateTarget {
         );
 
         binary.builder.build_call(
-            binary.module.get_function("seal_input").unwrap(),
+            binary.module.get_function("input").unwrap(),
             &[scratch_buf.into(), scratch_len.into()],
             "",
         );
@@ -254,11 +254,11 @@ impl SubstrateTarget {
             u8_ptr,
             u32_ptr
         );
-        external!("seal_input", void_type, u8_ptr, u32_ptr);
-        external!("seal_hash_keccak_256", void_type, u8_ptr, u32_val, u8_ptr);
-        external!("seal_hash_sha2_256", void_type, u8_ptr, u32_val, u8_ptr);
-        external!("seal_hash_blake2_128", void_type, u8_ptr, u32_val, u8_ptr);
-        external!("seal_hash_blake2_256", void_type, u8_ptr, u32_val, u8_ptr);
+        external!("input", void_type, u8_ptr, u32_ptr);
+        external!("hash_keccak_256", void_type, u8_ptr, u32_val, u8_ptr);
+        external!("hash_sha2_256", void_type, u8_ptr, u32_val, u8_ptr);
+        external!("hash_blake2_128", void_type, u8_ptr, u32_val, u8_ptr);
+        external!("hash_blake2_256", void_type, u8_ptr, u32_val, u8_ptr);
         external!("instantiation_nonce", i64_type,);
         external!("set_storage", i32_type, u8_ptr, u32_val, u8_ptr, u32_val);
         external!("seal_debug_message", i32_type, u8_ptr, u32_val);

--- a/src/emit/substrate/mod.rs
+++ b/src/emit/substrate/mod.rs
@@ -160,7 +160,7 @@ impl SubstrateTarget {
             "hash_blake2_128",
             "hash_blake2_256",
             "seal_return",
-            "seal_debug_message",
+            "debug_message",
             "instantiate",
             "seal_call",
             "seal_value_transferred",
@@ -261,7 +261,7 @@ impl SubstrateTarget {
         external!("hash_blake2_256", void_type, u8_ptr, u32_val, u8_ptr);
         external!("instantiation_nonce", i64_type,);
         external!("set_storage", i32_type, u8_ptr, u32_val, u8_ptr, u32_val);
-        external!("seal_debug_message", i32_type, u8_ptr, u32_val);
+        external!("debug_message", i32_type, u8_ptr, u32_val);
         external!("clear_storage", i32_type, u8_ptr, u32_val);
         external!("get_storage", i32_type, u8_ptr, u32_val, u8_ptr, u32_ptr);
         external!("seal_return", void_type, u32_val, u8_ptr, u32_val);
@@ -402,5 +402,5 @@ fn log_return_code(binary: &Binary, api: &'static str, code: IntValue) {
             .build_ptr_to_int(out_buf, binary.context.i32_type(), "out_buf_ptr"),
         "msg_len",
     );
-    call!("seal_debug_message", &[out_buf.into(), msg_len.into()]);
+    call!("debug_message", &[out_buf.into(), msg_len.into()]);
 }

--- a/src/emit/substrate/mod.rs
+++ b/src/emit/substrate/mod.rs
@@ -59,14 +59,11 @@ macro_rules! emit_context {
         #[allow(unused_macros)]
         macro_rules! seal_get_storage {
             ($key_ptr:expr, $key_len:expr, $value_ptr:expr, $value_len:expr) => {
-                call!(
-                    "seal_get_storage",
-                    &[$key_ptr, $key_len, $value_ptr, $value_len]
-                )
-                .try_as_basic_value()
-                .left()
-                .unwrap()
-                .into_int_value()
+                call!("get_storage", &[$key_ptr, $key_len, $value_ptr, $value_len])
+                    .try_as_basic_value()
+                    .left()
+                    .unwrap()
+                    .into_int_value()
             };
         }
 
@@ -156,7 +153,7 @@ impl SubstrateTarget {
             "call_chain_extension",
             "seal_input",
             "set_storage",
-            "seal_get_storage",
+            "get_storage",
             "seal_clear_storage",
             "seal_hash_keccak_256",
             "seal_hash_sha2_256",
@@ -266,14 +263,7 @@ impl SubstrateTarget {
         external!("set_storage", i32_type, u8_ptr, u32_val, u8_ptr, u32_val);
         external!("seal_debug_message", i32_type, u8_ptr, u32_val);
         external!("seal_clear_storage", i32_type, u8_ptr, u32_val);
-        external!(
-            "seal_get_storage",
-            i32_type,
-            u8_ptr,
-            u32_val,
-            u8_ptr,
-            u32_ptr
-        );
+        external!("get_storage", i32_type, u8_ptr, u32_val, u8_ptr, u32_ptr);
         external!("seal_return", void_type, u32_val, u8_ptr, u32_val);
         external!(
             "seal_instantiate",

--- a/src/emit/substrate/mod.rs
+++ b/src/emit/substrate/mod.rs
@@ -279,6 +279,8 @@ impl SubstrateTarget {
             u8_ptr,
             u32_val
         );
+        // We still use prefixed seal_call because it would collide with the expored call function.
+        // TODO: Refactor emit to use a dedicated module for the externals to avoid any collisions.
         external!(
             "seal_call",
             i32_type,

--- a/src/emit/substrate/storage.rs
+++ b/src/emit/substrate/storage.rs
@@ -92,7 +92,7 @@ impl StorageSlot for SubstrateTarget {
     fn storage_delete_single_slot(&self, binary: &Binary, slot: PointerValue) {
         emit_context!(binary);
 
-        let ret = call!("seal_clear_storage", &[slot.into(), i32_const!(32).into()])
+        let ret = call!("clear_storage", &[slot.into(), i32_const!(32).into()])
             .try_as_basic_value()
             .left()
             .unwrap()

--- a/src/emit/substrate/target.rs
+++ b/src/emit/substrate/target.rs
@@ -75,7 +75,7 @@ impl<'a> TargetRuntime<'a> for SubstrateTarget {
         );
 
         let ret = call!(
-            "seal_get_storage",
+            "get_storage",
             &[
                 slot.into(),
                 i32_const!(32).into(),

--- a/src/emit/substrate/target.rs
+++ b/src/emit/substrate/target.rs
@@ -1496,9 +1496,9 @@ impl<'a> TargetRuntime<'a> for SubstrateTarget {
                     .build_store(scratch_len, i32_const!(ns.address_length as u64));
 
                 call!(
-                    "seal_address",
+                    "address",
                     &[scratch_buf.into(), scratch_len.into()],
-                    "address"
+                    "seal_address"
                 );
 
                 binary
@@ -1516,9 +1516,9 @@ impl<'a> TargetRuntime<'a> for SubstrateTarget {
                     .build_store(scratch_len, i32_const!(ns.value_length as u64));
 
                 call!(
-                    "seal_balance",
+                    "balance",
                     &[scratch_buf.into(), scratch_len.into()],
-                    "balance"
+                    "seal_balance"
                 );
 
                 binary

--- a/src/emit/substrate/target.rs
+++ b/src/emit/substrate/target.rs
@@ -747,10 +747,7 @@ impl<'a> TargetRuntime<'a> for SubstrateTarget {
     ) {
         emit_context!(binary);
 
-        call!(
-            "seal_hash_keccak_256",
-            &[src.into(), length.into(), dest.into()]
-        );
+        call!("hash_keccak_256", &[src.into(), length.into(), dest.into()]);
     }
 
     fn return_abi<'b>(&self, binary: &'b Binary, data: PointerValue<'b>, length: IntValue) {
@@ -1180,11 +1177,11 @@ impl<'a> TargetRuntime<'a> for SubstrateTarget {
         emit_context!(binary);
 
         let (fname, hashlen) = match hash {
-            HashTy::Keccak256 => ("seal_hash_keccak_256", 32),
+            HashTy::Keccak256 => ("hash_keccak_256", 32),
             HashTy::Ripemd160 => ("ripemd160", 20),
-            HashTy::Sha256 => ("seal_hash_sha2_256", 32),
-            HashTy::Blake2_128 => ("seal_hash_blake2_128", 16),
-            HashTy::Blake2_256 => ("seal_hash_blake2_256", 32),
+            HashTy::Sha256 => ("hash_sha2_256", 32),
+            HashTy::Blake2_128 => ("hash_blake2_128", 16),
+            HashTy::Blake2_256 => ("hash_blake2_256", 32),
         };
 
         let res =
@@ -1381,7 +1378,7 @@ impl<'a> TargetRuntime<'a> for SubstrateTarget {
                     .build_store(scratch_len, i32_const!(SCRATCH_SIZE as u64));
 
                 // retrieve the data
-                call!("seal_input", &[data.into(), scratch_len.into()], "data");
+                call!("input", &[data.into(), scratch_len.into()], "data");
 
                 v
             }

--- a/src/emit/substrate/target.rs
+++ b/src/emit/substrate/target.rs
@@ -870,7 +870,7 @@ impl<'a> TargetRuntime<'a> for SubstrateTarget {
                 .build_store(scratch_len, i32_const!(ns.value_length as u64));
 
             call!(
-                "seal_minimum_balance",
+                "minimum_balance",
                 &[value_ptr.into(), scratch_len.into()],
                 "minimum_balance"
             );
@@ -1481,7 +1481,7 @@ impl<'a> TargetRuntime<'a> for SubstrateTarget {
             } => {
                 get_seal_value!(
                     "minimum_balance",
-                    "seal_minimum_balance",
+                    "minimum_balance",
                     ns.value_length as u32 * 8
                 )
             }

--- a/src/emit/substrate/target.rs
+++ b/src/emit/substrate/target.rs
@@ -1384,7 +1384,7 @@ impl<'a> TargetRuntime<'a> for SubstrateTarget {
                 ..
             } => {
                 let block_number =
-                    get_seal_value!("block_number", "seal_block_number", 32).into_int_value();
+                    get_seal_value!("seal_block_number", "block_number", 32).into_int_value();
 
                 // Cast to 64 bit
                 binary
@@ -1480,7 +1480,7 @@ impl<'a> TargetRuntime<'a> for SubstrateTarget {
                 ..
             } => {
                 get_seal_value!(
-                    "minimum_balance",
+                    "seal_minimum_balance",
                     "minimum_balance",
                     ns.value_length as u32 * 8
                 )

--- a/src/emit/substrate/target.rs
+++ b/src/emit/substrate/target.rs
@@ -1161,7 +1161,7 @@ impl<'a> TargetRuntime<'a> for SubstrateTarget {
 
         binary.builder.build_store(address, addr);
 
-        call!("seal_terminate", &[address.into()], "terminated");
+        call!("terminate", &[address.into()], "terminated");
 
         binary.builder.build_unreachable();
     }

--- a/src/emit/substrate/target.rs
+++ b/src/emit/substrate/target.rs
@@ -1061,7 +1061,7 @@ impl<'a> TargetRuntime<'a> for SubstrateTarget {
 
         // do the actual call
         let ret = call!(
-            "seal_transfer",
+            "transfer",
             &[
                 address.into(),
                 i32_const!(ns.address_length as u64).into(),
@@ -1283,7 +1283,7 @@ impl<'a> TargetRuntime<'a> for SubstrateTarget {
         };
 
         call!(
-            "seal_deposit_event",
+            "deposit_event",
             &[
                 topic_buf.into(),
                 topic_size.into(),
@@ -1400,7 +1400,7 @@ impl<'a> TargetRuntime<'a> for SubstrateTarget {
                 kind: codegen::Builtin::Timestamp,
                 ..
             } => {
-                let milliseconds = get_seal_value!("timestamp", "seal_now", 64).into_int_value();
+                let milliseconds = get_seal_value!("timestamp", "now", 64).into_int_value();
 
                 // Solidity expects the timestamp in seconds, not milliseconds
                 binary
@@ -1416,7 +1416,7 @@ impl<'a> TargetRuntime<'a> for SubstrateTarget {
                 kind: codegen::Builtin::Gasleft,
                 ..
             } => {
-                get_seal_value!("gas_left", "seal_gas_left", 64)
+                get_seal_value!("gas_left", "gas_left", 64)
             }
             codegen::Expression::Builtin {
                 kind: codegen::Builtin::Gasprice,
@@ -1438,7 +1438,7 @@ impl<'a> TargetRuntime<'a> for SubstrateTarget {
                     .build_store(scratch_len, i32_const!(ns.value_length as u64));
 
                 call!(
-                    "seal_weight_to_fee",
+                    "weight_to_fee",
                     &[gas.into(), scratch_buf.into(), scratch_len.into()],
                     "gas_price"
                 );
@@ -1462,9 +1462,9 @@ impl<'a> TargetRuntime<'a> for SubstrateTarget {
                     .build_store(scratch_len, i32_const!(ns.address_length as u64));
 
                 call!(
-                    "seal_caller",
+                    "caller",
                     &[scratch_buf.into(), scratch_len.into()],
-                    "caller"
+                    "seal_caller"
                 );
 
                 binary

--- a/src/emit/substrate/target.rs
+++ b/src/emit/substrate/target.rs
@@ -131,7 +131,7 @@ impl<'a> TargetRuntime<'a> for SubstrateTarget {
 
         binary.builder.position_at_end(delete_block);
 
-        let ret = call!("seal_clear_storage", &[slot.into(), i32_const!(32).into()])
+        let ret = call!("clear_storage", &[slot.into(), i32_const!(32).into()])
             .try_as_basic_value()
             .left()
             .unwrap()
@@ -902,7 +902,7 @@ impl<'a> TargetRuntime<'a> for SubstrateTarget {
             .build_store(scratch_len, i32_const!(SCRATCH_SIZE as u64 * 32));
 
         let ret = call!(
-            "seal_instantiate",
+            "instantiate",
             &[
                 codehash.into(),
                 contract_args.gas.unwrap().into(),

--- a/src/emit/substrate/target.rs
+++ b/src/emit/substrate/target.rs
@@ -804,14 +804,11 @@ impl<'a> TargetRuntime<'a> for SubstrateTarget {
     fn print(&self, binary: &Binary, string_ptr: PointerValue, string_len: IntValue) {
         emit_context!(binary);
 
-        let ret = call!(
-            "seal_debug_message",
-            &[string_ptr.into(), string_len.into()]
-        )
-        .try_as_basic_value()
-        .left()
-        .unwrap()
-        .into_int_value();
+        let ret = call!("debug_message", &[string_ptr.into(), string_len.into()])
+            .try_as_basic_value()
+            .left()
+            .unwrap()
+            .into_int_value();
 
         log_return_code(binary, "seal_debug_message", ret);
     }
@@ -1658,7 +1655,7 @@ impl<'a> TargetRuntime<'a> for SubstrateTarget {
         let error_with_loc = error_msg_with_loc(ns, &reason_string, reason_loc);
         let custom_error = string_to_basic_value(bin, ns, error_with_loc + ",\n");
         call!(
-            "seal_debug_message",
+            "debug_message",
             &[
                 bin.vector_bytes(custom_error).into(),
                 bin.vector_len(custom_error).into()

--- a/src/emit/substrate/target.rs
+++ b/src/emit/substrate/target.rs
@@ -1134,7 +1134,7 @@ impl<'a> TargetRuntime<'a> for SubstrateTarget {
             .build_store(value_len, i32_const!(ns.value_length as u64));
 
         call!(
-            "seal_value_transferred",
+            "value_transferred",
             &[value.into(), value_len.into()],
             "value_transferred"
         );

--- a/src/linker/wasm.rs
+++ b/src/linker/wasm.rs
@@ -103,7 +103,7 @@ fn generate_import_section(section: SectionLimited<Import>, module: &mut Module)
         };
         let module_name = match import.name {
             "memory" => import.module,
-            "seal_set_storage" => "seal2",
+            "set_storage" => "seal2",
             "seal_clear_storage"
             | "seal_contains_storage"
             | "seal_get_storage"

--- a/src/linker/wasm.rs
+++ b/src/linker/wasm.rs
@@ -106,7 +106,7 @@ fn generate_import_section(section: SectionLimited<Import>, module: &mut Module)
             "set_storage" => "seal2",
             "seal_clear_storage"
             | "seal_contains_storage"
-            | "seal_get_storage"
+            | "get_storage"
             | "seal_instantiate"
             | "seal_terminate"
             | "seal_call" => "seal1",

--- a/src/linker/wasm.rs
+++ b/src/linker/wasm.rs
@@ -104,12 +104,8 @@ fn generate_import_section(section: SectionLimited<Import>, module: &mut Module)
         let module_name = match import.name {
             "memory" => import.module,
             "set_storage" => "seal2",
-            "seal_clear_storage"
-            | "seal_contains_storage"
-            | "get_storage"
-            | "seal_instantiate"
-            | "seal_terminate"
-            | "seal_call" => "seal1",
+            "clear_storage" | "contains_storage" | "get_storage" | "instantiate"
+            | "seal_terminate" | "seal_call" => "seal1",
             _ => "seal0",
         };
         imports.import(module_name, import.name, import_type);

--- a/src/linker/wasm.rs
+++ b/src/linker/wasm.rs
@@ -104,8 +104,8 @@ fn generate_import_section(section: SectionLimited<Import>, module: &mut Module)
         let module_name = match import.name {
             "memory" => import.module,
             "set_storage" => "seal2",
-            "clear_storage" | "contains_storage" | "get_storage" | "instantiate"
-            | "seal_terminate" | "seal_call" => "seal1",
+            "clear_storage" | "contains_storage" | "get_storage" | "instantiate" | "terminate"
+            | "seal_call" => "seal1",
             _ => "seal0",
         };
         imports.import(module_name, import.name, import_type);

--- a/tests/substrate.rs
+++ b/tests/substrate.rs
@@ -354,7 +354,7 @@ impl Runtime {
     }
 
     #[seal(0)]
-    fn seal_value_transferred(dest_ptr: u32, out_len_ptr: u32) -> Result<(), Trap> {
+    fn value_transferred(dest_ptr: u32, out_len_ptr: u32) -> Result<(), Trap> {
         let value = vm.transferred_value.to_le_bytes();
         assert!(read_len(mem, out_len_ptr) >= value.len());
         println!("seal_value_transferred: {}", vm.transferred_value);
@@ -513,7 +513,7 @@ impl Runtime {
     }
 
     #[seal(0)]
-    fn seal_minimum_balance(out_ptr: u32, out_len_ptr: u32) -> Result<(), Trap> {
+    fn minimum_balance(out_ptr: u32, out_len_ptr: u32) -> Result<(), Trap> {
         assert!(read_len(mem, out_len_ptr) >= 16);
         write_buf(mem, out_ptr, &500u128.to_le_bytes());
         Ok(())

--- a/tests/substrate.rs
+++ b/tests/substrate.rs
@@ -396,7 +396,7 @@ impl Runtime {
     }
 
     #[seal(2)]
-    fn seal_set_storage(
+    fn set_storage(
         key_ptr: u32,
         key_len: u32,
         value_ptr: u32,

--- a/tests/substrate.rs
+++ b/tests/substrate.rs
@@ -414,7 +414,7 @@ impl Runtime {
     }
 
     #[seal(1)]
-    fn seal_clear_storage(key_ptr: u32, key_len: u32) -> Result<u32, Trap> {
+    fn clear_storage(key_ptr: u32, key_len: u32) -> Result<u32, Trap> {
         let key = StorageKey::try_from(read_buf(mem, key_ptr, key_len))
             .expect("storage key size must be 32 bytes");
         println!("clear_storage: {}", hex::encode(key));
@@ -520,7 +520,7 @@ impl Runtime {
     }
 
     #[seal(1)]
-    fn seal_instantiate(
+    fn instantiate(
         code_hash_ptr: u32,
         _gas: u64,
         value_ptr: u32,

--- a/tests/substrate.rs
+++ b/tests/substrate.rs
@@ -566,7 +566,7 @@ impl Runtime {
     }
 
     #[seal(0)]
-    fn seal_transfer(
+    fn transfer(
         account_ptr: u32,
         account_len: u32,
         value_ptr: u32,
@@ -603,7 +603,7 @@ impl Runtime {
     }
 
     #[seal(0)]
-    fn seal_caller(out_ptr: u32, out_len_ptr: u32) -> Result<(), Trap> {
+    fn caller(out_ptr: u32, out_len_ptr: u32) -> Result<(), Trap> {
         let out_len = read_len(mem, out_len_ptr);
         let address = vm.accounts[vm.caller_account].address;
         assert!(out_len >= address.len());
@@ -639,7 +639,7 @@ impl Runtime {
     }
 
     #[seal(0)]
-    fn seal_now(out_ptr: u32, out_len_ptr: u32) -> Result<(), Trap> {
+    fn now(out_ptr: u32, out_len_ptr: u32) -> Result<(), Trap> {
         let now = 1594035638000u64.to_le_bytes();
         let out_len = read_len(mem, out_len_ptr);
         assert!(out_len >= now.len());
@@ -651,7 +651,7 @@ impl Runtime {
     }
 
     #[seal(0)]
-    fn seal_gas_left(out_ptr: u32, out_len_ptr: u32) -> Result<(), Trap> {
+    fn gas_left(out_ptr: u32, out_len_ptr: u32) -> Result<(), Trap> {
         let gas = 2_224_097_461u64.to_le_bytes();
         let out_len = read_len(mem, out_len_ptr);
         assert!(out_len >= gas.len());
@@ -663,7 +663,7 @@ impl Runtime {
     }
 
     #[seal(0)]
-    fn seal_weight_to_fee(gas: u64, out_ptr: u32, out_len_ptr: u32) -> Result<(), Trap> {
+    fn weight_to_fee(gas: u64, out_ptr: u32, out_len_ptr: u32) -> Result<(), Trap> {
         let price = (59_541_253_813_967 * gas as u128).to_le_bytes();
         let out_len = read_len(mem, out_len_ptr);
         assert!(out_len >= price.len());
@@ -688,7 +688,7 @@ impl Runtime {
     }
 
     #[seal(0)]
-    fn seal_deposit_event(
+    fn deposit_event(
         topics_ptr: u32,
         topics_len: u32,
         data_ptr: u32,

--- a/tests/substrate.rs
+++ b/tests/substrate.rs
@@ -135,7 +135,7 @@ impl Contract {
         match instance
             .get_export(&store, name)
             .and_then(|export| export.into_func())
-            .expect("contract does not export '{function}'")
+            .expect(&format!("contract does not export '{name}'"))
             .call(&mut store, &[], &mut [])
         {
             Err(Error::Trap(trap)) if trap.trap_code().is_some() => {
@@ -675,7 +675,7 @@ impl Runtime {
     }
 
     #[seal(1)]
-    fn seal_terminate(beneficiary_ptr: u32) -> Result<(), Trap> {
+    fn terminate(beneficiary_ptr: u32) -> Result<(), Trap> {
         let free = vm.accounts.remove(vm.account).value;
         let address = read_account(mem, beneficiary_ptr);
         println!("seal_terminate: {} gets {free}", hex::encode(address));

--- a/tests/substrate.rs
+++ b/tests/substrate.rs
@@ -375,7 +375,7 @@ impl Runtime {
     }
 
     #[seal(1)]
-    fn seal_get_storage(
+    fn get_storage(
         key_ptr: u32,
         key_len: u32,
         out_ptr: u32,

--- a/tests/substrate.rs
+++ b/tests/substrate.rs
@@ -591,7 +591,7 @@ impl Runtime {
     }
 
     #[seal(0)]
-    fn seal_address(out_ptr: u32, out_len_ptr: u32) -> Result<(), Trap> {
+    fn address(out_ptr: u32, out_len_ptr: u32) -> Result<(), Trap> {
         let address = vm.accounts[vm.account].address;
         let out_len = read_len(mem, out_len_ptr);
         assert!(out_len >= address.len());
@@ -615,7 +615,7 @@ impl Runtime {
     }
 
     #[seal(0)]
-    fn seal_balance(out_ptr: u32, out_len_ptr: u32) -> Result<(), Trap> {
+    fn balance(out_ptr: u32, out_len_ptr: u32) -> Result<(), Trap> {
         let balance = vm.accounts[vm.account].value.to_le_bytes();
         let out_len = read_len(mem, out_len_ptr);
         assert!(out_len >= balance.len());

--- a/tests/substrate.rs
+++ b/tests/substrate.rs
@@ -135,7 +135,7 @@ impl Contract {
         match instance
             .get_export(&store, name)
             .and_then(|export| export.into_func())
-            .expect(&format!("contract does not export '{name}'"))
+            .unwrap_or_else(|| panic!("contract does not export '{name}'"))
             .call(&mut store, &[], &mut [])
         {
             Err(Error::Trap(trap)) if trap.trap_code().is_some() => {

--- a/tests/substrate.rs
+++ b/tests/substrate.rs
@@ -366,7 +366,7 @@ impl Runtime {
     }
 
     #[seal(0)]
-    fn seal_debug_message(data_ptr: u32, len: u32) -> Result<u32, Trap> {
+    fn debug_message(data_ptr: u32, len: u32) -> Result<u32, Trap> {
         let buf = read_buf(mem, data_ptr, len);
         let msg = std::str::from_utf8(&buf).expect("seal_debug_message: Invalid UFT8");
         println!("seal_debug_message: {msg}");

--- a/tests/substrate.rs
+++ b/tests/substrate.rs
@@ -627,7 +627,7 @@ impl Runtime {
     }
 
     #[seal(0)]
-    fn seal_block_number(out_ptr: u32, out_len_ptr: u32) -> Result<(), Trap> {
+    fn block_number(out_ptr: u32, out_len_ptr: u32) -> Result<(), Trap> {
         let block = 950_119_597u32.to_le_bytes();
         let out_len = read_len(mem, out_len_ptr);
         assert!(out_len >= block.len());

--- a/tests/substrate.rs
+++ b/tests/substrate.rs
@@ -336,7 +336,7 @@ fn read_account(mem: &[u8], ptr: u32) -> Address {
 #[wasm_host]
 impl Runtime {
     #[seal(0)]
-    fn seal_input(dest_ptr: u32, len_ptr: u32) -> Result<(), Trap> {
+    fn input(dest_ptr: u32, len_ptr: u32) -> Result<(), Trap> {
         assert!(read_len(mem, len_ptr) >= vm.input.len());
         println!("seal_input: {}", hex::encode(&vm.input));
 
@@ -426,7 +426,7 @@ impl Runtime {
     }
 
     #[seal(0)]
-    fn seal_hash_keccak_256(input_ptr: u32, input_len: u32, output_ptr: u32) -> Result<(), Trap> {
+    fn hash_keccak_256(input_ptr: u32, input_len: u32, output_ptr: u32) -> Result<(), Trap> {
         let mut hasher = Keccak::v256();
         hasher.update(&read_buf(mem, input_ptr, input_len));
         hasher.finalize(&mut mem[output_ptr as usize..(output_ptr + 32) as usize]);
@@ -434,7 +434,7 @@ impl Runtime {
     }
 
     #[seal(0)]
-    fn seal_hash_sha2_256(input_ptr: u32, input_len: u32, output_ptr: u32) -> Result<(), Trap> {
+    fn hash_sha2_256(input_ptr: u32, input_len: u32, output_ptr: u32) -> Result<(), Trap> {
         let mut hasher = Sha256::new();
         hasher.update(read_buf(mem, input_ptr, input_len));
         write_buf(mem, output_ptr, &hasher.finalize());
@@ -442,14 +442,14 @@ impl Runtime {
     }
 
     #[seal(0)]
-    fn seal_hash_blake2_128(input_ptr: u32, input_len: u32, output_ptr: u32) -> Result<(), Trap> {
+    fn hash_blake2_128(input_ptr: u32, input_len: u32, output_ptr: u32) -> Result<(), Trap> {
         let data = read_buf(mem, input_ptr, input_len);
         write_buf(mem, output_ptr, blake2b(16, &[], &data).as_bytes());
         Ok(())
     }
 
     #[seal(0)]
-    fn seal_hash_blake2_256(input_ptr: u32, input_len: u32, output_ptr: u32) -> Result<(), Trap> {
+    fn hash_blake2_256(input_ptr: u32, input_len: u32, output_ptr: u32) -> Result<(), Trap> {
         let data = read_buf(mem, input_ptr, input_len);
         write_buf(mem, output_ptr, blake2b(32, &[], &data).as_bytes());
         Ok(())


### PR DESCRIPTION
Since a while ago, the seal runtime API function imports do no longer need the `seal_` prefix. Since in Wasm the import name is found in the contract, it saves a few bytes in contract size. Unprefixed `return`  does not exist, and i left `seal_call` prefixed because it'll overwrite the `call` export.