### PR TITLE
`wasm-opt` for Substrate 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,10 @@ jobs:
       - name: Run cargo clippy
         if: always()
         run: cargo clippy --workspace --tests --bins -- -D warnings
-      - name: Test without llvm feature
+      - name: Run cargo clippy without wasm_opt feature
+        if: always()
+        run: cargo clippy --workspace --no-default-features --features llvm --bins -- -D warnings
+      - name: Run cargo clippy without llvm feature
         if: always()
         run: cargo clippy --workspace --no-default-features --lib -- -D warnings
       - name: Run cargo doc
@@ -155,6 +158,8 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose --workspace
+    - name: Run tests without wasm_opt
+      run: cargo test --verbose --workspace --no-default-features --features llvm
     - uses: actions/upload-artifact@v3.1.0
       with:
         name: solang-mac-arm

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,8 +60,8 @@ scale-info = "2.4"
 petgraph = "0.6.3"
 wasmparser = "0.106.0"
 wasm-encoder = "0.28"
-wasm-opt = "0.112.0"
-contract-build = "3.0.1"
+wasm-opt = { version = "0.112.0", optional = true }
+contract-build = { version = "3.0.1", optional = true }
 
 
 [dev-dependencies]
@@ -94,8 +94,9 @@ no-default-features = true
 lto = true
 
 [features]
-default = ["llvm"]
+default = ["llvm", "wasm_opt"]
 llvm = ["inkwell", "libc"]
+wasm_opt = ["wasm-opt", "contract-build"]
 
 [workspace]
 members = ["solang-parser", "tests/wasm_host_attr"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,8 @@ scale-info = "2.4"
 petgraph = "0.6.3"
 wasmparser = "0.106.0"
 wasm-encoder = "0.28"
+wasm-opt = "0.112.0"
+contract-build = "3.0.1"
 
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ lto = true
 [features]
 default = ["llvm", "wasm_opt"]
 llvm = ["inkwell", "libc"]
-wasm_opt = ["wasm-opt", "contract-build"]
+wasm_opt = ["llvm", "wasm-opt", "contract-build"]
 
 [workspace]
 members = ["solang-parser", "tests/wasm_host_attr"]

--- a/docs/code_gen_options.rst
+++ b/docs/code_gen_options.rst
@@ -145,6 +145,21 @@ This also means that, whenever the length of an array is accessed using '.length
 Note that this optimization does not cover every case. When an array is passed
 as a function argument, for instance, the length is unknown.
 
+``wasm-opt`` optimization passes
+--------------------------------
+
+For the Substrate target, optimization passes from the `binaryen <https://github.com/WebAssembly/binaryen>`_ ``wasm-opt`` 
+tool can be applied. This may vastly shrink the Wasm code size and can make the code more efficient as well.
+
+Use the ``--wasm-opt`` compile flag to enable ``wasm-opt`` optimizations. Possible values are 
+``0`` - ``4``, ``s`` and ``z``, corresponding to the ``wasm-opt`` flags ``-O0`` - ``-O4``, ``-Os`` and ``-Oz`` respectively.
+To learn more about the optimization levels please consult ``wasm-opt --help``.
+
+.. note::
+
+    In ``--release`` mode, if ``--wasm-opt`` is not specified, the level ``z`` ("super-focusing on code size") will be used.
+
+
 Debugging Options
 -----------------
 

--- a/docs/code_gen_options.rst
+++ b/docs/code_gen_options.rst
@@ -149,7 +149,7 @@ as a function argument, for instance, the length is unknown.
 --------------------------------
 
 For the Substrate target, optimization passes from the `binaryen <https://github.com/WebAssembly/binaryen>`_ ``wasm-opt`` 
-tool can be applied. This may vastly shrink the Wasm code size and make it more efficient.
+tool can be applied. This may shrink the Wasm code size and makes it more efficient.
 
 Use the ``--wasm-opt`` compile flag to enable ``wasm-opt`` optimizations. Possible values are 
 ``0`` - ``4``, ``s`` and ``z``, corresponding to the ``wasm-opt`` flags ``-O0`` - ``-O4``, ``-Os`` and ``-Oz`` respectively.

--- a/docs/code_gen_options.rst
+++ b/docs/code_gen_options.rst
@@ -149,7 +149,7 @@ as a function argument, for instance, the length is unknown.
 --------------------------------
 
 For the Substrate target, optimization passes from the `binaryen <https://github.com/WebAssembly/binaryen>`_ ``wasm-opt`` 
-tool can be applied. This may vastly shrink the Wasm code size and can make the code more efficient as well.
+tool can be applied. This may vastly shrink the Wasm code size and make it more efficient.
 
 Use the ``--wasm-opt`` compile flag to enable ``wasm-opt`` optimizations. Possible values are 
 ``0`` - ``4``, ``s`` and ``z``, corresponding to the ``wasm-opt`` flags ``-O0`` - ``-O4``, ``-Os`` and ``-Oz`` respectively.

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -87,11 +87,16 @@ Then you can build the image using:
 Option 5: Build Solang from source
 ----------------------------------
 
-In order to build Solang from source, you will need rust 1.68.0 or higher,
-and a build of LLVM based on the Solana LLVM tree. There are a few LLVM patches required that are not upstream yet.
+In order to build Solang from source, you will need:
+
+* Rust version 1.68.0 or higher
+* A C++ compiler with support for C++17
+* A build of LLVM based on the Solana LLVM tree. There are a few LLVM patches required that are not upstream yet.
+
 First, follow the steps below for installing LLVM and then proceed from there.
 
 If you do not have the correct version of rust installed, go to `rustup <https://rustup.rs/>`_.
+Compatible C++17 compilers are recent releases of ``gcc``, ``clang`` and Visual Studio 2019 or later.
 
 To install Solang from sources, do the following:
 

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -131,6 +131,9 @@ Options:
 \-\-release
    Disable all debugging features for :ref:`release`
 
+\-\-wasm-opt
+   wasm-opt passes for Wasm targets (0, 1, 2, 3, 4, s or z; see the wasm-opt help for more details).
+
 .. warning::
 
     If multiple Solidity source files define the same contract name, you will get a single

--- a/integration/substrate/build.sh
+++ b/integration/substrate/build.sh
@@ -6,7 +6,7 @@ if [[ $dup_contracts ]]; then
 	echo "Found contract with duplicate names: ${dup_contracts}"
 	/bin/false
 else
-	parallel solang compile -v -g --target substrate ::: *.sol test/*.sol tornado/contracts/*.sol
+	parallel solang compile -v -g --wasm-opt Z --target substrate ::: *.sol test/*.sol tornado/contracts/*.sol
 	solang compile -v --target substrate --release release_version.sol
 fi
 

--- a/src/bin/cli/mod.rs
+++ b/src/bin/cli/mod.rs
@@ -2,6 +2,7 @@
 
 use clap::{builder::ValueParser, value_parser, ArgAction, Args, Parser, Subcommand};
 use clap_complete::Shell;
+#[cfg(feature = "wasm_opt")]
 use contract_build::OptimizationPasses;
 
 use std::{ffi::OsString, path::PathBuf, process::exit};
@@ -181,6 +182,7 @@ pub struct Optimizations {
     #[arg(name = "OPT", help = "Set llvm optimizer level ", short = 'O', default_value = "default", value_parser = ["none", "less", "default", "aggressive"], num_args = 1)]
     pub opt_level: String,
 
+    #[cfg(feature = "wasm_opt")]
     #[arg(
         name = "WASM_OPT",
         help = "wasm-opt passes for Wasm targets (0, 1, 2, 3, 4, s or z; see the wasm-opt help for more details)",
@@ -270,6 +272,7 @@ pub fn options_arg(debug: &DebugFeatures, optimizations: &Optimizations) -> Opti
         log_api_return_codes: debug.log_api_return_codes & !debug.release,
         log_runtime_errors: debug.log_runtime_errors & !debug.release,
         log_prints: debug.log_prints & !debug.release,
+        #[cfg(feature = "wasm_opt")]
         wasm_opt: optimizations.wasm_opt_passes.or(if debug.release {
             Some(OptimizationPasses::Z)
         } else {

--- a/src/bin/cli/mod.rs
+++ b/src/bin/cli/mod.rs
@@ -183,7 +183,7 @@ pub struct Optimizations {
 
     #[arg(
         name = "WASM_OPT",
-        help = "wasm-opt passes for Wasm targets",
+        help = "wasm-opt passes for Wasm targets (0, 1, 2, 3, 4, s or z; see the wasm-opt help for more details)",
         long = "wasm-opt",
         num_args = 1
     )]

--- a/src/bin/cli/mod.rs
+++ b/src/bin/cli/mod.rs
@@ -2,6 +2,7 @@
 
 use clap::{builder::ValueParser, value_parser, ArgAction, Args, Parser, Subcommand};
 use clap_complete::Shell;
+use contract_build::OptimizationPasses;
 
 use std::{ffi::OsString, path::PathBuf, process::exit};
 
@@ -105,7 +106,7 @@ pub struct CompilerOutput {
     #[arg(name = "STD-JSON",help = "mimic solidity json output on stdout", conflicts_with_all = ["VERBOSE", "OUTPUT", "EMIT"] , action = ArgAction::SetTrue, long = "standard-json")]
     pub std_json_output: bool,
 
-    #[arg(name = "OUTPUT",help = "output directory", short = 'o', long = "output", num_args = 1, value_parser =ValueParser::string())]
+    #[arg(name = "OUTPUT",help = "output directory", short = 'o', long = "output", num_args = 1, value_parser = ValueParser::string())]
     pub output_directory: Option<String>,
 
     #[arg(name = "OUTPUTMETA",help = "output directory for metadata", long = "output-meta", num_args = 1, value_parser = ValueParser::string())]
@@ -179,6 +180,14 @@ pub struct Optimizations {
 
     #[arg(name = "OPT", help = "Set llvm optimizer level ", short = 'O', default_value = "default", value_parser = ["none", "less", "default", "aggressive"], num_args = 1)]
     pub opt_level: String,
+
+    #[arg(
+        name = "WASM_OPT",
+        help = "wasm-opt passes for Wasm targets",
+        long = "wasm-opt",
+        num_args = 1
+    )]
+    pub wasm_opt_passes: Option<OptimizationPasses>,
 }
 
 pub(crate) fn target_arg(target_arg: &TargetArg) -> Target {
@@ -261,6 +270,11 @@ pub fn options_arg(debug: &DebugFeatures, optimizations: &Optimizations) -> Opti
         log_api_return_codes: debug.log_api_return_codes & !debug.release,
         log_runtime_errors: debug.log_runtime_errors & !debug.release,
         log_prints: debug.log_prints & !debug.release,
+        wasm_opt: optimizations.wasm_opt_passes.or(if debug.release {
+            Some(OptimizationPasses::Z)
+        } else {
+            None
+        }),
     }
 }
 

--- a/src/bin/solang.rs
+++ b/src/bin/solang.rs
@@ -310,6 +310,7 @@ fn contract_results(
 
     let code = binary.code(Generate::Linked).expect("llvm build");
 
+    #[cfg(feature = "wasm_opt")]
     if let Some(level) = opt.wasm_opt.filter(|_| ns.target.is_substrate() && verbose) {
         eprintln!(
             "info: wasm-opt level '{}' for contract {}",

--- a/src/bin/solang.rs
+++ b/src/bin/solang.rs
@@ -20,7 +20,6 @@ use std::{
     path::{Path, PathBuf},
     process::exit,
 };
-use wasm_opt::OptimizationOptions;
 
 use crate::cli::{
     imports_arg, options_arg, target_arg, Cli, Commands, Compile, CompilerOutput, Doc,
@@ -309,40 +308,13 @@ fn contract_results(
         return;
     }
 
-    let mut code = binary.code(Generate::Linked).expect("llvm build");
+    let code = binary.code(Generate::Linked).expect("llvm build");
 
-    if let Some(level) = opt.wasm_opt.filter(|_| ns.target.is_substrate()) {
-        if verbose {
-            eprintln!(
-                "info: wasm-opt level '{}' for contract {}",
-                level, resolved_contract.name
-            );
-        }
-
-        let infile = PathBuf::from(&ns.contracts[contract_no].name);
-        let outfile = infile.with_extension("wasmopt");
-        let mut file = create_file(&infile);
-        file.write_all(&code).unwrap();
-
-        // Using the same config as cargo contract:
-        // https://github.com/paritytech/cargo-contract/blob/71a8a42096e2df36d54a695d099aecfb1e394b78/crates/build/src/wasm_opt.rs#L67
-        OptimizationOptions::from(level)
-            .mvp_features_only()
-            .zero_filled_memory(true)
-            .debug_info(opt.generate_debug_information)
-            .run(&infile, &outfile)
-            .map_err(|err| {
-                eprintln!(
-                    "error: wasm-opt for contract {} failed: {}",
-                    resolved_contract.name, err
-                );
-                exit(1);
-            })
-            .expect("exit(1) on error");
-
-        code = std::fs::read(&outfile).expect("just wrote this file");
-        std::fs::remove_file(outfile).expect("just wrote this file");
-        std::fs::remove_file(infile).expect("just wrote this file");
+    if let Some(level) = opt.wasm_opt.filter(|_| ns.target.is_substrate() && verbose) {
+        eprintln!(
+            "info: wasm-opt level '{}' for contract {}",
+            level, resolved_contract.name
+        );
     }
 
     if std_json {

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -44,6 +44,7 @@ use crate::codegen::cfg::ASTFunction;
 use crate::codegen::solana_accounts::account_management::manage_contract_accounts;
 use crate::codegen::yul::generate_yul_function_cfg;
 use crate::sema::Recurse;
+#[cfg(feature = "wasm_opt")]
 use contract_build::OptimizationPasses;
 use num_bigint::{BigInt, Sign};
 use num_rational::BigRational;
@@ -97,6 +98,7 @@ pub struct Options {
     pub log_api_return_codes: bool,
     pub log_runtime_errors: bool,
     pub log_prints: bool,
+    #[cfg(feature = "wasm_opt")]
     pub wasm_opt: Option<OptimizationPasses>,
 }
 
@@ -113,6 +115,7 @@ impl Default for Options {
             log_api_return_codes: false,
             log_runtime_errors: false,
             log_prints: true,
+            #[cfg(feature = "wasm_opt")]
             wasm_opt: None,
         }
     }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -44,6 +44,7 @@ use crate::codegen::cfg::ASTFunction;
 use crate::codegen::solana_accounts::account_management::manage_contract_accounts;
 use crate::codegen::yul::generate_yul_function_cfg;
 use crate::sema::Recurse;
+use contract_build::OptimizationPasses;
 use num_bigint::{BigInt, Sign};
 use num_rational::BigRational;
 use num_traits::{FromPrimitive, Zero};
@@ -96,6 +97,7 @@ pub struct Options {
     pub log_api_return_codes: bool,
     pub log_runtime_errors: bool,
     pub log_prints: bool,
+    pub wasm_opt: Option<OptimizationPasses>,
 }
 
 impl Default for Options {
@@ -111,6 +113,7 @@ impl Default for Options {
             log_api_return_codes: false,
             log_runtime_errors: false,
             log_prints: true,
+            wasm_opt: None,
         }
     }
 }

--- a/src/emit/binary.rs
+++ b/src/emit/binary.rs
@@ -147,9 +147,7 @@ impl<'a> Binary<'a> {
                 .zero_filled_memory(true)
                 .debug_info(self.options.generate_debug_information)
                 .run(&infile, &outfile)
-                .map_err(|err| {
-                    format!("error: wasm-opt for binary {} failed: {}", self.name, err)
-                })?;
+                .map_err(|err| format!("wasm-opt for binary {} failed: {}", self.name, err))?;
 
             blob = std::fs::read(&outfile).expect("just wrote this file");
         }

--- a/src/emit/binary.rs
+++ b/src/emit/binary.rs
@@ -139,7 +139,7 @@ impl<'a> Binary<'a> {
         #[cfg(feature = "wasm_opt")]
         if let Some(level) = self.options.wasm_opt.filter(|_| self.target.is_substrate()) {
             let mut infile = tempdir().map_err(|e| e.to_string())?.into_path();
-            infile.push(&self.name);
+            infile.push("code.wasm");
             let outfile = infile.with_extension("wasmopt");
             std::fs::write(&infile, &code).map_err(|e| e.to_string())?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,7 @@ pub fn compile(
     log_api_return_codes: bool,
     log_runtime_errors: bool,
     log_prints: bool,
+    #[cfg(feature = "wasm_opt")] wasm_opt: Option<contract_build::OptimizationPasses>,
 ) -> (Vec<(Vec<u8>, String)>, sema::ast::Namespace) {
     let mut ns = parse_and_resolve(filename, resolver, target);
     let opts = codegen::Options {
@@ -132,6 +133,8 @@ pub fn compile(
         opt_level: opt_level.into(),
         log_runtime_errors,
         log_prints,
+        #[cfg(feature = "wasm_opt")]
+        wasm_opt,
         ..Default::default()
     };
 

--- a/tests/codegen_testcases/solidity/unused_variable_elimination.sol
+++ b/tests/codegen_testcases/solidity/unused_variable_elimination.sol
@@ -66,7 +66,7 @@ contract c {
         x = 102 + t*y/(t+5*y) + g + test3() - vec.push(2) + ct.sum(1, 2);
 		return 2;
 // CHECK: push array ty:int32[] value:int32 2
-// CHECK: _ = external call::regular address:%ct payload:%abi_encoded.temp.90 value:uint128 0 gas:uint64 0 accounts: seeds:
+// CHECK: _ = external call::regular address:%ct payload:%abi_encoded.temp.90 value:uint128 0 gas:uint64 0 accounts: seeds: contract|function:(0, 2)
 }
 
 }

--- a/tests/codegen_testcases/solidity/unused_variable_elimination.sol
+++ b/tests/codegen_testcases/solidity/unused_variable_elimination.sol
@@ -66,7 +66,7 @@ contract c {
         x = 102 + t*y/(t+5*y) + g + test3() - vec.push(2) + ct.sum(1, 2);
 		return 2;
 // CHECK: push array ty:int32[] value:int32 2
-// CHECK: _ = external call::regular address:%ct payload:%abi_encoded.temp.90 value:uint128 0 gas:uint64 0 accounts: seeds: contract|function:(0, 2)
+// CHECK: _ = external call::regular address:%ct payload:%abi_encoded.temp.90 value:uint128 0 gas:uint64 0 accounts: seeds:
 }
 
 }

--- a/tests/solana.rs
+++ b/tests/solana.rs
@@ -147,6 +147,8 @@ fn build_solidity(src: &str) -> VirtualMachine {
         false,
         true,
         true,
+        #[cfg(feature = "wasm_opt")]
+        None,
     );
 
     ns.print_diagnostics_in_plain(&cache, false);

--- a/tests/substrate.rs
+++ b/tests/substrate.rs
@@ -967,7 +967,17 @@ pub fn build_wasm(src: &str, log_ret: bool, log_err: bool) -> Vec<(Vec<u8>, Stri
     cache.set_file_contents(tmp_file.to_str().unwrap(), src.to_string());
     let opt = inkwell::OptimizationLevel::Default;
     let target = Target::default_substrate();
-    let (wasm, ns) = compile(tmp_file, &mut cache, opt, target, log_ret, log_err, true);
+    let (wasm, ns) = compile(
+        tmp_file,
+        &mut cache,
+        opt,
+        target,
+        log_ret,
+        log_err,
+        true,
+        #[cfg(feature = "wasm_opt")]
+        Some(contract_build::OptimizationPasses::Z),
+    );
     ns.print_diagnostics_in_plain(&cache, false);
     assert!(!wasm.is_empty());
     wasm

--- a/tests/substrate_tests/inheritance.rs
+++ b/tests/substrate_tests/inheritance.rs
@@ -38,6 +38,8 @@ fn test_abstract() {
         false,
         false,
         true,
+        #[cfg(feature = "wasm_opt")]
+        Some(contract_build::OptimizationPasses::Z),
     );
 
     assert!(!ns.diagnostics.any_errors());
@@ -78,6 +80,8 @@ fn test_abstract() {
         false,
         false,
         true,
+        #[cfg(feature = "wasm_opt")]
+        Some(contract_build::OptimizationPasses::Z),
     );
 
     assert!(!ns.diagnostics.any_errors());

--- a/tests/undefined_variable_detection.rs
+++ b/tests/undefined_variable_detection.rs
@@ -22,6 +22,7 @@ fn parse_and_codegen(src: &'static str) -> Namespace {
         log_api_return_codes: false,
         log_runtime_errors: false,
         log_prints: true,
+        wasm_opt: None,
     };
 
     codegen(&mut ns, &opt);

--- a/tests/undefined_variable_detection.rs
+++ b/tests/undefined_variable_detection.rs
@@ -22,6 +22,7 @@ fn parse_and_codegen(src: &'static str) -> Namespace {
         log_api_return_codes: false,
         log_runtime_errors: false,
         log_prints: true,
+        #[cfg(feature = "wasm_opt")]
         wasm_opt: None,
     };
 


### PR DESCRIPTION
`wasm-opt` brings some great optimizations and we should use it (`cargo contract` uses it for ink contracts). For example, the Wasm blob of our flipper example (compile `--release`) goes down from 2.2kb to 1.2kb. 