### PR TITLE
Allow .wrap() and .unwrap() user defined type methods in constants

### DIFF
--- a/src/sema/builtin.rs
+++ b/src/sema/builtin.rs
@@ -292,7 +292,7 @@ static BUILTIN_FUNCTIONS: Lazy<[Prototype; 24]> = Lazy::new(|| {
             ret: vec![Type::UserType(0)],
             target: vec![],
             doc: "wrap type into user defined type",
-            constant: false,
+            constant: true,
         },
         Prototype {
             builtin: Builtin::UserTypeUnwrap,
@@ -303,7 +303,7 @@ static BUILTIN_FUNCTIONS: Lazy<[Prototype; 24]> = Lazy::new(|| {
             ret: vec![],
             target: vec![],
             doc: "unwrap user defined type",
-            constant: false,
+            constant: true,
         },
     ]
 });

--- a/src/sema/statements.rs
+++ b/src/sema/statements.rs
@@ -752,7 +752,7 @@ fn statement(
 
                         Ok(true)
                     } else {
-                        ns.diagnostics.push(Diagnostic::error(
+                        ns.diagnostics.push(Diagnostic::warning(
                             *loc,
                             "argument to 'delete' should be storage reference".to_string(),
                         ));

--- a/tests/contract_testcases/substrate/arrays/storage_delete.sol
+++ b/tests/contract_testcases/substrate/arrays/storage_delete.sol
@@ -7,4 +7,6 @@
             }
         }
 // ---- Expect: diagnostics ----
-// error: 6:17-27: argument to 'delete' should be storage reference
+// warning: 3:13-24: storage variable 'bar' has never been used
+// warning: 5:13-35: function can be declared 'pure'
+// warning: 6:17-27: argument to 'delete' should be storage reference

--- a/tests/evm.rs
+++ b/tests/evm.rs
@@ -248,7 +248,7 @@ fn ethereum_solidity_tests() {
         })
         .sum();
 
-    assert_eq!(errors, 1063);
+    assert_eq!(errors, 1055);
 }
 
 fn set_file_contents(source: &str, path: &Path) -> (FileResolver, Vec<String>) {

--- a/tests/evm.rs
+++ b/tests/evm.rs
@@ -248,7 +248,7 @@ fn ethereum_solidity_tests() {
         })
         .sum();
 
-    assert_eq!(errors, 1068);
+    assert_eq!(errors, 1063);
 }
 
 fn set_file_contents(source: &str, path: &Path) -> (FileResolver, Vec<String>) {


### PR DESCRIPTION
This is valid Solidity:

```
type Int is int8;

Int constant zero = Int.wrap(0);
```
Also, on solc `delete` on a local variable is a no-op. Make the error a warning.