### PR TITLE
functions that use .call() should be not allowed in view functions

### DIFF
--- a/tests/contract_testcases/evm/call/call_02.sol
+++ b/tests/contract_testcases/evm/call/call_02.sol
@@ -4,8 +4,7 @@
                 (bool s, bytes memory bs) = a.call{value: 2}("");
             }
         }
-        
+
 // ---- Expect: diagnostics ----
-// warning: 3:13-49: function can be declared 'view'
 // warning: 4:23-24: destructure variable 's' has never been used
 // warning: 4:39-41: destructure variable 'bs' has never been used

--- a/tests/contract_testcases/evm/comment_tests.sol
+++ b/tests/contract_testcases/evm/comment_tests.sol
@@ -678,9 +678,7 @@ function _approve(
     //
 }/**//**//**//**//**//**//**///
 // ---- Expect: diagnostics ----
-// warning: 188:5-75: function can be declared 'view'
 // warning: 195:50-56: conversion truncates uint256 to uint128, as value is type uint128 on target evm
-// warning: 264:5-270:37: function can be declared 'view'
 // warning: 268:17-25: function parameter 'weiValue' is unused
 // warning: 269:23-35: function parameter 'errorMessage' is unused
 // warning: 276:70-78: conversion truncates uint256 to uint128, as value is type uint128 on target evm

--- a/tests/contract_testcases/substrate/builtins/msg_01.sol
+++ b/tests/contract_testcases/substrate/builtins/msg_01.sol
@@ -1,8 +1,8 @@
-
-        contract bar {
-            function test(uint128 v) public returns (bool) {
-                return msg.value > v;
-            }
-        }
+contract bar {
+	uint128 state;
+	function test(uint128 v) public returns (bool) {
+		return state > v;
+       }
+}
 // ---- Expect: diagnostics ----
-// warning: 3:13-59: function can be declared 'pure'
+// warning: 3:2-48: function can be declared 'view'

--- a/tests/contract_testcases/substrate/functions/mutability_12.sol
+++ b/tests/contract_testcases/substrate/functions/mutability_12.sol
@@ -1,0 +1,14 @@
+contract c {
+	// private functions cannot be payable and solc checks msg.value as
+	// state read in them
+	function foo() private view returns (uint) {
+		return msg.value;
+	}
+
+	function bar() public returns (uint) {
+		return foo();
+	}
+}
+
+// ---- Expect: diagnostics ----
+// warning: 8:2-38: function can be declared 'view'

--- a/tests/contract_testcases/substrate/modifier/mutability_01.sol
+++ b/tests/contract_testcases/substrate/modifier/mutability_01.sol
@@ -1,10 +1,18 @@
+contract c {
+    uint128 var;
+    modifier foo1() { uint128 x = var; _; }
+    modifier foo2() { var = 2; _; }
+    modifier foo3() { var = msg.value; _; }
 
-        contract c {
-            uint64 var;
-            modifier foo() { uint64 x = var; _; }
-
-            function bar() foo() public pure {}
-        }
+    function bar1() foo1() public pure {}
+    function bar2() foo2() public view {}
+    function bar3() foo3() public {}
+}
 // ---- Expect: diagnostics ----
-// warning: 4:37-38: local variable 'x' has been assigned, but never read
-// error: 4:41-44: function declared 'pure' but this expression reads from state
+// warning: 3:31-32: local variable 'x' has been assigned, but never read
+// error: 7:21-27: function declared 'pure' but modifier reads from state
+// 	note 3:35-38: read to state
+// error: 8:21-27: function declared 'view' but modifier writes to state
+// 	note 4:23-26: write to state
+// error: 9:21-27: function declared 'nonpayable' but modifier accesses value sent, which is only allowed for payable functions
+// 	note 5:29-38: access of value sent

--- a/tests/evm.rs
+++ b/tests/evm.rs
@@ -248,7 +248,7 @@ fn ethereum_solidity_tests() {
         })
         .sum();
 
-    assert_eq!(errors, 1048);
+    assert_eq!(errors, 1042);
 }
 
 fn set_file_contents(source: &str, path: &Path) -> (FileResolver, Vec<String>) {


### PR DESCRIPTION
Functions that modify the state, like the SPL-token `mint_to`, are not `view` functions, but the compiler warns that they can be declared as view.

Example: 
```solidity
	function mint_to(address mint, address account, address authority, uint64 amount) internal {
		bytes instr = new bytes(9);

		instr[0] = uint8(TokenInstruction.MintTo);
		instr.writeUint64LE(amount, 1);

		AccountMeta[3] metas = [
			AccountMeta({pubkey: mint, is_writable: true, is_signer: false}),
			AccountMeta({pubkey: account, is_writable: true, is_signer: false}),
			AccountMeta({pubkey: authority, is_writable: true, is_signer: true})
		];

		tokenProgramId.call{accounts: metas}(instr);
	}
```

Warning:
```
warning: function can be declared 'view'
   ┌─ /solang/solana-library/spl_token.sol:46:2
   │
46 │     function mint_to(address mint, address account, address authority, uint64 amount) internal {
   │
```

Fixes https://github.com/hyperledger/solang/issues/997

Another PR will implement staticcall for Solana, which is allowed in view functions.