### PR TITLE
Allow returns values to be ignored in try catch

### DIFF
--- a/src/codegen/statements.rs
+++ b/src/codegen/statements.rs
@@ -1172,7 +1172,7 @@ fn try_catch(
 
                 cfg.set_basic_block(success_block);
 
-                if func_returns != vec![Type::Void] {
+                if !try_stmt.returns.is_empty() {
                     let mut res = Vec::new();
 
                     for ret in &try_stmt.returns {

--- a/src/sema/statements.rs
+++ b/src/sema/statements.rs
@@ -2272,7 +2272,7 @@ fn try_catch(
                 func_returns = vec![];
             }
 
-            if returns.len() != func_returns.len() {
+            if !returns.is_empty() && returns.len() != func_returns.len() {
                 diagnostics.push(Diagnostic::error(
                     expr.loc(),
                     format!(

--- a/tests/codegen_testcases/solidity/try_catch.sol
+++ b/tests/codegen_testcases/solidity/try_catch.sol
@@ -1,0 +1,17 @@
+// RUN: --target substrate --emit cfg
+interface I {
+	function bar() external returns (int32, bool);
+}
+
+contract C {
+// BEGIN-CHECK: C::C::function::foo
+	function foo(I i) public returns (int32 x) {
+        try i.bar() {
+            // ensure no abi decoding is done because the return values of bar() are not used
+            x = 1;
+        } catch (bytes) {
+            x = 2;
+        }
+// NOT-CHECK: builtin ReadFromBuffer ((external call return data)
+	}
+}

--- a/tests/evm.rs
+++ b/tests/evm.rs
@@ -248,7 +248,7 @@ fn ethereum_solidity_tests() {
         })
         .sum();
 
-    assert_eq!(errors, 1038);
+    assert_eq!(errors, 1032);
 }
 
 fn set_file_contents(source: &str, path: &Path) -> (FileResolver, Vec<String>) {


### PR DESCRIPTION
A try catch statement does not need to decode the return values if it is not interested.

```
interface I {
      function func()   externalpublic returns (int, bool);
}

contract C {
     function test(I i) public {
           try I.func() {
           }
           catch (bytes memory bs) { 
           }
     } 
}
```

Here `func()` returns two values but the try statement does not use them at all. This means they do not have abi decoded either.