### PR TITLE
Fix a bunch of subxt-tests rust warnings

### DIFF
--- a/integration/subxt-tests/src/cases/arrays.rs
+++ b/integration/subxt-tests/src/cases/arrays.rs
@@ -65,7 +65,7 @@ async fn case() -> anyhow::Result<()> {
         users.push((name, rnd_addr, id, perms));
     }
 
-    let (name, addr, id, perms) = users.choose(&mut thread_rng()).unwrap();
+    let (_name, _addr, id, _perms) = users.choose(&mut thread_rng()).unwrap();
 
     let output = contract
         .try_call(
@@ -78,7 +78,7 @@ async fn case() -> anyhow::Result<()> {
         )
         .await?;
 
-    let (name, addr, id, perms) =
+    let (_name, _addr, id, perms) =
         <(String, AccountId32, u64, Vec<u8>)>::decode(&mut output.as_bytes_ref())?;
 
     if !perms.is_empty() {

--- a/integration/subxt-tests/src/cases/balances.rs
+++ b/integration/subxt-tests/src/cases/balances.rs
@@ -59,7 +59,7 @@ async fn case() -> anyhow::Result<()> {
             &api,
             sp_keyring::AccountKeyring::Alice,
             0,
-            &|t: &ContractMessageTranscoder| {
+            &|_: &ContractMessageTranscoder| {
                 let mut s = keccak_256(b"transfer(address,uint128)")[..4].to_vec();
                 dave.encode_to(&mut s);
                 20000_u128.encode_to(&mut s);
@@ -77,7 +77,7 @@ async fn case() -> anyhow::Result<()> {
             &api,
             sp_keyring::AccountKeyring::Alice,
             0,
-            &|t: &ContractMessageTranscoder| {
+            &|_: &ContractMessageTranscoder| {
                 let mut s = keccak_256(b"send(address,uint128)")[..4].to_vec();
                 dave.encode_to(&mut s);
                 10000_u128.encode_to(&mut s);

--- a/integration/subxt-tests/src/cases/builtins.rs
+++ b/integration/subxt-tests/src/cases/builtins.rs
@@ -31,7 +31,7 @@ async fn case() -> anyhow::Result<()> {
             sp_keyring::AccountKeyring::Alice,
             0,
             &|t: &ContractMessageTranscoder| {
-                t.encode("hash_ripemd160", [format!("0x{}", hex::encode(&input_str))])
+                t.encode("hash_ripemd160", [format!("0x{}", hex::encode(input_str))])
                     .unwrap()
             },
         )
@@ -47,7 +47,7 @@ async fn case() -> anyhow::Result<()> {
             sp_keyring::AccountKeyring::Alice,
             0,
             &|t: &ContractMessageTranscoder| {
-                t.encode("hash_sha256", [format!("0x{}", hex::encode(&input_str))])
+                t.encode("hash_sha256", [format!("0x{}", hex::encode(input_str))])
                     .unwrap()
             },
         )
@@ -63,11 +63,8 @@ async fn case() -> anyhow::Result<()> {
             sp_keyring::AccountKeyring::Alice,
             0,
             &|t: &ContractMessageTranscoder| {
-                t.encode(
-                    "hash_kecccak256",
-                    [format!("0x{}", hex::encode(&input_str))],
-                )
-                .unwrap()
+                t.encode("hash_kecccak256", [format!("0x{}", hex::encode(input_str))])
+                    .unwrap()
             },
         )
         .await?;

--- a/integration/subxt-tests/src/cases/builtins2.rs
+++ b/integration/subxt-tests/src/cases/builtins2.rs
@@ -28,10 +28,8 @@ async fn case() -> anyhow::Result<()> {
     // check blake2_128
     let input_str = "Call me Ishmael.";
 
-    let selector = transcoder.encode(
-        "hash_blake2_128",
-        [format!("0x{}", hex::encode(&input_str))],
-    )?;
+    let selector =
+        transcoder.encode("hash_blake2_128", [format!("0x{}", hex::encode(input_str))])?;
 
     let rv = ReadContract {
         caller: sp_keyring::AccountKeyring::Alice,
@@ -46,10 +44,8 @@ async fn case() -> anyhow::Result<()> {
     assert_eq!(rv.return_value, expected);
 
     // check blake2_256
-    let selector = transcoder.encode(
-        "hash_blake2_256",
-        [format!("0x{}", hex::encode(&input_str))],
-    )?;
+    let selector =
+        transcoder.encode("hash_blake2_256", [format!("0x{}", hex::encode(input_str))])?;
 
     let rv = ReadContract {
         caller: sp_keyring::AccountKeyring::Alice,

--- a/integration/subxt-tests/src/cases/external_call.rs
+++ b/integration/subxt-tests/src/cases/external_call.rs
@@ -20,8 +20,8 @@ async fn case() -> anyhow::Result<()> {
     let c_callee = Contract::new("./contracts/callee.contract")?;
     let t_callee = &c_callee.transcoder;
 
-    let c_callee2 = Contract::new("./contracts/callee2.contract")?;
-    let t_callee2 = &c_caller.transcoder;
+    let _c_callee2 = Contract::new("./contracts/callee2.contract")?;
+    let _t_callee2 = &c_caller.transcoder;
 
     let selector = t_caller.encode::<_, String>("new", [])?;
 
@@ -53,7 +53,7 @@ async fn case() -> anyhow::Result<()> {
     .await?;
 
     // setX on callee
-    let selector = t_callee.encode::<_, String>("set_x", [format!("102")])?;
+    let selector = t_callee.encode::<_, String>("set_x", ["102".into()])?;
 
     WriteContract {
         caller: sp_keyring::AccountKeyring::Alice,

--- a/integration/subxt-tests/src/cases/primitives.rs
+++ b/integration/subxt-tests/src/cases/primitives.rs
@@ -38,18 +38,18 @@ async fn case() -> anyhow::Result<()> {
 
     // test res
     #[derive(Encode, Decode)]
-    enum oper {
-        add,
-        sub,
-        mul,
-        div,
-        r#mod,
-        pow,
-        shl,
-        shr,
-        or,
-        and,
-        xor,
+    enum Oper {
+        Add,
+        Sub,
+        Mul,
+        Div,
+        Mod,
+        Pow,
+        Shl,
+        Shr,
+        Or,
+        And,
+        Xor,
     }
 
     let is_mul = c
@@ -68,9 +68,9 @@ async fn case() -> anyhow::Result<()> {
                 .expect("unable to find selector")
         })
         .await
-        .and_then(|rv| oper::decode(&mut rv.as_bytes_ref()).map_err(Into::into))?;
+        .and_then(|rv| Oper::decode(&mut rv.as_bytes_ref()).map_err(Into::into))?;
 
-    if let oper::div = return_div {
+    if let Oper::Div = return_div {
     } else {
         panic!("not div");
     }
@@ -230,7 +230,7 @@ async fn case() -> anyhow::Result<()> {
             // since i256 is not supported by contract-metadata we need to manually supply the selector and encode its inputs
             let mut sel = hex::decode("d6435f25").expect("unable to decode selector");
 
-            oper::add.encode_to(&mut sel);
+            Oper::Add.encode_to(&mut sel);
             U256::from_dec_str("1000")
                 .map(|o| o.encode_to(&mut sel))
                 .expect("unable to encode to selector");
@@ -250,7 +250,7 @@ async fn case() -> anyhow::Result<()> {
             // since i256 is not supported by contract-metadata we need to manually supply the selector and encode its inputs
             let mut sel = hex::decode("d6435f25").expect("unable to decode selector");
 
-            oper::sub.encode_to(&mut sel);
+            Oper::Sub.encode_to(&mut sel);
             U256::from_dec_str("1000")
                 .map(|o| o.encode_to(&mut sel))
                 .expect("unable to encode to selector");
@@ -271,7 +271,7 @@ async fn case() -> anyhow::Result<()> {
             // since i256 is not supported by contract-metadata we need to manually supply the selector and encode its inputs
             let mut sel = hex::decode("d6435f25").expect("unable to decode selector");
 
-            oper::mul.encode_to(&mut sel);
+            Oper::Mul.encode_to(&mut sel);
             U256::from_dec_str("1000")
                 .map(|o| o.encode_to(&mut sel))
                 .expect("unable to encode to selector");
@@ -291,7 +291,7 @@ async fn case() -> anyhow::Result<()> {
             // since i256 is not supported by contract-metadata we need to manually supply the selector and encode its inputs
             let mut sel = hex::decode("d6435f25").expect("unable to decode selector");
 
-            oper::div.encode_to(&mut sel);
+            Oper::Div.encode_to(&mut sel);
             U256::from_dec_str("1000")
                 .map(|o| o.encode_to(&mut sel))
                 .expect("unable to encode to selector");
@@ -311,7 +311,7 @@ async fn case() -> anyhow::Result<()> {
             // since i256 is not supported by contract-metadata we need to manually supply the selector and encode its inputs
             let mut sel = hex::decode("d6435f25").expect("unable to decode selector");
 
-            oper::r#mod.encode_to(&mut sel);
+            Oper::Mod.encode_to(&mut sel);
             U256::from_dec_str("1000")
                 .map(|o| o.encode_to(&mut sel))
                 .expect("unable to encode to selector");
@@ -330,7 +330,7 @@ async fn case() -> anyhow::Result<()> {
             // since i256 is not supported by contract-metadata we need to manually supply the selector and encode its inputs
             let mut sel = hex::decode("d6435f25").expect("unable to decode selector");
 
-            oper::shl.encode_to(&mut sel);
+            Oper::Shl.encode_to(&mut sel);
             (!U256::from_dec_str("10000000000000").unwrap() + U256::one()).encode_to(&mut sel);
 
             U256::from_dec_str("8")
@@ -348,7 +348,7 @@ async fn case() -> anyhow::Result<()> {
             // since i256 is not supported by contract-metadata we need to manually supply the selector and encode its inputs
             let mut sel = hex::decode("d6435f25").expect("unable to decode selector");
 
-            oper::shr.encode_to(&mut sel);
+            Oper::Shr.encode_to(&mut sel);
             (!U256::from_dec_str("10000000000000").unwrap() + U256::one()).encode_to(&mut sel);
 
             U256::from_dec_str("8")
@@ -370,7 +370,7 @@ async fn case() -> anyhow::Result<()> {
             // since i256 is not supported by contract-metadata we need to manually supply the selector and encode its inputs
             let mut sel = hex::decode("b446eacd").expect("unable to decode selector");
 
-            oper::add.encode_to(&mut sel);
+            Oper::Add.encode_to(&mut sel);
             U256::from_dec_str("1000")
                 .map(|o| o.encode_to(&mut sel))
                 .expect("unable to encode to selector");
@@ -389,7 +389,7 @@ async fn case() -> anyhow::Result<()> {
             // since i256 is not supported by contract-metadata we need to manually supply the selector and encode its inputs
             let mut sel = hex::decode("b446eacd").expect("unable to decode selector");
 
-            oper::sub.encode_to(&mut sel);
+            Oper::Sub.encode_to(&mut sel);
             U256::from_dec_str("1000")
                 .map(|o| o.encode_to(&mut sel))
                 .expect("unable to encode to selector");
@@ -408,7 +408,7 @@ async fn case() -> anyhow::Result<()> {
             // since i256 is not supported by contract-metadata we need to manually supply the selector and encode its inputs
             let mut sel = hex::decode("b446eacd").expect("unable to decode selector");
 
-            oper::mul.encode_to(&mut sel);
+            Oper::Mul.encode_to(&mut sel);
             U256::from_dec_str("123456789")
                 .map(|o| o.encode_to(&mut sel))
                 .expect("unable to encode to selector");
@@ -427,7 +427,7 @@ async fn case() -> anyhow::Result<()> {
             // since i256 is not supported by contract-metadata we need to manually supply the selector and encode its inputs
             let mut sel = hex::decode("b446eacd").expect("unable to decode selector");
 
-            oper::div.encode_to(&mut sel);
+            Oper::Div.encode_to(&mut sel);
             U256::from_dec_str("123456789")
                 .map(|o| o.encode_to(&mut sel))
                 .expect("unable to encode to selector");
@@ -446,7 +446,7 @@ async fn case() -> anyhow::Result<()> {
             // since i256 is not supported by contract-metadata we need to manually supply the selector and encode its inputs
             let mut sel = hex::decode("b446eacd").expect("unable to decode selector");
 
-            oper::r#mod.encode_to(&mut sel);
+            Oper::Mod.encode_to(&mut sel);
             U256::from_dec_str("123456789")
                 .map(|o| o.encode_to(&mut sel))
                 .expect("unable to encode to selector");
@@ -465,7 +465,7 @@ async fn case() -> anyhow::Result<()> {
             // since i256 is not supported by contract-metadata we need to manually supply the selector and encode its inputs
             let mut sel = hex::decode("b446eacd").expect("unable to decode selector");
 
-            oper::pow.encode_to(&mut sel);
+            Oper::Pow.encode_to(&mut sel);
             U256::from_dec_str("123456789")
                 .map(|o| o.encode_to(&mut sel))
                 .expect("unable to encode to selector");
@@ -488,7 +488,7 @@ async fn case() -> anyhow::Result<()> {
             // since i256 is not supported by contract-metadata we need to manually supply the selector and encode its inputs
             let mut sel = hex::decode("b446eacd").expect("unable to decode selector");
 
-            oper::shl.encode_to(&mut sel);
+            Oper::Shl.encode_to(&mut sel);
             U256::from_dec_str("10000000000000")
                 .map(|o| o.encode_to(&mut sel))
                 .expect("unable to encode to selector");
@@ -507,7 +507,7 @@ async fn case() -> anyhow::Result<()> {
             // since i256 is not supported by contract-metadata we need to manually supply the selector and encode its inputs
             let mut sel = hex::decode("b446eacd").expect("unable to decode selector");
 
-            oper::shr.encode_to(&mut sel);
+            Oper::Shr.encode_to(&mut sel);
             U256::from_dec_str("10000000000000")
                 .map(|o| o.encode_to(&mut sel))
                 .expect("unable to encode to selector");

--- a/integration/subxt-tests/src/cases/store.rs
+++ b/integration/subxt-tests/src/cases/store.rs
@@ -46,11 +46,11 @@ async fn case() -> anyhow::Result<()> {
     assert_eq!(res, (0, 0, 0, U256::zero()));
 
     #[derive(Encode, Decode, PartialEq, Eq, Debug)]
-    enum enum_bar {
-        bar1,
-        bar2,
-        bar3,
-        bar4,
+    enum Bar {
+        Bar1,
+        Bar2,
+        Bar3,
+        Bar4,
     }
 
     let selector = transcoder.encode::<_, String>("get_values2", [])?;
@@ -64,7 +64,7 @@ async fn case() -> anyhow::Result<()> {
     .execute(&api)
     .await
     .and_then(|e| {
-        <(U256, String, Vec<u8>, [u8; 4], enum_bar)>::decode(&mut e.return_value.as_bytes_ref())
+        <(U256, String, Vec<u8>, [u8; 4], Bar)>::decode(&mut e.return_value.as_bytes_ref())
             .map_err(Into::into)
     })?;
 
@@ -75,7 +75,7 @@ async fn case() -> anyhow::Result<()> {
             "".into(),
             hex::decode("b00b1e")?,
             <_>::from_hex("00000000")?,
-            enum_bar::bar1
+            Bar::Bar1
         )
     );
 
@@ -127,7 +127,7 @@ async fn case() -> anyhow::Result<()> {
     .execute(&api)
     .await
     .and_then(|e| {
-        <(U256, String, Vec<u8>, [u8; 4], enum_bar)>::decode(&mut e.return_value.as_bytes_ref())
+        <(U256, String, Vec<u8>, [u8; 4], Bar)>::decode(&mut e.return_value.as_bytes_ref())
             .map_err(Into::into)
     })?;
 
@@ -138,7 +138,7 @@ async fn case() -> anyhow::Result<()> {
             "the course of true love never did run smooth".into(),
             hex::decode("b00b1e")?,
             <_>::from_hex("41424344")?,
-            enum_bar::bar2
+            Bar::Bar2
         )
     );
 
@@ -190,7 +190,7 @@ async fn case() -> anyhow::Result<()> {
     .execute(&api)
     .await
     .and_then(|e| {
-        <(U256, String, Vec<u8>, [u8; 4], enum_bar)>::decode(&mut e.return_value.as_bytes_ref())
+        <(U256, String, Vec<u8>, [u8; 4], Bar)>::decode(&mut e.return_value.as_bytes_ref())
             .map_err(Into::into)
     })?;
 
@@ -201,7 +201,7 @@ async fn case() -> anyhow::Result<()> {
             "".into(),
             hex::decode("b0ff1e")?,
             <_>::from_hex("61626364")?,
-            enum_bar::bar4
+            Bar::Bar4
         )
     );
 

--- a/integration/subxt-tests/src/cases/structs.rs
+++ b/integration/subxt-tests/src/cases/structs.rs
@@ -43,25 +43,25 @@ async fn case() -> anyhow::Result<()> {
     let selector = transcoder.encode::<_, String>("get_both_foos", [])?;
 
     #[derive(Encode, Decode, Eq, PartialEq, Debug)]
-    enum enum_bar {
-        bar1,
-        bar2,
-        bar3,
-        bar4,
+    enum EnumBar {
+        Bar1,
+        Bar2,
+        Bar3,
+        Bar4,
     }
 
     #[derive(Encode, Decode, Eq, PartialEq, Debug)]
-    struct struct_foo {
-        f1: enum_bar,
+    struct StructFoo {
+        f1: EnumBar,
         f2: Vec<u8>,
         f3: i64,
         f4: [u8; 3],
         f5: String,
-        f6: inner_foo,
+        f6: InnerFoo,
     }
 
     #[derive(Encode, Decode, Eq, PartialEq, Debug)]
-    struct inner_foo {
+    struct InnerFoo {
         in1: bool,
         in2: String,
     }
@@ -74,27 +74,25 @@ async fn case() -> anyhow::Result<()> {
     }
     .execute(&api)
     .await
-    .and_then(|v| {
-        <(struct_foo, struct_foo)>::decode(&mut &v.return_value[..]).map_err(Into::into)
-    })?;
+    .and_then(|v| <(StructFoo, StructFoo)>::decode(&mut &v.return_value[..]).map_err(Into::into))?;
 
     assert_eq!(rs,
      (
-        struct_foo { f1: enum_bar::bar2, f2: hex::decode("446f6e277420636f756e7420796f757220636869636b656e73206265666f72652074686579206861746368")?, f3: -102, f4: <_>::from_hex("edaeda")?, f5: "You can't have your cake and eat it too".into(), f6: inner_foo { in1: true, in2: "There are other fish in the sea".into() } },
-        struct_foo { f1: enum_bar::bar1, f2: vec![], f3: 0, f4: <_>::from_hex("000000")?, f5: String::new(), f6:inner_foo { in1: false, in2: "".into()} } 
+        StructFoo { f1: EnumBar::Bar2, f2: hex::decode("446f6e277420636f756e7420796f757220636869636b656e73206265666f72652074686579206861746368")?, f3: -102, f4: <_>::from_hex("edaeda")?, f5: "You can't have your cake and eat it too".into(), f6: InnerFoo { in1: true, in2: "There are other fish in the sea".into() } },
+        StructFoo { f1: EnumBar::Bar1, f2: vec![], f3: 0, f4: <_>::from_hex("000000")?, f5: String::new(), f6:InnerFoo { in1: false, in2: "".into()} }
      )
     );
 
     // TODO: find a way to generate signature with enum input
     let mut selector = hex::decode("9c408762").unwrap();
 
-    let mut input = struct_foo {
-        f1: enum_bar::bar2,
+    let mut input = StructFoo {
+        f1: EnumBar::Bar2,
         f2: hex::decode("b52b073595ccb35eaebb87178227b779")?,
         f3: -123112321,
         f4: <_>::from_hex("123456")?,
         f5: "Barking up the wrong tree".into(),
-        f6: inner_foo {
+        f6: InnerFoo {
             in1: true,
             in2: "Drive someone up the wall".into(),
         },
@@ -124,7 +122,7 @@ async fn case() -> anyhow::Result<()> {
     }
     .execute(&api)
     .await
-    .and_then(|v| <struct_foo>::decode(&mut &v.return_value[..]).map_err(Into::into))?;
+    .and_then(|v| <StructFoo>::decode(&mut &v.return_value[..]).map_err(Into::into))?;
 
     assert_eq!(rs, input);
 
@@ -138,13 +136,11 @@ async fn case() -> anyhow::Result<()> {
     }
     .execute(&api)
     .await
-    .and_then(|v| {
-        <(struct_foo, struct_foo)>::decode(&mut &v.return_value[..]).map_err(Into::into)
-    })?;
+    .and_then(|v| <(StructFoo, StructFoo)>::decode(&mut &v.return_value[..]).map_err(Into::into))?;
 
     assert_eq!(rs,
      (
-        struct_foo { f1: enum_bar::bar2, f2: hex::decode("446f6e277420636f756e7420796f757220636869636b656e73206265666f72652074686579206861746368")?, f3: -102, f4: <_>::from_hex("edaeda")?, f5: "You can't have your cake and eat it too".into(), f6: inner_foo { in1: true, in2: "There are other fish in the sea".into() } },
+        StructFoo { f1: EnumBar::Bar2, f2: hex::decode("446f6e277420636f756e7420796f757220636869636b656e73206265666f72652074686579206861746368")?, f3: -102, f4: <_>::from_hex("edaeda")?, f5: "You can't have your cake and eat it too".into(), f6: InnerFoo { in1: true, in2: "There are other fish in the sea".into() } },
         input
 
      )
@@ -171,17 +167,17 @@ async fn case() -> anyhow::Result<()> {
     }
     .execute(&api)
     .await
-    .and_then(|v| <struct_foo>::decode(&mut &v.return_value[..]).map_err(Into::into))?;
+    .and_then(|v| <StructFoo>::decode(&mut &v.return_value[..]).map_err(Into::into))?;
 
     assert_eq!(
         rs,
-        struct_foo {
-            f1: enum_bar::bar2,
+        StructFoo {
+            f1: EnumBar::Bar2,
             f2: hex::decode("b52b073595ccb35eaebb87178227b779")?,
             f3: -123112321,
             f4: <_>::from_hex("123456")?,
             f5: "Barking up the wrong tree".into(),
-            f6: inner_foo {
+            f6: InnerFoo {
                 in1: true,
                 in2: "nah".into()
             }
@@ -209,19 +205,19 @@ async fn case() -> anyhow::Result<()> {
     }
     .execute(&api)
     .await
-    .and_then(|v| <struct_foo>::decode(&mut &v.return_value[..]).map_err(Into::into))?;
+    .and_then(|v| <StructFoo>::decode(&mut &v.return_value[..]).map_err(Into::into))?;
 
     assert_eq!(
         rs,
-        struct_foo {
-            f1: enum_bar::bar4,
+        StructFoo {
+            f1: EnumBar::Bar4,
             f2: hex::decode(
                 "537570657263616c6966726167696c697374696365787069616c69646f63696f7573"
             )?,
             f3: 64927,
             f4: <_>::from_hex("e282ac")?,
             f5: "Antidisestablishmentarianism".into(),
-            f6: inner_foo {
+            f6: InnerFoo {
                 in1: true,
                 in2: "Pseudopseudohypoparathyroidism".into()
             }

--- a/integration/subxt-tests/src/cases/uniswapv2_factory.rs
+++ b/integration/subxt-tests/src/cases/uniswapv2_factory.rs
@@ -251,7 +251,7 @@ impl MockWorld {
                         "new",
                         [format!(
                             "0x{}",
-                            hex::encode(&sp_keyring::AccountKeyring::Alice.to_account_id())
+                            hex::encode(sp_keyring::AccountKeyring::Alice.to_account_id())
                         )],
                     )
                     .unwrap()

--- a/integration/subxt-tests/src/cases/uniswapv2_pair.rs
+++ b/integration/subxt-tests/src/cases/uniswapv2_pair.rs
@@ -29,7 +29,7 @@ async fn mint() -> anyhow::Result<()> {
             &api,
             sp_keyring::AccountKeyring::Alice,
             0,
-            &|t: &ContractMessageTranscoder| {
+            &|_: &ContractMessageTranscoder| {
                 let mut s = keccak_256(b"transfer(address,uint)")[..4].to_vec();
                 w.pair.address.clone().unwrap().encode_to(&mut s);
                 U256::from(10_u8).pow(18_u8.into()).encode_to(&mut s);
@@ -44,7 +44,7 @@ async fn mint() -> anyhow::Result<()> {
             &api,
             sp_keyring::AccountKeyring::Alice,
             0,
-            &|t: &ContractMessageTranscoder| {
+            &|_: &ContractMessageTranscoder| {
                 let mut s = keccak_256(b"transfer(address,uint)")[..4].to_vec();
                 w.pair.address.clone().unwrap().encode_to(&mut s);
                 U256::from(10_u8)
@@ -159,7 +159,7 @@ async fn mint() -> anyhow::Result<()> {
         U256::from(10_u8).pow(18_u8.into()).mul(U256::from(4_u8))
     );
 
-    let (r0, r1, block) = w
+    let (r0, r1, _) = w
         .pair
         .try_call(
             &api,
@@ -191,8 +191,6 @@ async fn swap_token0() -> anyhow::Result<()> {
     let token1_amount = U256::from(10_u8).pow(U256::from(19_u8));
 
     let w = MockWorld::init(&api).await?;
-
-    let min_liquidity: U256 = U256::from(1000_u32);
 
     w.add_liquitity(&api, &token0_amount, &token1_amount)
         .await?;
@@ -252,11 +250,7 @@ async fn swap_token0() -> anyhow::Result<()> {
             &|t: &ContractMessageTranscoder| t.encode::<_, String>("getReserves", []).unwrap(),
         )
         .await
-        .and_then(|v| {
-            let t = &w.pair.transcoder;
-
-            <(u128, u128, u32)>::decode(&mut &v[..]).map_err(Into::into)
-        })?;
+        .and_then(|v| <(u128, u128, u32)>::decode(&mut &v[..]).map_err(Into::into))?;
 
     assert_eq!(U256::from(out.0), token0_amount + swap_amount);
     assert_eq!(U256::from(out.1), token1_amount - expected_output);
@@ -383,8 +377,6 @@ async fn swap_token1() -> anyhow::Result<()> {
     let token1_amount = U256::from(10_u8).pow(U256::from(19_u8));
 
     let w = MockWorld::init(&api).await?;
-
-    let min_liquidity: U256 = U256::from(1000_u32);
 
     w.add_liquitity(&api, &token0_amount, &token1_amount)
         .await?;
@@ -777,7 +769,7 @@ impl MockWorld {
                         "new",
                         [format!(
                             "0x{}",
-                            hex::encode(&sp_keyring::AccountKeyring::Alice.to_account_id())
+                            hex::encode(sp_keyring::AccountKeyring::Alice.to_account_id())
                         )],
                     )
                     .unwrap()
@@ -860,7 +852,7 @@ impl MockWorld {
             .await
             .and_then(|v| <AccountId32>::decode(&mut &v[..]).map_err(Into::into))?;
 
-        pair = pair.from_addr(pair_addr)?;
+        pair = pair.new_with_addr(pair_addr)?;
 
         let token_0_addr = pair
             .try_call(
@@ -897,7 +889,7 @@ impl MockWorld {
                 api,
                 sp_keyring::AccountKeyring::Alice,
                 0,
-                &|t: &ContractMessageTranscoder| {
+                &|_: &ContractMessageTranscoder| {
                     let mut s = keccak_256(b"transfer(address,uint)")[..4].to_vec();
                     self.pair.address.clone().unwrap().encode_to(&mut s);
                     amount_a.encode_to(&mut s);
@@ -911,7 +903,7 @@ impl MockWorld {
                 api,
                 sp_keyring::AccountKeyring::Alice,
                 0,
-                &|t: &ContractMessageTranscoder| {
+                &|_: &ContractMessageTranscoder| {
                     let mut s = keccak_256(b"transfer(address,uint)")[..4].to_vec();
                     self.pair.address.clone().unwrap().encode_to(&mut s);
                     amount_b.encode_to(&mut s);
@@ -925,7 +917,7 @@ impl MockWorld {
                 api,
                 sp_keyring::AccountKeyring::Alice,
                 0,
-                &|t: &ContractMessageTranscoder| {
+                &|_: &ContractMessageTranscoder| {
                     let mut s = keccak_256(b"mint(address)")[..4].to_vec();
                     sp_keyring::AccountKeyring::Alice
                         .to_account_id()

--- a/integration/subxt-tests/src/lib.rs
+++ b/integration/subxt-tests/src/lib.rs
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
+#![allow(unused_imports)]
+#![allow(dead_code)]
 
 use contract_transcode::ContractMessageTranscoder;
 
@@ -429,7 +431,7 @@ impl Contract {
         })
     }
 
-    pub fn from_addr(&self, address: AccountId32) -> anyhow::Result<Self> {
+    pub fn new_with_addr(&self, address: AccountId32) -> anyhow::Result<Self> {
         let mut out = Contract::new(self.path)?;
 
         out.address.replace(address);
@@ -468,7 +470,7 @@ impl Contract {
         .await?;
         let addr = deployed.contract_address;
 
-        self.address.replace(addr.clone());
+        self.address.replace(addr);
 
         Ok(deployed.events)
     }


### PR DESCRIPTION
If you don't have a substrate node running you still get errors. I don't know what to do about that.

I've tried putting it in `#[cfg(test)]` which didn't help.