### PR TITLE
Restrict external function callable scope

### DIFF
--- a/docs/language/functions.rst
+++ b/docs/language/functions.rst
@@ -19,13 +19,24 @@ which are provided in the return statement, the values of the return variables a
 of the function is returned. It is still possible to explicitly return some values
 with a return statement.
 
-Functions which are declared ``public`` will be present in the ABI and are callable
-externally. If a function is declared ``private`` then it is not callable externally,
-but it can be called from within the contract. If a function is defined outside a
-contract, then it cannot have a visibility specifier (e.g. ``public``).
-
 Any DocComment before a function will be include in the ABI. Currently only Substrate
 supports documentation in the ABI.
+
+Function visibility
+___________________
+
+Solidity functions have a visibility specifier that restricts the scope in which they can be called.
+Functions can be declared public, private, internal or external with the following definitions:
+
+    - ``public`` functions can be invoked inside and outside a contract (e.g. by an RPC). They are
+      present in the contract's ABI or IDL.
+    - ``private`` functions can only be called inside the contract they are declared.
+    - ``internal`` functions can only be called internally within the contract or by any contract
+      that inherits that one where the function is declared.
+    - ``external`` function can exclusively be invoked by other contracts or directly by an RPC. They
+      are also present in the contract's ABI or IDL.
+
+If a function is defined outside a contract,  it cannot have a visibility specifier (e.g. ``public``).
 
 Arguments passing and return values
 ___________________________________

--- a/docs/language/functions.rst
+++ b/docs/language/functions.rst
@@ -32,11 +32,17 @@ Functions can be declared public, private, internal or external with the followi
       present in the contract's ABI or IDL.
     - ``private`` functions can only be called inside the contract they are declared.
     - ``internal`` functions can only be called internally within the contract or by any contract
-      that inherits that one where the function is declared.
-    - ``external`` function can exclusively be invoked by other contracts or directly by an RPC. They
+      inherited contract.
+    - ``external`` functions can exclusively be invoked by other contracts or directly by an RPC. They
       are also present in the contract's ABI or IDL.
 
-If a function is defined outside a contract,  it cannot have a visibility specifier (e.g. ``public``).
+Both internal and external functions can be called using the syntax ``this.func()``. In this case, the
+arguments are ABI encoded for the call, as it is treated like an external call. This is the only way to
+call an external function from inside the same contract it is defined. This method, however, should be avoided
+for public functions, as it will be more costly to call them than simply using ``func()``.
+
+If a function is defined outside a contract, it cannot have a visibility specifier (e.g. ``public``).
+
 
 Arguments passing and return values
 ___________________________________

--- a/docs/language/functions.rst
+++ b/docs/language/functions.rst
@@ -28,15 +28,15 @@ ___________________
 Solidity functions have a visibility specifier that restricts the scope in which they can be called.
 Functions can be declared public, private, internal or external with the following definitions:
 
-    - ``public`` functions can be invoked inside and outside a contract (e.g. by an RPC). They are
+    - ``public`` functions can be called inside and outside a contract (e.g. by an RPC). They are
       present in the contract's ABI or IDL.
     - ``private`` functions can only be called inside the contract they are declared.
     - ``internal`` functions can only be called internally within the contract or by any contract
       inherited contract.
-    - ``external`` functions can exclusively be invoked by other contracts or directly by an RPC. They
+    - ``external`` functions can exclusively be called by other contracts or directly by an RPC. They
       are also present in the contract's ABI or IDL.
 
-Both internal and external functions can be called using the syntax ``this.func()``. In this case, the
+Both public and external functions can be called using the syntax ``this.func()``. In this case, the
 arguments are ABI encoded for the call, as it is treated like an external call. This is the only way to
 call an external function from inside the same contract it is defined. This method, however, should be avoided
 for public functions, as it will be more costly to call them than simply using ``func()``.

--- a/src/sema/contracts.rs
+++ b/src/sema/contracts.rs
@@ -259,10 +259,10 @@ impl ast::Namespace {
 }
 
 // Is a contract a base of another contract
-pub fn is_base(base: usize, parent: usize, ns: &ast::Namespace) -> bool {
-    let bases = &ns.contracts[parent].bases;
+pub fn is_base(base: usize, derived: usize, ns: &ast::Namespace) -> bool {
+    let bases = &ns.contracts[derived].bases;
 
-    if base == parent || bases.iter().any(|e| e.contract_no == base) {
+    if base == derived || bases.iter().any(|e| e.contract_no == base) {
         return true;
     }
 

--- a/src/sema/expression/function_call.rs
+++ b/src/sema/expression/function_call.rs
@@ -2591,9 +2591,10 @@ fn resolve_internal_call(
         if is_base(base_no, derived_no, ns) && matches!(func.visibility, Visibility::External(_)) {
             errors.push(Diagnostic::error_with_note(
                 *loc,
-                "external functions can only be invoked outside the contract".to_string(),
+                "functions declared external cannot be called via an internal function call"
+                    .to_string(),
                 func.loc,
-                "function defined here".to_string(),
+                format!("declaration of {} '{}'", func.ty, func.name),
             ));
             return None;
         }

--- a/src/sema/expression/function_call.rs
+++ b/src/sema/expression/function_call.rs
@@ -17,7 +17,7 @@ use crate::sema::{builtin, using};
 use crate::Target;
 use solang_parser::diagnostics::Diagnostic;
 use solang_parser::pt;
-use solang_parser::pt::CodeLocation;
+use solang_parser::pt::{CodeLocation, Visibility};
 use std::collections::HashMap;
 
 /// Resolve a function call via function type
@@ -320,6 +320,12 @@ pub fn function_call_pos_args(
             ));
 
             continue;
+        } else if matches!(func.visibility, Visibility::External(_)) {
+            errors.push(Diagnostic::error(
+                *loc,
+                "external functions can only be invoked outside the contract".to_string(),
+            ));
+            continue;
         }
 
         let returns = function_returns(func, resolve_to);
@@ -505,6 +511,12 @@ pub(super) fn function_call_named_args(
                 format!("declaration of function '{}'", func.name),
             ));
 
+            continue;
+        } else if matches!(func.visibility, Visibility::External(_)) {
+            errors.push(Diagnostic::error(
+                *loc,
+                "external functions can only be invoked outside the contract".to_string(),
+            ));
             continue;
         }
 

--- a/tests/contract_testcases/solana/functions/external_functions.sol
+++ b/tests/contract_testcases/solana/functions/external_functions.sol
@@ -42,9 +42,9 @@ contract bar2 is bar1 {
 }
 
 // ---- Expect: diagnostics ----
-// error: 25:16-27: external functions can only be invoked outside the contract
-// 	note 19:5-61: function defined here
-// error: 30:16-35: external functions can only be invoked outside the contract
-// 	note 19:5-61: function defined here
-// error: 40:16-38: external functions can only be invoked outside the contract
-// 	note 10:5-72: function defined here
+// error: 25:16-27: functions declared external cannot be called via an internal function call
+// 	note 19:5-61: declaration of function 'hello'
+// error: 30:16-35: functions declared external cannot be called via an internal function call
+// 	note 19:5-61: declaration of function 'hello'
+// error: 40:16-38: functions declared external cannot be called via an internal function call
+// 	note 10:5-72: declaration of function 'this_is_external'

--- a/tests/contract_testcases/solana/functions/external_functions.sol
+++ b/tests/contract_testcases/solana/functions/external_functions.sol
@@ -1,0 +1,19 @@
+contract bar {
+    constructor() {}
+
+    function hello(int a, int b) external pure returns (int) {
+        return a - b;
+    }
+
+    function test2(int c, int d) external returns (int) {
+        return hello(c, d);
+    }
+
+    function test3(int f, int g) external returns (int) {
+        return hello({b: g, a: f});
+    }
+}
+
+// ---- Expect: diagnostics ----
+// error: 9:16-27: external functions can only be invoked outside the contract
+// error: 13:16-35: external functions can only be invoked outside the contract

--- a/tests/contract_testcases/solana/functions/external_functions.sol
+++ b/tests/contract_testcases/solana/functions/external_functions.sol
@@ -1,4 +1,19 @@
-contract bar {
+
+function doThis(bar1 bb) returns (int) {
+    // This is allwoed
+    return bb.this_is_external(1, 2);
+}
+
+contract bar1 {
+    constructor() {}
+
+    function this_is_external(int a, int b) external pure returns (int) {
+        return a-b;
+    }
+}
+
+
+contract bar2 is bar1 {
     constructor() {}
 
     function hello(int a, int b) external pure returns (int) {
@@ -6,14 +21,30 @@ contract bar {
     }
 
     function test2(int c, int d) external returns (int) {
+        // Not allowed
         return hello(c, d);
     }
 
     function test3(int f, int g) external returns (int) {
+        // Not allowed
         return hello({b: g, a: f});
+    }
+
+    function test4(int c, int d) public returns (int) {
+        // This is allowed
+        return this.this_is_external(c, d) + this.hello(d, c);
+    }
+
+    function test5(int f, int g) external returns (int) {
+        // Not allowed
+        return this_is_external(f, g);
     }
 }
 
 // ---- Expect: diagnostics ----
-// error: 9:16-27: external functions can only be invoked outside the contract
-// error: 13:16-35: external functions can only be invoked outside the contract
+// error: 25:16-27: external functions can only be invoked outside the contract
+// 	note 19:5-61: function defined here
+// error: 30:16-35: external functions can only be invoked outside the contract
+// 	note 19:5-61: function defined here
+// error: 40:16-38: external functions can only be invoked outside the contract
+// 	note 10:5-72: function defined here

--- a/tests/evm.rs
+++ b/tests/evm.rs
@@ -249,7 +249,7 @@ fn ethereum_solidity_tests() {
         })
         .sum();
 
-    assert_eq!(errors, 1092);
+    assert_eq!(errors, 1082);
 }
 
 fn set_file_contents(source: &str, path: &Path) -> (FileResolver, Vec<String>) {

--- a/tests/evm.rs
+++ b/tests/evm.rs
@@ -249,7 +249,7 @@ fn ethereum_solidity_tests() {
         })
         .sum();
 
-    assert_eq!(errors, 1084);
+    assert_eq!(errors, 1092);
 }
 
 fn set_file_contents(source: &str, path: &Path) -> (FileResolver, Vec<String>) {

--- a/tests/evm.rs
+++ b/tests/evm.rs
@@ -249,7 +249,7 @@ fn ethereum_solidity_tests() {
         })
         .sum();
 
-    assert_eq!(errors, 1079);
+    assert_eq!(errors, 1070);
 }
 
 fn set_file_contents(source: &str, path: &Path) -> (FileResolver, Vec<String>) {

--- a/tests/evm.rs
+++ b/tests/evm.rs
@@ -249,7 +249,7 @@ fn ethereum_solidity_tests() {
         })
         .sum();
 
-    assert_eq!(errors, 1082);
+    assert_eq!(errors, 1079);
 }
 
 fn set_file_contents(source: &str, path: &Path) -> (FileResolver, Vec<String>) {

--- a/tests/evm.rs
+++ b/tests/evm.rs
@@ -249,7 +249,7 @@ fn ethereum_solidity_tests() {
         })
         .sum();
 
-    assert_eq!(errors, 1070);
+    assert_eq!(errors, 1079);
 }
 
 fn set_file_contents(source: &str, path: &Path) -> (FileResolver, Vec<String>) {


### PR DESCRIPTION
On Solc, external functions can exclusively be called outside a contract. In order for use to accomplish #1251, we need to restrict their scope to can declare and organize the accounts the function needs.