### PR TITLE
v0.3.0 Venice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 All notable changes to [Solang](https://github.com/hyperledger/solang/)
 will be documented here.
 
+## v0.3.0 Venice
+
+The parser and semantic analysis stage of Solang have gone through
+[a security audit](https://github.com/solana-labs/security-audits/blob/master/solang/Trail_of_Bits_Solang_Final_report.pdf). All security issues have been fixed.
+
+### Added
+- The CLI now has a `--release` option, which disables printing of errors [salaheldinsoliman](https://github.com/salaheldinsoliman)
+- **Substrate**: chain extensions can be now used.
+  [xermicus](https://github.com/xermicus)
+
+### Fixed
+- Solidity error definitions are now parsed.
+  [seanyoung](https://github.com/seanyoung)
+- The Ethereum Solidity parser and semantic analysis tests are now run on Solang sema during
+  `cargo test`.
+  [seanyoung](https://github.com/seanyoung)
+- If a function returns a `storage` reference, then not returning a value explicitly is an error, since
+  the reference must refer to an existing storage variable.
+  [seanyoung](https://github.com/seanyoung)
+- Many small improvements have been made to the parser and semantic analysis, improving compatibility
+  with Ethereum Solidity.
+  [seanyoung](https://github.com/seanyoung)
+  [xermicus](https://github.com/xermicus)
+  [LucasSte](https://github.com/LucasSte)
+
+### Changed
+- **Solana**: Addresses are now base58 encoded when formated with `"address:{}".format(address)`.
+  [LucasSte](https://github.com/LucasSte)
+- **Substrate**: No longer use the prefixed names for seal runtime API calls, which grants small improvements in contract sizes. [xermicus](https://github.com/xermicus)
+
 ## v0.2.3 Geneva
 
 ### Added
@@ -11,7 +41,7 @@ will be documented here.
   [seanyoung](https://github.com/seanyoung)
 - **Solana**: if a contract uses the `SystemAccount`, `ClockAccount`, or other standard builtin
   accounts, then this is automatically added to the IDL. [LucasSte](https://github.com/LucasSte)
-- **Substrate**: The content of the debug buffer is formatted in a human readable way. This vastly improves it's readability, allowing to spot API runtime return codes, runtime errors and debug prints much easier. [salaheldinsoliman](https://github.com/salaheldinsoliman) 
+- **Substrate**: The content of the debug buffer is formatted in a human readable way. This vastly improves its readability, allowing to spot API runtime return codes, runtime errors and debug prints much easier. [salaheldinsoliman](https://github.com/salaheldinsoliman)
 
 ### Fixed
 - Solana: contracts with a seed for the constructor do not require a signer in the Anchor IDL

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solang"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["Sean Young <sean@mess.org>", "Lucas Steuernagel <lucas.tnagel@gmail.com>", "Cyrill Leutwiler <bigcyrill@hotmail.com>"]
 homepage = "https://github.com/hyperledger/solang"
 documentation = "https://solang.readthedocs.io/"
@@ -46,7 +46,7 @@ itertools = "0.10"
 num-rational = "0.4"
 indexmap = "1.9"
 once_cell = "1.17"
-solang-parser = { path = "solang-parser", version = "0.2.4" }
+solang-parser = { path = "solang-parser", version = "0.3.0" }
 codespan-reporting = "0.11"
 phf = { version = "0.11", features = ["macros"] }
 rust-lapper = "1.1"

--- a/README.md
+++ b/README.md
@@ -133,21 +133,6 @@ up to date with the newest Solidity syntax and features.  In addition, we focus 
 and improve developer experience.
 Here is a brief description of what we envision for the next versions.
 
-### V0.3
-
-| Feature                                      | Status      |
-|----------------------------------------------|-------------|
-| Specify values as "1 sol" and "1e9 lamports" | Completed   |
-| Call Solana's Rust contracts from Solidity   | Completed   |
-| Improvements in overflow checking            | Completed   |
-| Support Solana's Program Derived Addresses   | Completed   |
-| Call Solidity from Solana's Rust contracts   | Not started |
-| Improve developer experience for Substrate   | Completed   |
-| Tooling for calls between ink! <> solidity   | In progress |
-| Support chain extensions for Substrate       | Completed   |
-| Provide CLI for node interactions            | Not started |
-
-
 ### V0.4
 
 | Feature                                            | Status      |
@@ -156,6 +141,9 @@ Here is a brief description of what we envision for the next versions.
 | Adopt single static assignment for code generation | Not started |
 | Support openzeppelin on Substrate target           | Not started |
 | Provide Solidity -> Substrate porting guide        | Not started |
+| Call Solidity from Solana's Rust contracts         | Not started |
+| Tooling for calls between ink! <> solidity         | In progress |
+| Provide CLI for node interactions                  | Not started |
 
 ## License
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -16,7 +16,6 @@
 - Merge the PR
 - Apply tag to merged commit on main branch
 - Push tag to origin
-- When changing LLVM version, regenerate the CI image using GitHub's manual actions trigger
 - Wait for build to succeed
 - `cargo publish`
 - Release new version of vscode plugin if needed

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -28,11 +28,11 @@ Option 2: Download binaries
 
 There are binaries available on github releases:
 
-- `Linux x86-64 <https://github.com/hyperledger/solang/releases/download/v0.2.3/solang-linux-x86-64>`_
-- `Linux arm64 <https://github.com/hyperledger/solang/releases/download/v0.2.3/solang-linux-arm64>`_
-- `Windows x64 <https://github.com/hyperledger/solang/releases/download/v0.2.3/solang.exe>`_
-- `MacOS intel <https://github.com/hyperledger/solang/releases/download/v0.2.3/solang-mac-intel>`_
-- `MacOS arm <https://github.com/hyperledger/solang/releases/download/v0.2.3/solang-mac-arm>`_
+- `Linux x86-64 <https://github.com/hyperledger/solang/releases/download/v0.3.0/solang-linux-x86-64>`_
+- `Linux arm64 <https://github.com/hyperledger/solang/releases/download/v0.3.0/solang-linux-arm64>`_
+- `Windows x64 <https://github.com/hyperledger/solang/releases/download/v0.3.0/solang.exe>`_
+- `MacOS intel <https://github.com/hyperledger/solang/releases/download/v0.3.0/solang-mac-intel>`_
+- `MacOS arm <https://github.com/hyperledger/solang/releases/download/v0.3.0/solang-mac-arm>`_
 
 Download the file and save it somewhere in your ``$PATH``, for example the bin directory in your home directory. If the
 path you use is not already in ``$PATH``, then you need to add it yourself.
@@ -56,7 +56,7 @@ Option 3: Use ghcr.io/hyperledger/solang containers
 
 New images are automatically made available on
 `solang containers <https://github.com/hyperledger/solang/pkgs/container/solang>`_.
-There is a release `v0.2.3` tag and a `latest` tag:
+There is a release `v0.3.0` tag and a `latest` tag:
 
 .. code-block:: bash
 
@@ -113,7 +113,7 @@ These patches make it possible to generate code for Solana, and fixes
 concurrency issues in the lld linker.
 
 You can either download the pre-built libraries from
-`github <https://github.com/hyperledger/solang/releases/tag/v0.2.3>`_
+`github <https://github.com/hyperledger/solang/releases/tag/v0.3.0>`_
 or :ref:`build your own from source <llvm-from-source>`. After that, you need to add the ``bin`` of your
 LLVM directory to your path, so that the build system of Solang can find the correct version of LLVM to use.
 

--- a/solang-parser/Cargo.toml
+++ b/solang-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solang-parser"
-version = "0.2.4"
+version = "0.3.0"
 authors = ["Sean Young <sean@mess.org>", "Lucas Steuernagel <lucas.tnagel@gmail.com>", "Cyrill Leutwiler <bigcyrill@hotmail.com>"]
 homepage = "https://github.com/hyperledger/solang"
 documentation = "https://solang.readthedocs.io/"


### PR DESCRIPTION
The parser and semantic analysis stage of Solang have gone through
[a security audit](https://github.com/solana-labs/security-audits/blob/master/solang/Trail_of_Bits_Solang_Final_report.pdf). All security issues have been fixed.

### Added
- The CLI now has a `--release` option, which disables printing of errors [salaheldinsoliman](https://github.com/salaheldinsoliman)
- **Substrate**: chain extensions can be now used.
  [xermicus](https://github.com/xermicus)

### Fixed
- Solidity error definitions are now parsed.
  [seanyoung](https://github.com/seanyoung)
- The Ethereum Solidity parser and semantic analysis tests are now run on Solang sema during
  `cargo test`.
  [seanyoung](https://github.com/seanyoung)
- If a function returns a `storage` reference, then not returning a value explicitly is an error, since
  the reference must refer to an existing storage variable.
  [seanyoung](https://github.com/seanyoung)
- Many small improvements have been made to the parser and semantic analysis, improving compatibility
  with Ethereum Solidity.
  [seanyoung](https://github.com/seanyoung)
  [xermicus](https://github.com/xermicus)
  [LucasSte](https://github.com/LucasSte)

### Changed
- **Solana**: Addresses are now base58 encoded when formated with `"address:{}".format(address)`.
  [LucasSte](https://github.com/LucasSte)
- **Substrate**: No longer use the prefixed names for seal runtime API calls, which grants small improvements in contract sizes. [xermicus](https://github.com/xermicus)
