### PR TITLE
salt is of type bytes32

### DIFF
--- a/docs/language/contracts.rst
+++ b/docs/language/contracts.rst
@@ -77,12 +77,15 @@ _______________________________________________________
     on Solana, the address of the new account must be set using ``address:``.
 
 When a new contract is created, the address for the new contract is a hash of the input
-(the constructor arguments) to the new contract. So, a contract cannot be created twice
-with the same input. This is why the salt is concatenated to the input. The salt is
-either a random value or it can be explicitly set using the ``{salt: 2}`` syntax. A
-constant will remove the need for the runtime random generation, however creating
-a contract twice with the same salt and arguments will fail. The salt is of type
-``uint256``.
+(the encoded constructor arguments) to the new contract and the salt. A contract cannot be
+created twice with the same input and salt. By giving a different salt, the same input
+can be used twice for a new contract. The salt can be set using the
+``{salt: hex"439d399ee3b5b0fae6c8d567a8cbfa22d59f8f2c5fe308fd0a92366c116e5f1a"}``
+syntax, or if it is omitted, then a random value is used.
+
+Specifying a salt will remove the need for generating a random value at runtime, however
+care must be taken to avoid using the same salt more than once. Creating a contract twice
+with the same salt and arguments will fail.  The salt is of type ``bytes32``.
 
 If gas is specified, this limits the amount gas the constructor for the new contract
 can use. gas is a ``uint64``.

--- a/integration/substrate/UniswapV2Factory.sol
+++ b/integration/substrate/UniswapV2Factory.sol
@@ -30,7 +30,7 @@ contract UniswapV2Factory is IUniswapV2Factory {
         //assembly {
         //    pair := create2(0, add(bytecode, 32), mload(bytecode), salt)
         //}
-        pair = address(new UniswapV2Pair{salt: uint256(salt), value: 1e16}());
+        pair = address(new UniswapV2Pair{salt: salt, value: 1e16}());
         UniswapV2Pair(pair).initialize(token0, token1);
         getPair[token0][token1] = pair;
         getPair[token1][token0] = pair; // populate mapping in the reverse direction

--- a/src/sema/expression/function_call.rs
+++ b/src/sema/expression/function_call.rs
@@ -2085,7 +2085,7 @@ pub(super) fn parse_call_args(
                     return Err(());
                 }
 
-                let ty = Type::Uint(256);
+                let ty = Type::Bytes(32);
 
                 let expr = expression(
                     &arg.expr,

--- a/tests/evm.rs
+++ b/tests/evm.rs
@@ -248,7 +248,7 @@ fn ethereum_solidity_tests() {
         })
         .sum();
 
-    assert_eq!(errors, 1042);
+    assert_eq!(errors, 1038);
 }
 
 fn set_file_contents(source: &str, path: &Path) -> (FileResolver, Vec<String>) {

--- a/tests/substrate_tests/errors.rs
+++ b/tests/substrate_tests/errors.rs
@@ -69,8 +69,8 @@ fn errors() {
 
         // contract creation failed (contract was deplyed with no value)
         function create_child() public {
-            c = new child{value: 900e15, salt:2}();
-            c2 = new child{value: 900e15, salt:2}();
+            c = new child{value: 900e15, salt: hex"02"}();
+            c2 = new child{value: 900e15, salt: hex"02"}();
             uint128 x = address(this).balance;
             //print("sesa");
             print("x = {}".format(x));
@@ -228,7 +228,7 @@ fn errors() {
 
     assert_eq!(
         runtime.debug_buffer(),
-        "runtime_error: contract creation failed in test.sol:64:17-51,\n"
+        "runtime_error: contract creation failed in test.sol:64:17-58,\n"
     );
 
     runtime.debug_buffer().clear();

--- a/tests/substrate_tests/value.rs
+++ b/tests/substrate_tests/value.rs
@@ -199,7 +199,7 @@ fn constructor_salt() {
         r##"
         contract b {
             function step1() public {
-                a f = new a{salt: 1}();
+                a f = new a{salt: hex"01"}();
             }
         }
 
@@ -217,8 +217,8 @@ fn constructor_salt() {
         r##"
         contract b {
             function step1() public {
-                a f = new a{salt: 1}();
-                f = new a{salt: 2}();
+                a f = new a{salt: hex"01"}();
+                f = new a{salt: hex"02"}();
             }
         }
 


### PR DESCRIPTION
solang mistakenly uses `uint256` as the type for the salt argument. Change this to `bytes32` to be compatible with solc.