### PR TITLE
Implicit accessor function should return struct members, not struct

### DIFF
--- a/src/abi/tests.rs
+++ b/src/abi/tests.rs
@@ -84,30 +84,10 @@ fn constants_and_types() {
 
     assert_eq!(idl.types.len(), 2);
 
-    assert_eq!(idl.types[0].name, "MyStruct");
+    assert_eq!(idl.types[0].name, "Week");
     assert!(idl.types[0].docs.is_none());
     assert_eq!(
         idl.types[0].ty,
-        IdlTypeDefinitionTy::Struct {
-            fields: vec![
-                IdlField {
-                    name: "g".to_string(),
-                    docs: None,
-                    ty: IdlType::U8,
-                },
-                IdlField {
-                    name: "d".to_string(),
-                    docs: None,
-                    ty: IdlType::Array(IdlType::U8.into(), 2)
-                }
-            ]
-        }
-    );
-
-    assert_eq!(idl.types[1].name, "Week");
-    assert!(idl.types[1].docs.is_none());
-    assert_eq!(
-        idl.types[1].ty,
         IdlTypeDefinitionTy::Enum {
             variants: vec![
                 IdlEnumVariant {
@@ -121,6 +101,31 @@ fn constants_and_types() {
                 IdlEnumVariant {
                     name: "Wednesday".to_string(),
                     fields: None,
+                }
+            ]
+        }
+    );
+
+    assert_eq!(idl.types[1].name, "cte5_returns");
+    assert_eq!(
+        idl.types[1].docs,
+        Some(vec![
+            "Data structure to hold the multiple returns of function cte5".into()
+        ])
+    );
+    assert_eq!(
+        idl.types[1].ty,
+        IdlTypeDefinitionTy::Struct {
+            fields: vec![
+                IdlField {
+                    name: "g".to_string(),
+                    docs: None,
+                    ty: IdlType::U8,
+                },
+                IdlField {
+                    name: "d".to_string(),
+                    docs: None,
+                    ty: IdlType::Array(IdlType::U8.into(), 2)
                 }
             ]
         }

--- a/src/sema/expression/function_call.rs
+++ b/src/sema/expression/function_call.rs
@@ -2665,13 +2665,22 @@ fn resolve_internal_call(
         return None;
     } else if let (Some(base_no), Some(derived_no)) = (func.contract_no, context.contract_no) {
         if is_base(base_no, derived_no, ns) && matches!(func.visibility, Visibility::External(_)) {
-            errors.push(Diagnostic::error_with_note(
-                *loc,
-                "functions declared external cannot be called via an internal function call"
-                    .to_string(),
-                func.loc,
-                format!("declaration of {} '{}'", func.ty, func.name),
-            ));
+            if func.is_accessor {
+                errors.push(Diagnostic::error_with_note(
+                    *loc,
+                    "accessor function cannot be called via an internal function call".to_string(),
+                    func.loc,
+                    format!("declaration of '{}'", func.name),
+                ));
+            } else {
+                errors.push(Diagnostic::error_with_note(
+                    *loc,
+                    "functions declared external cannot be called via an internal function call"
+                        .to_string(),
+                    func.loc,
+                    format!("declaration of {} '{}'", func.ty, func.name),
+                ));
+            }
             return None;
         }
     }

--- a/tests/contract_testcases/solana/accessor/accessor_is_external.sol
+++ b/tests/contract_testcases/solana/accessor/accessor_is_external.sol
@@ -1,0 +1,10 @@
+contract C {
+	int constant public c = 102;
+
+	function f() public {
+		int x = c();
+	}
+}
+// ---- Expect: diagnostics ----
+// error: 5:11-14: accessor function cannot be called via an internal function call
+// 	note 2:22-23: declaration of 'c'

--- a/tests/evm.rs
+++ b/tests/evm.rs
@@ -248,7 +248,7 @@ fn ethereum_solidity_tests() {
         })
         .sum();
 
-    assert_eq!(errors, 1032);
+    assert_eq!(errors, 1029);
 }
 
 fn set_file_contents(source: &str, path: &Path) -> (FileResolver, Vec<String>) {

--- a/tests/solana_tests/accessor.rs
+++ b/tests/solana_tests/accessor.rs
@@ -205,3 +205,44 @@ fn constant() {
         ])
     );
 }
+
+#[test]
+fn struct_accessor() {
+    let mut vm = build_solidity(
+        r#"
+        contract C {
+            struct E {
+                bytes4 b4;
+            }
+            struct S {
+                int64 f1;
+                bool f2;
+                E f3;
+            }
+            S public a = S({f1: -63, f2: false, f3: E("nuff")});
+            S[100] public s;
+            mapping(int => S) public m;
+            E public constant e = E("cons");
+
+            constructor() {
+                s[99] = S({f1: 65535, f2: true, f3: E("naff")});
+                m[1023413412] = S({f1: 414243, f2: true, f3: E("niff")});
+            }
+
+            function f() public view {
+                (int64 a1, bool b, E memory c) = this.a();
+                require(a1 == -63 && !b && c.b4 == "nuff", "a");
+                (a1, b, c) = this.s(99);
+                require(a1 == 65535 && b && c.b4 == "naff", "b");
+                (a1, b, c) = this.m(1023413412);
+                require(a1 == 414243 && b && c.b4 == "niff", "c");
+                c.b4 = this.e();
+                require(a1 == 414243 && b && c.b4 == "cons", "E");
+            }
+        }"#,
+    );
+
+    vm.constructor(&[]);
+
+    vm.function("f", &[]);
+}

--- a/tests/substrate_tests/inheritance.rs
+++ b/tests/substrate_tests/inheritance.rs
@@ -666,12 +666,12 @@ fn var_or_function() {
         r##"
         contract x is c {
             function f1() public returns (int64) {
-                return c.selector();
+                return selector;
             }
 
             function f2() public returns (int64)  {
-                function() internal returns (int64) a = c.selector;
-                return a();
+                function() external returns (int64) a = this.selector;
+                return a{flags: 8}();
             }
         }
 


### PR DESCRIPTION
If the acessor function returns a single struct, then the members should be returned. If any of those members are structs, then those members will remain structs.

	contract C {
		struct S { int a; bool b; }

		S public s;

		function foo() public {
			(int a, bool b) = this.s();
		}
	}

Also, the accesor function should be declared `external` and therefore not accessible as an internal function call.