### PR TITLE
Ensure that "require(i < 2**255);" parses correctly

### DIFF
--- a/src/codegen/constant_folding.rs
+++ b/src/codegen/constant_folding.rs
@@ -1345,27 +1345,55 @@ fn expression(
             let left = expression(left, vars, cfg, ns);
             let right = expression(right, vars, cfg, ns);
 
-            (
-                Expression::Equal {
-                    loc: *loc,
-                    left: Box::new(left.0),
-                    right: Box::new(right.0),
-                },
-                false,
-            )
+            if let (
+                Expression::BytesLiteral { value: l, .. },
+                Expression::BytesLiteral { value: r, .. },
+            ) = (&left.0, &right.0)
+            {
+                (
+                    Expression::BoolLiteral {
+                        loc: *loc,
+                        value: l == r,
+                    },
+                    true,
+                )
+            } else {
+                (
+                    Expression::Equal {
+                        loc: *loc,
+                        left: Box::new(left.0),
+                        right: Box::new(right.0),
+                    },
+                    false,
+                )
+            }
         }
         Expression::NotEqual { loc, left, right } => {
             let left = expression(left, vars, cfg, ns);
             let right = expression(right, vars, cfg, ns);
 
-            (
-                Expression::NotEqual {
-                    loc: *loc,
-                    left: Box::new(left.0),
-                    right: Box::new(right.0),
-                },
-                false,
-            )
+            if let (
+                Expression::BytesLiteral { value: l, .. },
+                Expression::BytesLiteral { value: r, .. },
+            ) = (&left.0, &right.0)
+            {
+                (
+                    Expression::BoolLiteral {
+                        loc: *loc,
+                        value: l != r,
+                    },
+                    true,
+                )
+            } else {
+                (
+                    Expression::NotEqual {
+                        loc: *loc,
+                        left: Box::new(left.0),
+                        right: Box::new(right.0),
+                    },
+                    false,
+                )
+            }
         }
         Expression::Not { loc, expr } => {
             let expr = expression(expr, vars, cfg, ns);

--- a/src/emit/strings.rs
+++ b/src/emit/strings.rs
@@ -566,9 +566,16 @@ pub(super) fn string_location<'a, T: TargetRuntime<'a> + ?Sized>(
                 .const_int(literal.len() as u64, false),
         ),
         StringLocation::RunTime(e) => {
-            let v = expression(target, bin, e, vartab, function, ns);
+            if let Expression::BytesLiteral { value, .. } = e.as_ref() {
+                (
+                    bin.emit_global_string("const_string", value, true),
+                    bin.context.i32_type().const_int(value.len() as u64, false),
+                )
+            } else {
+                let v = expression(target, bin, e, vartab, function, ns);
 
-            (bin.vector_bytes(v), bin.vector_len(v))
+                (bin.vector_bytes(v), bin.vector_len(v))
+            }
         }
     }
 }

--- a/src/sema/expression/assign.rs
+++ b/src/sema/expression/assign.rs
@@ -3,7 +3,7 @@
 use crate::sema::ast::{Expression, Namespace, RetrieveType, Type};
 use crate::sema::diagnostics::Diagnostics;
 use crate::sema::eval::check_term_for_constant_overflow;
-use crate::sema::expression::integers::get_int_length;
+use crate::sema::expression::integers::type_bits_and_sign;
 use crate::sema::expression::resolve_expression::expression;
 use crate::sema::expression::{ExprContext, ResolveTo};
 use crate::sema::symtable::Symtable;
@@ -198,8 +198,9 @@ pub(super) fn assign_expr(
      -> Result<Expression, ()> {
         let set = match expr {
             pt::Expression::AssignShiftLeft(..) | pt::Expression::AssignShiftRight(..) => {
-                let left_length = get_int_length(ty, loc, true, ns, diagnostics)?;
-                let right_length = get_int_length(&set_type, &left.loc(), false, ns, diagnostics)?;
+                let left_length = type_bits_and_sign(ty, loc, true, ns, diagnostics)?;
+                let right_length =
+                    type_bits_and_sign(&set_type, &left.loc(), false, ns, diagnostics)?;
 
                 // TODO: does shifting by negative value need compiletime/runtime check?
                 if left_length == right_length {

--- a/src/sema/expression/integers.rs
+++ b/src/sema/expression/integers.rs
@@ -41,7 +41,9 @@ pub(super) fn coerce(
     coerce_number(l, l_loc, r, r_loc, true, false, ns, diagnostics)
 }
 
-pub(super) fn get_int_length(
+/// Calculate the number of bits and the sign of a type, or generate a diagnostic
+/// that the type that is not allowed.
+pub(super) fn type_bits_and_sign(
     l: &Type,
     l_loc: &pt::Loc,
     allow_bytes: bool,
@@ -75,8 +77,8 @@ pub(super) fn get_int_length(
             ));
             Err(())
         }
-        Type::Ref(n) => get_int_length(n, l_loc, allow_bytes, ns, diagnostics),
-        Type::StorageRef(_, n) => get_int_length(n, l_loc, allow_bytes, ns, diagnostics),
+        Type::Ref(n) => type_bits_and_sign(n, l_loc, allow_bytes, ns, diagnostics),
+        Type::StorageRef(_, n) => type_bits_and_sign(n, l_loc, allow_bytes, ns, diagnostics),
         _ => {
             diagnostics.push(Diagnostic::error(
                 *l_loc,
@@ -154,9 +156,9 @@ pub fn coerce_number(
         _ => (),
     }
 
-    let (left_len, left_signed) = get_int_length(l, l_loc, false, ns, diagnostics)?;
+    let (left_len, left_signed) = type_bits_and_sign(l, l_loc, false, ns, diagnostics)?;
 
-    let (right_len, right_signed) = get_int_length(r, r_loc, false, ns, diagnostics)?;
+    let (right_len, right_signed) = type_bits_and_sign(r, r_loc, false, ns, diagnostics)?;
 
     Ok(match (left_signed, right_signed) {
         (true, true) => Type::Int(left_len.max(right_len)),

--- a/src/sema/expression/integers.rs
+++ b/src/sema/expression/integers.rs
@@ -4,6 +4,7 @@ use crate::sema::ast::{Expression, Namespace, Type};
 use crate::sema::diagnostics::Diagnostics;
 use crate::sema::expression::ResolveTo;
 use num_bigint::{BigInt, Sign};
+use num_traits::Zero;
 use solang_parser::diagnostics::Diagnostic;
 use solang_parser::pt;
 
@@ -189,19 +190,19 @@ pub fn bigint_to_expression(
 
     if let ResolveTo::Type(resolve_to) = resolve_to {
         if *resolve_to != Type::Unresolved {
-            if !resolve_to.is_integer(ns) {
+            if !(resolve_to.is_integer(ns) || matches!(resolve_to, Type::Bytes(_)) && n.is_zero()) {
                 diagnostics.push(Diagnostic::cast_error(
                     *loc,
                     format!("expected '{}', found integer", resolve_to.to_string(ns)),
                 ));
                 return Err(());
-            } else {
-                return Ok(Expression::NumberLiteral {
-                    loc: *loc,
-                    ty: resolve_to.clone(),
-                    value: n.clone(),
-                });
             }
+
+            return Ok(Expression::NumberLiteral {
+                loc: *loc,
+                ty: resolve_to.clone(),
+                value: n.clone(),
+            });
         }
     }
 

--- a/src/sema/expression/resolve_expression.rs
+++ b/src/sema/expression/resolve_expression.rs
@@ -8,7 +8,7 @@ use crate::sema::expression::{
     assign::{assign_expr, assign_single},
     constructor::{constructor_named_args, new},
     function_call::{call_expr, named_call_expr},
-    integers::{bigint_to_expression, coerce, coerce_number, get_int_length},
+    integers::{bigint_to_expression, coerce, coerce_number, type_bits_and_sign},
     literals::{
         address_literal, array_literal, hex_literal, hex_number_literal, number_literal,
         rational_number_literal, string_literal, unit_literal,
@@ -169,7 +169,7 @@ pub fn expression(
             used_variable(ns, &expr, symtable);
             let expr_type = expr.ty();
 
-            get_int_length(&expr_type, loc, false, ns, diagnostics)?;
+            type_bits_and_sign(&expr_type, loc, false, ns, diagnostics)?;
 
             diagnostics.push(Diagnostic::error(
                 *loc,
@@ -458,7 +458,8 @@ fn bitwise_not(
 
     let expr_ty = expr.ty();
 
-    get_int_length(&expr_ty, loc, true, ns, diagnostics)?;
+    // Ensure that the argument is an integer or fixed bytes type
+    type_bits_and_sign(&expr_ty, loc, true, ns, diagnostics)?;
 
     Ok(Expression::BitwiseNot {
         loc: *loc,
@@ -537,7 +538,7 @@ fn negate(
                     value: -r,
                 })
             } else {
-                get_int_length(&expr_type, loc, false, ns, diagnostics)?;
+                type_bits_and_sign(&expr_type, loc, false, ns, diagnostics)?;
 
                 if !expr_type.is_signed_int(ns) {
                     diagnostics.push(Diagnostic::error(

--- a/tests/codegen_testcases/solidity/const.sol
+++ b/tests/codegen_testcases/solidity/const.sol
@@ -22,4 +22,18 @@ contract c {
 // CHECK: return uint32 16
 		return x;
 	}
+
+// BEGIN-CHECK: c::function::equal
+	function equal() public pure returns (bool) {
+		// should be const folded
+// CHECK: return true
+		return "abcd" == "abcd";
+	}
+
+// BEGIN-CHECK: c::function::not_equal
+	function not_equal() public pure returns (bool) {
+		// should be const folded
+// CHECK: return false
+		return "abcd" != "abcd";
+	}
 }

--- a/tests/contract_testcases/evm/int_resolve_unknown.sol
+++ b/tests/contract_testcases/evm/int_resolve_unknown.sol
@@ -1,0 +1,17 @@
+contract c {
+	uint16 public x = 0x10000 * 10 - 0x9ffff;
+
+	// When resolving the argument to require, we first 
+	// resolve it with ResolveTo::Unknown. Make sure this
+	// works correctly for integer expressions
+	function f(uint i, bytes4 b) public pure {
+		require(i < 2**225);
+		require(i > 255+255);
+		require(i >= 127*127);
+		require(i <= (2**127)*2);
+		require(b != 0);
+		require(b == 0);
+	}
+}
+
+// ---- Expect: diagnostics ----

--- a/tests/contract_testcases/solana/rational_comparison.sol
+++ b/tests/contract_testcases/solana/rational_comparison.sol
@@ -23,7 +23,7 @@ contract c {
 // ---- Expect: diagnostics ----
 // error: 4:10-23: cannot use rational numbers with '>=' operator
 // error: 7:10-19: cannot use rational numbers with '>' operator
-// error: 10:10-19: cannot use rational numbers with '!=' or '==' operator
+// error: 10:10-19: cannot use rational numbers with '==' operator
 // error: 13:10-11: expression not allowed in constant rational number expression
 // error: 16:10-26: cannot use rational numbers with '<=' operator
-// error: 19:10-24: cannot use rational numbers with '!=' or '==' operator
+// error: 19:10-24: cannot use rational numbers with '!=' operator

--- a/tests/contract_testcases/solana/rational_comparison2.sol
+++ b/tests/contract_testcases/solana/rational_comparison2.sol
@@ -30,8 +30,8 @@ contract c {
 
 
 // ---- Expect: diagnostics ----
-// error: 3:10-20: cannot use rational numbers with '!=' or '==' operator
-// error: 7:10-20: cannot use rational numbers with '!=' or '==' operator
+// error: 3:10-20: cannot use rational numbers with '==' operator
+// error: 7:10-20: cannot use rational numbers with '!=' operator
 // error: 11:11-20: cannot use rational numbers with '<' operator
 // error: 15:16-26: cannot use rational numbers with '<=' operator
 // error: 19:7-14: cannot use rational numbers with '>' operator

--- a/tests/evm.rs
+++ b/tests/evm.rs
@@ -249,7 +249,7 @@ fn ethereum_solidity_tests() {
         })
         .sum();
 
-    assert_eq!(errors, 1078);
+    assert_eq!(errors, 1072);
 }
 
 fn set_file_contents(source: &str, path: &Path) -> (FileResolver, Vec<String>) {


### PR DESCRIPTION
Found with uniswap v3. This change also includes a little refactoring, and now Expression::NotEqual is generated by sema.

Before this change, 

```solidity
require(i < 2**255);
```
Gave the error: value 53919893334301279589334030174039261347274288845081144962207220498432 does not fit into type uint8.

This is because with `ResolveTo::Unknown` the integers default to the smallest size possible.