### PR TITLE
Update Address and Hash types to ink ABI v4

### DIFF
--- a/src/abi/substrate.rs
+++ b/src/abi/substrate.rs
@@ -102,7 +102,7 @@ fn resolve_ast(ty: &ast::Type, ns: &ast::Namespace, registry: &mut PortableRegis
             // substituted to struct { AccountId }
             let field = Field::new(None, address_ty.into(), None, vec![]);
             let c = TypeDefComposite::new(vec![field]);
-            let path = path!("ink_env", "types", "AccountId");
+            let path = path!("ink_primitives", "types", "AccountId");
             let ty: Type<PortableForm> =
                 Type::new(path, vec![], TypeDef::Composite(c), Default::default());
             registry.register_type(ty)
@@ -219,7 +219,7 @@ fn resolve_ast(ty: &ast::Type, ns: &ast::Namespace, registry: &mut PortableRegis
                 ("Hash", pt::Loc::Builtin) => {
                     let field = Field::new(None, resolved.into(), None, vec![]);
                     let composite = TypeDef::Composite(TypeDefComposite::new([field]));
-                    let path = path!("ink_env", "types", "Hash");
+                    let path = path!("ink_primitives", "types", "Hash");
                     registry.register_type(Type::new(path, vec![], composite, vec![]))
                 }
                 _ => resolved,

--- a/src/sema/types.rs
+++ b/src/sema/types.rs
@@ -1395,6 +1395,7 @@ impl Type {
             Type::Slice(_) => false,
             Type::Unresolved => false,
             Type::FunctionSelector => false,
+            Type::UserType(no) => ns.user_types[*no].ty.is_fixed_reference_type(ns),
             _ => unreachable!("{:?}", self),
         }
     }

--- a/testdata/ink/mother.json
+++ b/testdata/ink/mother.json
@@ -1,0 +1,1041 @@
+{
+  "source": {
+    "hash": "0x05cc2edbb7547b2311d2a442aac3c183e055bf1f3faa96568b4a68e3ac5e17f0",
+    "language": "ink! 4.2.0",
+    "compiler": "rustc 1.69.0",
+    "build_info": {
+      "build_mode": "Debug",
+      "cargo_contract_version": "3.0.1",
+      "rust_toolchain": "stable-x86_64-unknown-linux-gnu",
+      "wasm_opt_settings": {
+        "keep_debug_symbols": false,
+        "optimization_passes": "Zero"
+      }
+    }
+  },
+  "contract": {
+    "name": "mother",
+    "version": "4.2.0",
+    "authors": [
+      "Parity Technologies <admin@parity.io>"
+    ],
+    "description": "Mother of all contracts"
+  },
+  "spec": {
+    "constructors": [
+      {
+        "args": [
+          {
+            "label": "auction",
+            "type": {
+              "displayName": [
+                "Auction"
+              ],
+              "type": 13
+            }
+          }
+        ],
+        "default": false,
+        "docs": [],
+        "label": "new",
+        "payable": false,
+        "returnType": {
+          "displayName": [
+            "ink_primitives",
+            "ConstructorResult"
+          ],
+          "type": 18
+        },
+        "selector": "0x9bae9d5e"
+      },
+      {
+        "args": [],
+        "default": false,
+        "docs": [],
+        "label": "new_default",
+        "payable": false,
+        "returnType": {
+          "displayName": [
+            "ink_primitives",
+            "ConstructorResult"
+          ],
+          "type": 18
+        },
+        "selector": "0x61ef7e3e"
+      },
+      {
+        "args": [
+          {
+            "label": "fail",
+            "type": {
+              "displayName": [
+                "bool"
+              ],
+              "type": 11
+            }
+          }
+        ],
+        "default": false,
+        "docs": [
+          "Demonstrates the ability to fail a constructor safely."
+        ],
+        "label": "failed_new",
+        "payable": false,
+        "returnType": {
+          "displayName": [
+            "ink_primitives",
+            "ConstructorResult"
+          ],
+          "type": 21
+        },
+        "selector": "0x87a495f6"
+      }
+    ],
+    "docs": [],
+    "environment": {
+      "accountId": {
+        "displayName": [
+          "AccountId"
+        ],
+        "type": 8
+      },
+      "balance": {
+        "displayName": [
+          "Balance"
+        ],
+        "type": 9
+      },
+      "blockNumber": {
+        "displayName": [
+          "BlockNumber"
+        ],
+        "type": 10
+      },
+      "chainExtension": {
+        "displayName": [
+          "ChainExtension"
+        ],
+        "type": 27
+      },
+      "hash": {
+        "displayName": [
+          "Hash"
+        ],
+        "type": 1
+      },
+      "maxEventTopics": 4,
+      "timestamp": {
+        "displayName": [
+          "Timestamp"
+        ],
+        "type": 26
+      }
+    },
+    "events": [
+      {
+        "args": [
+          {
+            "docs": [],
+            "indexed": false,
+            "label": "auction",
+            "type": {
+              "displayName": [
+                "Auction"
+              ],
+              "type": 13
+            }
+          }
+        ],
+        "docs": [
+          "Event emitted when an auction being echoed."
+        ],
+        "label": "AuctionEchoed"
+      }
+    ],
+    "lang_error": {
+      "displayName": [
+        "ink",
+        "LangError"
+      ],
+      "type": 20
+    },
+    "messages": [
+      {
+        "args": [
+          {
+            "label": "auction",
+            "type": {
+              "displayName": [
+                "Auction"
+              ],
+              "type": 13
+            }
+          }
+        ],
+        "default": false,
+        "docs": [
+          " Takes an auction data struct as input and returns it back."
+        ],
+        "label": "echo_auction",
+        "mutates": true,
+        "payable": false,
+        "returnType": {
+          "displayName": [
+            "ink",
+            "MessageResult"
+          ],
+          "type": 24
+        },
+        "selector": "0xbc7ac4cf"
+      },
+      {
+        "args": [
+          {
+            "label": "fail",
+            "type": {
+              "displayName": [
+                "Option"
+              ],
+              "type": 25
+            }
+          }
+        ],
+        "default": false,
+        "docs": [
+          " Fails contract execution in the required way."
+        ],
+        "label": "revert_or_trap",
+        "mutates": true,
+        "payable": false,
+        "returnType": {
+          "displayName": [
+            "ink",
+            "MessageResult"
+          ],
+          "type": 21
+        },
+        "selector": "0xe62a1df5"
+      },
+      {
+        "args": [
+          {
+            "label": "_message",
+            "type": {
+              "displayName": [
+                "String"
+              ],
+              "type": 0
+            }
+          }
+        ],
+        "default": false,
+        "docs": [
+          " Prints the specified string into node's debug log."
+        ],
+        "label": "debug_log",
+        "mutates": true,
+        "payable": false,
+        "returnType": {
+          "displayName": [
+            "ink",
+            "MessageResult"
+          ],
+          "type": 18
+        },
+        "selector": "0x238582df"
+      }
+    ]
+  },
+  "storage": {
+    "root": {
+      "layout": {
+        "struct": {
+          "fields": [
+            {
+              "layout": {
+                "struct": {
+                  "fields": [
+                    {
+                      "layout": {
+                        "leaf": {
+                          "key": "0x00000000",
+                          "ty": 0
+                        }
+                      },
+                      "name": "name"
+                    },
+                    {
+                      "layout": {
+                        "leaf": {
+                          "key": "0x00000000",
+                          "ty": 1
+                        }
+                      },
+                      "name": "subject"
+                    },
+                    {
+                      "layout": {
+                        "struct": {
+                          "fields": [
+                            {
+                              "layout": {
+                                "leaf": {
+                                  "key": "0x00000000",
+                                  "ty": 4
+                                }
+                              },
+                              "name": "0"
+                            }
+                          ],
+                          "name": "Bids"
+                        }
+                      },
+                      "name": "bids"
+                    },
+                    {
+                      "layout": {
+                        "array": {
+                          "layout": {
+                            "leaf": {
+                              "key": "0x00000000",
+                              "ty": 10
+                            }
+                          },
+                          "len": 3,
+                          "offset": "0x00000000"
+                        }
+                      },
+                      "name": "terms"
+                    },
+                    {
+                      "layout": {
+                        "enum": {
+                          "dispatchKey": "0x00000000",
+                          "name": "Status",
+                          "variants": {
+                            "0": {
+                              "fields": [],
+                              "name": "NotStarted"
+                            },
+                            "1": {
+                              "fields": [],
+                              "name": "OpeningPeriod"
+                            },
+                            "2": {
+                              "fields": [
+                                {
+                                  "layout": {
+                                    "leaf": {
+                                      "key": "0x00000000",
+                                      "ty": 10
+                                    }
+                                  },
+                                  "name": "0"
+                                }
+                              ],
+                              "name": "EndingPeriod"
+                            },
+                            "3": {
+                              "fields": [
+                                {
+                                  "layout": {
+                                    "enum": {
+                                      "dispatchKey": "0x00000000",
+                                      "name": "Outline",
+                                      "variants": {
+                                        "0": {
+                                          "fields": [],
+                                          "name": "NoWinner"
+                                        },
+                                        "1": {
+                                          "fields": [],
+                                          "name": "WinnerDetected"
+                                        },
+                                        "2": {
+                                          "fields": [],
+                                          "name": "PayoutCompleted"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "name": "0"
+                                }
+                              ],
+                              "name": "Ended"
+                            },
+                            "4": {
+                              "fields": [
+                                {
+                                  "layout": {
+                                    "leaf": {
+                                      "key": "0x00000000",
+                                      "ty": 10
+                                    }
+                                  },
+                                  "name": "0"
+                                }
+                              ],
+                              "name": "RfDelay"
+                            }
+                          }
+                        }
+                      },
+                      "name": "status"
+                    },
+                    {
+                      "layout": {
+                        "leaf": {
+                          "key": "0x00000000",
+                          "ty": 11
+                        }
+                      },
+                      "name": "finalized"
+                    },
+                    {
+                      "layout": {
+                        "leaf": {
+                          "key": "0x00000000",
+                          "ty": 12
+                        }
+                      },
+                      "name": "vector"
+                    }
+                  ],
+                  "name": "Auction"
+                }
+              },
+              "name": "auction"
+            },
+            {
+              "layout": {
+                "root": {
+                  "layout": {
+                    "leaf": {
+                      "key": "0x013a6e2b",
+                      "ty": 9
+                    }
+                  },
+                  "root_key": "0x013a6e2b"
+                }
+              },
+              "name": "balances"
+            }
+          ],
+          "name": "Mother"
+        }
+      },
+      "root_key": "0x00000000"
+    }
+  },
+  "types": [
+    {
+      "id": 0,
+      "type": {
+        "def": {
+          "primitive": "str"
+        }
+      }
+    },
+    {
+      "id": 1,
+      "type": {
+        "def": {
+          "composite": {
+            "fields": [
+              {
+                "type": 2,
+                "typeName": "[u8; 32]"
+              }
+            ]
+          }
+        },
+        "path": [
+          "ink_primitives",
+          "types",
+          "Hash"
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "type": {
+        "def": {
+          "array": {
+            "len": 32,
+            "type": 3
+          }
+        }
+      }
+    },
+    {
+      "id": 3,
+      "type": {
+        "def": {
+          "primitive": "u8"
+        }
+      }
+    },
+    {
+      "id": 4,
+      "type": {
+        "def": {
+          "sequence": {
+            "type": 5
+          }
+        }
+      }
+    },
+    {
+      "id": 5,
+      "type": {
+        "def": {
+          "sequence": {
+            "type": 6
+          }
+        }
+      }
+    },
+    {
+      "id": 6,
+      "type": {
+        "def": {
+          "variant": {
+            "variants": [
+              {
+                "index": 0,
+                "name": "None"
+              },
+              {
+                "fields": [
+                  {
+                    "type": 7
+                  }
+                ],
+                "index": 1,
+                "name": "Some"
+              }
+            ]
+          }
+        },
+        "params": [
+          {
+            "name": "T",
+            "type": 7
+          }
+        ],
+        "path": [
+          "Option"
+        ]
+      }
+    },
+    {
+      "id": 7,
+      "type": {
+        "def": {
+          "tuple": [
+            8,
+            9
+          ]
+        }
+      }
+    },
+    {
+      "id": 8,
+      "type": {
+        "def": {
+          "composite": {
+            "fields": [
+              {
+                "type": 2,
+                "typeName": "[u8; 32]"
+              }
+            ]
+          }
+        },
+        "path": [
+          "ink_primitives",
+          "types",
+          "AccountId"
+        ]
+      }
+    },
+    {
+      "id": 9,
+      "type": {
+        "def": {
+          "primitive": "u128"
+        }
+      }
+    },
+    {
+      "id": 10,
+      "type": {
+        "def": {
+          "primitive": "u32"
+        }
+      }
+    },
+    {
+      "id": 11,
+      "type": {
+        "def": {
+          "primitive": "bool"
+        }
+      }
+    },
+    {
+      "id": 12,
+      "type": {
+        "def": {
+          "sequence": {
+            "type": 3
+          }
+        }
+      }
+    },
+    {
+      "id": 13,
+      "type": {
+        "def": {
+          "composite": {
+            "fields": [
+              {
+                "name": "name",
+                "type": 0,
+                "typeName": "String"
+              },
+              {
+                "name": "subject",
+                "type": 1,
+                "typeName": "Hash"
+              },
+              {
+                "name": "bids",
+                "type": 14,
+                "typeName": "Bids"
+              },
+              {
+                "name": "terms",
+                "type": 15,
+                "typeName": "[BlockNumber; 3]"
+              },
+              {
+                "name": "status",
+                "type": 16,
+                "typeName": "Status"
+              },
+              {
+                "name": "finalized",
+                "type": 11,
+                "typeName": "bool"
+              },
+              {
+                "name": "vector",
+                "type": 12,
+                "typeName": "Vec<u8>"
+              }
+            ]
+          }
+        },
+        "path": [
+          "mother",
+          "mother",
+          "Auction"
+        ]
+      }
+    },
+    {
+      "id": 14,
+      "type": {
+        "def": {
+          "composite": {
+            "fields": [
+              {
+                "type": 4,
+                "typeName": "Vec<Vec<Option<(AccountId, Balance)>>>"
+              }
+            ]
+          }
+        },
+        "path": [
+          "mother",
+          "mother",
+          "Bids"
+        ]
+      }
+    },
+    {
+      "id": 15,
+      "type": {
+        "def": {
+          "array": {
+            "len": 3,
+            "type": 10
+          }
+        }
+      }
+    },
+    {
+      "id": 16,
+      "type": {
+        "def": {
+          "variant": {
+            "variants": [
+              {
+                "index": 0,
+                "name": "NotStarted"
+              },
+              {
+                "index": 1,
+                "name": "OpeningPeriod"
+              },
+              {
+                "fields": [
+                  {
+                    "type": 10,
+                    "typeName": "BlockNumber"
+                  }
+                ],
+                "index": 2,
+                "name": "EndingPeriod"
+              },
+              {
+                "fields": [
+                  {
+                    "type": 17,
+                    "typeName": "Outline"
+                  }
+                ],
+                "index": 3,
+                "name": "Ended"
+              },
+              {
+                "fields": [
+                  {
+                    "type": 10,
+                    "typeName": "BlockNumber"
+                  }
+                ],
+                "index": 4,
+                "name": "RfDelay"
+              }
+            ]
+          }
+        },
+        "path": [
+          "mother",
+          "mother",
+          "Status"
+        ]
+      }
+    },
+    {
+      "id": 17,
+      "type": {
+        "def": {
+          "variant": {
+            "variants": [
+              {
+                "index": 0,
+                "name": "NoWinner"
+              },
+              {
+                "index": 1,
+                "name": "WinnerDetected"
+              },
+              {
+                "index": 2,
+                "name": "PayoutCompleted"
+              }
+            ]
+          }
+        },
+        "path": [
+          "mother",
+          "mother",
+          "Outline"
+        ]
+      }
+    },
+    {
+      "id": 18,
+      "type": {
+        "def": {
+          "variant": {
+            "variants": [
+              {
+                "fields": [
+                  {
+                    "type": 19
+                  }
+                ],
+                "index": 0,
+                "name": "Ok"
+              },
+              {
+                "fields": [
+                  {
+                    "type": 20
+                  }
+                ],
+                "index": 1,
+                "name": "Err"
+              }
+            ]
+          }
+        },
+        "params": [
+          {
+            "name": "T",
+            "type": 19
+          },
+          {
+            "name": "E",
+            "type": 20
+          }
+        ],
+        "path": [
+          "Result"
+        ]
+      }
+    },
+    {
+      "id": 19,
+      "type": {
+        "def": {
+          "tuple": []
+        }
+      }
+    },
+    {
+      "id": 20,
+      "type": {
+        "def": {
+          "variant": {
+            "variants": [
+              {
+                "index": 1,
+                "name": "CouldNotReadInput"
+              }
+            ]
+          }
+        },
+        "path": [
+          "ink_primitives",
+          "LangError"
+        ]
+      }
+    },
+    {
+      "id": 21,
+      "type": {
+        "def": {
+          "variant": {
+            "variants": [
+              {
+                "fields": [
+                  {
+                    "type": 22
+                  }
+                ],
+                "index": 0,
+                "name": "Ok"
+              },
+              {
+                "fields": [
+                  {
+                    "type": 20
+                  }
+                ],
+                "index": 1,
+                "name": "Err"
+              }
+            ]
+          }
+        },
+        "params": [
+          {
+            "name": "T",
+            "type": 22
+          },
+          {
+            "name": "E",
+            "type": 20
+          }
+        ],
+        "path": [
+          "Result"
+        ]
+      }
+    },
+    {
+      "id": 22,
+      "type": {
+        "def": {
+          "variant": {
+            "variants": [
+              {
+                "fields": [
+                  {
+                    "type": 19
+                  }
+                ],
+                "index": 0,
+                "name": "Ok"
+              },
+              {
+                "fields": [
+                  {
+                    "type": 23
+                  }
+                ],
+                "index": 1,
+                "name": "Err"
+              }
+            ]
+          }
+        },
+        "params": [
+          {
+            "name": "T",
+            "type": 19
+          },
+          {
+            "name": "E",
+            "type": 23
+          }
+        ],
+        "path": [
+          "Result"
+        ]
+      }
+    },
+    {
+      "id": 23,
+      "type": {
+        "def": {
+          "variant": {
+            "variants": [
+              {
+                "fields": [
+                  {
+                    "type": 0,
+                    "typeName": "String"
+                  }
+                ],
+                "index": 0,
+                "name": "Revert"
+              },
+              {
+                "index": 1,
+                "name": "Panic"
+              }
+            ]
+          }
+        },
+        "path": [
+          "mother",
+          "mother",
+          "Failure"
+        ]
+      }
+    },
+    {
+      "id": 24,
+      "type": {
+        "def": {
+          "variant": {
+            "variants": [
+              {
+                "fields": [
+                  {
+                    "type": 13
+                  }
+                ],
+                "index": 0,
+                "name": "Ok"
+              },
+              {
+                "fields": [
+                  {
+                    "type": 20
+                  }
+                ],
+                "index": 1,
+                "name": "Err"
+              }
+            ]
+          }
+        },
+        "params": [
+          {
+            "name": "T",
+            "type": 13
+          },
+          {
+            "name": "E",
+            "type": 20
+          }
+        ],
+        "path": [
+          "Result"
+        ]
+      }
+    },
+    {
+      "id": 25,
+      "type": {
+        "def": {
+          "variant": {
+            "variants": [
+              {
+                "index": 0,
+                "name": "None"
+              },
+              {
+                "fields": [
+                  {
+                    "type": 23
+                  }
+                ],
+                "index": 1,
+                "name": "Some"
+              }
+            ]
+          }
+        },
+        "params": [
+          {
+            "name": "T",
+            "type": 23
+          }
+        ],
+        "path": [
+          "Option"
+        ]
+      }
+    },
+    {
+      "id": 26,
+      "type": {
+        "def": {
+          "primitive": "u64"
+        }
+      }
+    },
+    {
+      "id": 27,
+      "type": {
+        "def": {
+          "variant": {}
+        },
+        "path": [
+          "ink_env",
+          "types",
+          "NoChainExtension"
+        ]
+      }
+    }
+  ],
+  "version": "4"
+}

--- a/tests/substrate.rs
+++ b/tests/substrate.rs
@@ -951,7 +951,7 @@ pub fn build_solidity_with_options(src: &str, log_ret: bool, log_err: bool) -> M
     MockSubstrate(Store::new(&Engine::default(), Runtime::new(blobs)))
 }
 
-fn build_wasm(src: &str, log_ret: bool, log_err: bool) -> Vec<(Vec<u8>, String)> {
+pub fn build_wasm(src: &str, log_ret: bool, log_err: bool) -> Vec<(Vec<u8>, String)> {
     let tmp_file = OsStr::new("test.sol");
     let mut cache = FileResolver::new();
     cache.set_file_contents(tmp_file.to_str().unwrap(), src.to_string());
@@ -963,7 +963,7 @@ fn build_wasm(src: &str, log_ret: bool, log_err: bool) -> Vec<(Vec<u8>, String)>
     wasm
 }
 
-fn load_abi(s: &str) -> InkProject {
+pub fn load_abi(s: &str) -> InkProject {
     let bundle = serde_json::from_str::<ContractMetadata>(s).unwrap();
     serde_json::from_value::<InkProject>(serde_json::to_value(bundle.abi).unwrap()).unwrap()
 }

--- a/tests/substrate_tests/abi.rs
+++ b/tests/substrate_tests/abi.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{build_wasm, load_abi};
+use ink_env::{
+    hash::{Blake2x256, CryptoHash},
+    topics::PrefixedValue,
+};
+use ink_metadata::InkProject;
+use ink_primitives::{AccountId, Hash};
+use parity_scale_codec::Encode;
+use scale_info::form::PortableForm;
+use solang::{file_resolver::FileResolver, Target};
+use std::ffi::OsStr;
+
+#[test]
+fn mother() {
+    // Partial mock of the ink! "mother" integration test.
+    let src = r##"
+import "substrate";
+
+contract Mother {
+    enum Status {
+        NotStarted,
+        OpeningPeriod
+    }
+
+    struct Auction {
+        string name;
+        Hash subject;
+        uint64[3] terms;
+        Status status;
+        bool finalized;
+        bytes vector;
+    }
+
+    Auction auction;
+    mapping(address => uint128) balances;
+
+    function echo_auction(Auction _auction) public pure returns (Auction) {
+        return _auction;
+    }
+}"##;
+
+    let solidity_abi = load_abi(&build_wasm(src, false, false)[0].1).spec();
+    let ink_str = std::fs::read_to_string("testdata/ink/mother.json").unwrap();
+    let ink_abi: InkProject = serde_json::from_str(&ink_str).unwrap();
+}

--- a/tests/substrate_tests/abi.rs
+++ b/tests/substrate_tests/abi.rs
@@ -5,7 +5,7 @@ use ink_env::{
     hash::{Blake2x256, CryptoHash},
     topics::PrefixedValue,
 };
-use ink_metadata::InkProject;
+use ink_metadata::{InkProject, TypeSpec};
 use ink_primitives::{AccountId, Hash};
 use parity_scale_codec::Encode;
 use scale_info::form::PortableForm;
@@ -41,7 +41,21 @@ contract Mother {
     }
 }"##;
 
-    let solidity_abi = load_abi(&build_wasm(src, false, false)[0].1).spec();
+    let solang_abi = load_abi(&build_wasm(src, false, false)[0].1);
     let ink_str = std::fs::read_to_string("testdata/ink/mother.json").unwrap();
     let ink_abi: InkProject = serde_json::from_str(&ink_str).unwrap();
+
+    let solang_env = solang_abi.spec().environment();
+    let ink_env = ink_abi.spec().environment();
+
+    assert_path(solang_env.timestamp(), ink_env.timestamp());
+    assert_path(solang_env.account_id(), ink_env.account_id());
+    assert_path(solang_env.hash(), ink_env.hash());
+    assert_path(solang_env.balance(), ink_env.balance());
+    assert_path(solang_env.block_number(), ink_env.block_number());
+    assert_eq!(solang_env.max_event_topics(), ink_env.max_event_topics());
+}
+
+fn assert_path(a: &TypeSpec<PortableForm>, b: &TypeSpec<PortableForm>) {
+    assert_eq!(a.display_name(), b.display_name());
 }

--- a/tests/substrate_tests/abi.rs
+++ b/tests/substrate_tests/abi.rs
@@ -45,11 +45,6 @@ fn eq_display(a: &TypeSpec<PortableForm>, b: &TypeSpec<PortableForm>) {
     assert_eq!(a.display_name(), b.display_name());
 }
 
-fn eq_path(a: &scale_info::Type<PortableForm>, b: &scale_info::Type<PortableForm>) {
-    dbg!(&a.type_def);
-    assert_eq!(a.type_def, b.type_def);
-}
-
 #[test]
 fn environment_matches_ink() {
     let mother = MOTHER.lock().unwrap();

--- a/tests/substrate_tests/mod.rs
+++ b/tests/substrate_tests/mod.rs
@@ -5,6 +5,7 @@ mod enums;
 #[allow(clippy::unreadable_literal, clippy::naive_bytecount)]
 mod expressions;
 
+mod abi;
 mod array_boundary_check;
 mod arrays;
 mod builtins;


### PR DESCRIPTION
This slipped through integration tests because the frontends remain backwards compatibility. I added a test that would have caught it (based of it, more can be added in the future).