### PR TITLE
solc does not warn or error for duplicate @param tags

### DIFF
--- a/tests/contract_testcases/substrate/tags/event_tag_02.sol
+++ b/tests/contract_testcases/substrate/tags/event_tag_02.sol
@@ -5,4 +5,6 @@
             uint32 f
         );
 // ---- Expect: diagnostics ----
-// error: 3:14-20: duplicate tag '@param' for 'f'
+// warning: 3:13-25: duplicate tag '@param' for 'f'
+// 	note 2:13-27: previous tag '@param' for 'f'
+// warning: 4:15-16: event 'x' has never been emitted

--- a/tests/contract_testcases/substrate/tags/functions_02.sol
+++ b/tests/contract_testcases/substrate/tags/functions_02.sol
@@ -7,4 +7,7 @@
             function foo(int f) public {}
         }
 // ---- Expect: diagnostics ----
-// error: 5:15-21: duplicate tag '@param' for 'f'
+// warning: 5:14-27: duplicate tag '@param' for 'f'
+// 	note 3:17-25: previous tag '@param' for 'f'
+// warning: 7:13-39: function can be declared 'pure'
+// warning: 7:30-31: function parameter 'f' has never been read

--- a/tests/contract_testcases/substrate/tags/struct_tag_02.sol
+++ b/tests/contract_testcases/substrate/tags/struct_tag_02.sol
@@ -5,4 +5,5 @@
             uint32 f;
         }
 // ---- Expect: diagnostics ----
-// error: 3:14-20: duplicate tag '@param' for 'f'
+// warning: 3:13-25: duplicate tag '@param' for 'f'
+// 	note 2:13-27: previous tag '@param' for 'f'


### PR DESCRIPTION
Make it a warning and add note to previous doc tag, and fix the locations.