### PR TITLE
Update to `ink!` v4.2 and bump MSRV to 1.68

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         submodules: recursive
     - name: Rust stable
-      run: rustup default 1.65.0
+      run: rustup default 1.68.0
     - name: Build
       run: cargo build --verbose --release
     - name: Run tests
@@ -40,7 +40,7 @@ jobs:
       with:
         submodules: recursive
     - name: Rust stable
-      run: rustup default 1.65.0
+      run: rustup default 1.68.0
     - name: Build
       run: cargo build --verbose --release
     - name: Run tests
@@ -67,7 +67,7 @@ jobs:
       run: unzip c:\llvm.zip -d c:/
     - name: Add LLVM to Path
       run: echo "c:\llvm15.0\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
-    - uses: dtolnay/rust-toolchain@1.65.0
+    - uses: dtolnay/rust-toolchain@1.68.0
       with:
         components: clippy
     - name: Build
@@ -91,7 +91,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: recursive
-    - uses: dtolnay/rust-toolchain@1.65.0
+    - uses: dtolnay/rust-toolchain@1.68.0
     - name: Get LLVM
       run: curl -sSL --output llvm15.0-mac-arm.tar.xz https://github.com/hyperledger/solang-llvm/releases/download/llvm15-1/llvm15.0-mac-arm.tar.xz
     - name: Extract LLVM
@@ -121,7 +121,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: recursive
-    - uses: dtolnay/rust-toolchain@1.65.0
+    - uses: dtolnay/rust-toolchain@1.68.0
     - name: Get LLVM
       run: wget -q -O llvm15.0-mac-intel.tar.xz https://github.com/hyperledger/solang-llvm/releases/download/llvm15-1/llvm15.0-mac-intel.tar.xz
     - name: Extract LLVM

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
       with:
         submodules: recursive
     - name: Rust stable
-      run: rustup default 1.65.0
+      run: rustup default 1.68.0
     - name: Build
       run: cargo build --verbose
     - name: Run tests
@@ -93,7 +93,7 @@ jobs:
       with:
         submodules: recursive
     - name: Rust stable
-      run: rustup default 1.65.0
+      run: rustup default 1.68.0
     - name: Build
       run: cargo build --verbose
     - name: Run tests
@@ -117,7 +117,7 @@ jobs:
       run: unzip c:\llvm.zip -d c:/
     - name: Add LLVM to Path
       run: echo "c:\llvm15.0\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8
-    - uses: dtolnay/rust-toolchain@1.65.0
+    - uses: dtolnay/rust-toolchain@1.68.0
       with:
         components: clippy
     # We run clippy on Linux in the lint job above, but this does not check #[cfg(windows)] items
@@ -141,7 +141,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: recursive
-    - uses: dtolnay/rust-toolchain@1.65.0
+    - uses: dtolnay/rust-toolchain@1.68.0
     - name: Get LLVM
       run: curl -sSL --output llvm15.0-mac-arm.tar.xz https://github.com/hyperledger/solang-llvm/releases/download/llvm15-1/llvm15.0-mac-arm.tar.xz
     - name: Extract LLVM
@@ -165,7 +165,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: recursive
-    - uses: dtolnay/rust-toolchain@1.65.0
+    - uses: dtolnay/rust-toolchain@1.68.0
     - name: Get LLVM
       run: wget -q -O llvm15.0-mac-intel.tar.xz https://github.com/hyperledger/solang-llvm/releases/download/llvm15-1/llvm15.0-mac-intel.tar.xz
     - name: Extract LLVM

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 build = "build.rs"
 description = "Solang Solidity Compiler"
 keywords = [ "solidity", "compiler", "solana", "substrate" ]
-rust-version = "1.65.0"
+rust-version = "1.68.0"
 edition = "2021"
 exclude = [ "/.*", "/docs",  "/examples", "/solana-library", "/tests", "/integration", "/vscode", "/testdata" ]
 
@@ -54,8 +54,8 @@ anchor-syn = { version = "0.27.0", features = ["idl"] }
 convert_case = "0.6"
 parse-display = "0.8.0"
 parity-scale-codec = "3.4"
-ink_env = "=4.1.0"
-ink_metadata = "=4.1.0"
+ink_env = "=4.2.0"
+ink_metadata = "=4.2.0"
 scale-info = "2.4"
 petgraph = "0.6.3"
 wasmparser = "0.104.0"
@@ -81,7 +81,7 @@ borsh = "0.10"
 tempfile = "3.3"
 rayon = "1"
 walkdir = "2.3.3"
-ink_primitives = "=4.1.0"
+ink_primitives = "=4.2.0"
 wasm_host_attr = { path = "tests/wasm_host_attr" }
 
 [package.metadata.docs.rs]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . src
 WORKDIR /src/stdlib/
 RUN make
 
-RUN rustup default 1.65.0
+RUN rustup default 1.68.0
 
 WORKDIR /src
 RUN cargo build --release

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -87,7 +87,7 @@ Then you can build the image using:
 Option 5: Build Solang from source
 ----------------------------------
 
-In order to build Solang from source, you will need rust 1.65.0 or higher,
+In order to build Solang from source, you will need rust 1.68.0 or higher,
 and a build of LLVM based on the Solana LLVM tree. There are a few LLVM patches required that are not upstream yet.
 First, follow the steps below for installing LLVM and then proceed from there.
 

--- a/integration/substrate/events.spec.ts
+++ b/integration/substrate/events.spec.ts
@@ -30,7 +30,7 @@ describe('Deploy events contract and test event data, docs and topics', () => {
         expect(events.length).toEqual(4);
 
         expect(events[0].event.identifier).toBe("foo1");
-        expect(events[0].event.docs).toEqual(["Ladida tada\n\n"]);
+        expect(events[0].event.docs).toEqual(["Ladida tada"]);
         expect(events[0].args.map(a => a.toJSON())).toEqual([254, "hello there"]);
 
         expect(events[1].event.identifier).toBe("foo2");

--- a/src/abi/substrate.rs
+++ b/src/abi/substrate.rs
@@ -437,7 +437,7 @@ pub fn gen_project(contract_no: usize, ns: &ast::Namespace) -> InkProject {
             .collect::<Vec<_>>();
         EventSpec::new(e.name.clone())
             .args(args)
-            .docs(vec![render(&e.tags)])
+            .docs(vec![render(&e.tags).as_str()])
             .done()
     };
 


### PR DESCRIPTION
Spared this for after the release. Upgrading to the latest `ink!` version requires a MSRV of `1.68.0`. In my opinion this is fine because `1.69.0` is already out anyways.