### PR TITLE
Do not pin `ink!` dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,8 @@ anchor-syn = { version = "0.27.0", features = ["idl"] }
 convert_case = "0.6"
 parse-display = "0.8.0"
 parity-scale-codec = "3.4"
-ink_env = "=4.2.0"
-ink_metadata = "=4.2.0"
+ink_env = "4.2.0"
+ink_metadata = "4.2.0"
 scale-info = "2.4"
 petgraph = "0.6.3"
 wasmparser = "0.106.0"
@@ -82,7 +82,7 @@ borsh = "0.10"
 tempfile = "3.3"
 rayon = "1"
 walkdir = "2.3.3"
-ink_primitives = "=4.2.0"
+ink_primitives = "4.2.0"
 wasm_host_attr = { path = "tests/wasm_host_attr" }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
This was required for 4.1.0 because back then we were on rust 1.65 while 4.2.0 was on 1.68

Fixes #1351 