### PR TITLE
Use custom substrate CI image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -313,7 +313,7 @@ jobs:
       # We can't run substrate as a github actions service, since it requires
       # command line arguments. See https://github.com/actions/runner/pull/1152
     - name: Start substrate
-      run: echo id=$(docker run -d -p 9944:9944 paritytech/contracts-ci-linux@sha256:77a885f3c22d38385b017983c942bf7e063ac127bdc0477670d23a38711a2c38 substrate-contracts-node --dev --ws-external) >> $GITHUB_OUTPUT
+      run: echo id=$(docker run -d -p 9944:9944 ghcr.io/hyperledger/solang-substrate-ci:a1a354a substrate-contracts-node --dev --ws-external) >> $GITHUB_OUTPUT
       id: substrate
     - uses: actions/setup-node@v3
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -313,7 +313,7 @@ jobs:
       # We can't run substrate as a github actions service, since it requires
       # command line arguments. See https://github.com/actions/runner/pull/1152
     - name: Start substrate
-      run: echo id=$(docker run -d -p 9944:9944 ghcr.io/hyperledger/solang-substrate-ci:a1a354a substrate-contracts-node --dev --ws-external) >> $GITHUB_OUTPUT
+      run: echo id=$(docker run -d -p 9944:9944 ghcr.io/hyperledger/solang-substrate-ci:e41a9c0 substrate-contracts-node --dev --ws-external) >> $GITHUB_OUTPUT
       id: substrate
     - uses: actions/setup-node@v3
       with:

--- a/integration/substrate/package.json
+++ b/integration/substrate/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "tsc; ts-mocha -t 20000 *.spec.ts",
     "build": "./build.sh",
-    "build-ink": "docker run --rm -v $(pwd)/ink/caller:/opt/contract ghcr.io/hyperledger/solang-substrate-ci:a1a354a cargo contract build --release --manifest-path /opt/contract/Cargo.toml"
+    "build-ink": "docker run --rm -v $(pwd)/ink/caller:/opt/contract ghcr.io/hyperledger/solang-substrate-ci:e41a9c0 cargo contract build --release --manifest-path /opt/contract/Cargo.toml"
   },
   "contributors": [
     {

--- a/integration/substrate/package.json
+++ b/integration/substrate/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "tsc; ts-mocha -t 20000 *.spec.ts",
     "build": "./build.sh",
-    "build-ink": "docker run --rm -v $(pwd)/ink/caller:/opt/contract paritytech/contracts-ci-linux@sha256:77a885f3c22d38385b017983c942bf7e063ac127bdc0477670d23a38711a2c38 cargo contract build --release --manifest-path /opt/contract/Cargo.toml"
+    "build-ink": "docker run --rm -v $(pwd)/ink/caller:/opt/contract ghcr.io/hyperledger/solang-substrate-ci:a1a354a cargo contract build --release --manifest-path /opt/contract/Cargo.toml"
   },
   "contributors": [
     {


### PR DESCRIPTION
Use [a custom node](https://github.com/hyperledger/solang-substrate-ci) for the integration tests. This tests contains chain extension which I'll add integration tests for in a followup PR.