### PR TITLE
Access payer account using `tx.accounts.account_name`

### DIFF
--- a/docs/targets/solana.rst
+++ b/docs/targets/solana.rst
@@ -354,7 +354,7 @@ uint64 ``lamports``
     The lamports of the accounts. This field can be modified, however the lamports need to be
     balanced for all accounts by the end of the transaction.
 
-bytes ``data```
+bytes ``data``
     The account data. This field can be modified, but use with caution.
 
 address ``owner``
@@ -473,3 +473,11 @@ such a constructor.
 
 .. include:: ../examples/solana/payer_annotation.sol
   :code: solidity
+
+
+Accessing accounts' data
+________________________
+
+Accounts declared on a constructor using the ``@payer`` annotation are available for access inside it.
+For an account declared as ``@payer(funder)``, the access follows the syntax ``tx.accounts.funder``, which returns
+the :ref:`AccountInfo builtin struct <account_info>`.

--- a/integration/solana/create_contract.sol
+++ b/integration/solana/create_contract.sol
@@ -48,6 +48,8 @@ contract Child {
     @payer(payer)
     @space(511 + 7)
     constructor() {
+        assert(tx.accounts.payer.is_signer);
+        assert(tx.accounts.payer.is_writable);
         print("In child constructor");
     }
 

--- a/src/codegen/cfg.rs
+++ b/src/codegen/cfg.rs
@@ -189,6 +189,14 @@ pub enum Instr {
     /// be removed. We only have this so we can pass evm code through sema/codegen, which is used
     /// by the language server and the ethereum solidity tests.
     Unimplemented { reachable: bool },
+    /// This instruction serves to track account accesses through 'tx.accounts.my_account'
+    /// on Solana, and has no emit implementation. It is exchanged by the proper
+    /// Expression::Subscript at solana_accounts/account_management.rs
+    AccountAccess {
+        loc: pt::Loc,
+        var_no: usize,
+        name: String,
+    },
 }
 
 /// This struct defined the return codes that we send to the execution environment when we return
@@ -348,6 +356,7 @@ impl Instr {
             | Instr::Nop
             | Instr::ReturnCode { .. }
             | Instr::Branch { .. }
+            | Instr::AccountAccess { .. }
             | Instr::PopMemory { .. }
             | Instr::Unimplemented { .. } => {}
         }
@@ -1351,6 +1360,10 @@ impl ControlFlowGraph {
 
             Instr::Unimplemented { .. } => {
                 "unimplemented".into()
+            }
+
+            Instr::AccountAccess { .. } => {
+                unreachable!("Instr::AccountAccess shall never be in the final CFG")
             }
         }
     }

--- a/src/codegen/expression.rs
+++ b/src/codegen/expression.rs
@@ -1098,7 +1098,7 @@ pub fn expression(
                 var_no: var,
             }
         }
-        ast::Expression::NamedSubscript {
+        ast::Expression::NamedMember {
             loc, array, name, ..
         } => {
             // This expression should only exist for Solana's AccountInfo array

--- a/src/codegen/solana_accounts/account_collection.rs
+++ b/src/codegen/solana_accounts/account_collection.rs
@@ -451,6 +451,7 @@ fn check_instruction(instr: &Instr, data: &mut RecurseData) {
                 expr.recurse(data, check_expression);
             }
         }
+        Instr::AccountAccess { .. } => (),
     }
 }
 

--- a/src/codegen/solana_accounts/account_management.rs
+++ b/src/codegen/solana_accounts/account_management.rs
@@ -14,7 +14,11 @@ use std::collections::{HashSet, VecDeque};
 /// AccountMeta array with all the accounts the constructor needs.
 pub(crate) fn manage_contract_accounts(contract_no: usize, ns: &mut Namespace) {
     let contract_functions = ns.contracts[contract_no].functions.clone();
+    let mut constructor_no = None;
     for function_no in &contract_functions {
+        if ns.functions[*function_no].is_constructor() {
+            constructor_no = Some(*function_no);
+        }
         let cfg_no = ns.contracts[contract_no]
             .all_functions
             .get(function_no)
@@ -24,6 +28,15 @@ pub(crate) fn manage_contract_accounts(contract_no: usize, ns: &mut Namespace) {
             &mut ns.contracts[contract_no].cfg[cfg_no],
             &ns.functions,
             *function_no,
+        );
+    }
+
+    if let Some(constructor) = constructor_no {
+        let dispatch = ns.contracts[contract_no].dispatch_no;
+        traverse_cfg(
+            &mut ns.contracts[contract_no].cfg[dispatch],
+            &ns.functions,
+            constructor,
         );
     }
 }
@@ -98,7 +111,7 @@ fn process_instruction(instr: &mut Instr, functions: &[Function], ast_no: usize)
                     .borrow()
                     .get_index_of(name)
                     .unwrap();
-                let ptr_to_address = index_accounts_vector(account_index);
+                let ptr_to_address = accounts_vector_key_at_index(account_index);
                 account_metas.push(account_meta_literal(
                     ptr_to_address,
                     account.is_signer,
@@ -118,11 +131,54 @@ fn process_instruction(instr: &mut Instr, functions: &[Function], ast_no: usize)
 
         *address = None;
         *accounts = Some(metas_vector);
+    } else if let Instr::AccountAccess { loc, name, var_no } = instr {
+        // This could have been an Expression::AccountAccess if we had a three-address form.
+        // The amount of code necessary to traverse all Instructions and all expressions recursively
+        // (Expressions form a tree) makes the usage of Expression::AccountAccess too burdensome.
+
+        // Alternatively, we can create a codegen::Expression::AccountAccess when we have the
+        // new SSA IR complete.
+        let account_index = functions[ast_no]
+            .solana_accounts
+            .borrow()
+            .get_index_of(name)
+            .unwrap();
+        let expr = index_accounts_vector(account_index);
+
+        *instr = Instr::Set {
+            loc: *loc,
+            res: *var_no,
+            expr,
+        };
     }
 }
 
 /// This function automates the process of retrieving 'tx.accounts[index].key'.
-pub(crate) fn index_accounts_vector(index: usize) -> Expression {
+pub(crate) fn accounts_vector_key_at_index(index: usize) -> Expression {
+    let payer_info = index_accounts_vector(index);
+
+    retrieve_key_from_account_info(payer_info)
+}
+
+/// This function retrieves the account key from the AccountInfo struct.
+/// The argument should be of type 'Type::Ref(Type::Struct(StructType::AccountInfo))'.
+pub(crate) fn retrieve_key_from_account_info(account_info: Expression) -> Expression {
+    let address = Expression::StructMember {
+        loc: Loc::Codegen,
+        ty: Type::Ref(Box::new(Type::Ref(Box::new(Type::Address(false))))),
+        expr: Box::new(account_info),
+        member: 0,
+    };
+
+    Expression::Load {
+        loc: Loc::Codegen,
+        ty: Type::Ref(Box::new(Type::Address(false))),
+        expr: Box::new(address),
+    }
+}
+
+/// This function automates the process of retrieving 'tx.accounts[index]'.
+fn index_accounts_vector(index: usize) -> Expression {
     let accounts_vector = Expression::Builtin {
         loc: Loc::Codegen,
         tys: vec![Type::Array(
@@ -133,7 +189,7 @@ pub(crate) fn index_accounts_vector(index: usize) -> Expression {
         args: vec![],
     };
 
-    let payer_info = Expression::Subscript {
+    Expression::Subscript {
         loc: Loc::Codegen,
         ty: Type::Ref(Box::new(Type::Struct(StructType::AccountInfo))),
         array_ty: Type::Array(
@@ -146,19 +202,6 @@ pub(crate) fn index_accounts_vector(index: usize) -> Expression {
             ty: Type::Uint(32),
             value: BigInt::from(index),
         }),
-    };
-
-    let address = Expression::StructMember {
-        loc: Loc::Codegen,
-        ty: Type::Ref(Box::new(Type::Ref(Box::new(Type::Address(false))))),
-        expr: Box::new(payer_info),
-        member: 0,
-    };
-
-    Expression::Load {
-        loc: Loc::Codegen,
-        ty: Type::Ref(Box::new(Type::Address(false))),
-        expr: Box::new(address),
     }
 }
 

--- a/src/codegen/subexpression_elimination/instruction.rs
+++ b/src/codegen/subexpression_elimination/instruction.rs
@@ -196,6 +196,7 @@ impl<'a, 'b: 'a> AvailableExpressionSet<'a> {
             | Instr::ReturnCode { .. }
             | Instr::Branch { .. }
             | Instr::PopMemory { .. }
+            | Instr::AccountAccess { .. }
             | Instr::Unimplemented { .. } => {}
         }
     }

--- a/src/codegen/vector_to_slice.rs
+++ b/src/codegen/vector_to_slice.rs
@@ -118,6 +118,7 @@ fn find_writable_vectors(
             | Instr::AssertFailure { .. }
             | Instr::ReturnData { .. }
             | Instr::ValueTransfer { .. }
+            | Instr::AccountAccess { .. }
             | Instr::Unimplemented { .. } => {
                 apply_transfers(&block.transfers[instr_no], vars, writable);
             }

--- a/src/emit/instructions.rs
+++ b/src/emit/instructions.rs
@@ -1103,6 +1103,9 @@ pub(super) fn process_instruction<'a, T: TargetRuntime<'a> + ?Sized>(
         }
 
         Instr::Unimplemented { .. } => unimplemented!(),
+        Instr::AccountAccess { .. } => {
+            unreachable!("Instr::AccountAccess shall never appear in the CFG")
+        }
     }
 }
 

--- a/src/sema/ast.rs
+++ b/src/sema/ast.rs
@@ -1072,7 +1072,7 @@ pub enum Expression {
         array: Box<Expression>,
         index: Box<Expression>,
     },
-    NamedSubscript {
+    NamedMember {
         loc: pt::Loc,
         ty: Type,
         array: Box<Expression>,
@@ -1426,7 +1426,7 @@ impl CodeLocation for Expression {
             | Expression::FormatString { loc, format: _ }
             | Expression::InterfaceId { loc, .. }
             | Expression::And { loc, .. }
-            | Expression::NamedSubscript { loc, .. }
+            | Expression::NamedMember { loc, .. }
             | Expression::UserDefinedOperator { loc, .. } => *loc,
         }
     }

--- a/src/sema/ast.rs
+++ b/src/sema/ast.rs
@@ -1072,6 +1072,12 @@ pub enum Expression {
         array: Box<Expression>,
         index: Box<Expression>,
     },
+    NamedSubscript {
+        loc: pt::Loc,
+        ty: Type,
+        array: Box<Expression>,
+        name: String,
+    },
     StructMember {
         loc: pt::Loc,
         ty: Type,
@@ -1420,6 +1426,7 @@ impl CodeLocation for Expression {
             | Expression::FormatString { loc, format: _ }
             | Expression::InterfaceId { loc, .. }
             | Expression::And { loc, .. }
+            | Expression::NamedSubscript { loc, .. }
             | Expression::UserDefinedOperator { loc, .. } => *loc,
         }
     }
@@ -1457,24 +1464,28 @@ impl CodeLocation for Instr {
                 _ => expr.loc(),
             },
             Instr::Call { args, .. } if args.is_empty() => pt::Loc::Codegen,
-            Instr::Call { args, .. } => args[0].loc(),
             Instr::Return { value } if value.is_empty() => pt::Loc::Codegen,
-            Instr::Return { value } => value[0].loc(),
-            Instr::EmitEvent { data, .. } => data.loc(),
-            Instr::BranchCond { cond, .. } => cond.loc(),
-            Instr::Store { dest, .. } => dest.loc(),
-            Instr::SetStorageBytes { storage, .. }
-            | Instr::PushStorage { storage, .. }
-            | Instr::PopStorage { storage, .. }
-            | Instr::LoadStorage { storage, .. }
-            | Instr::ClearStorage { storage, .. } => storage.loc(),
-            Instr::ExternalCall { value, .. } | Instr::SetStorage { value, .. } => value.loc(),
-            Instr::PushMemory { value, .. } => value.loc(),
-            Instr::Constructor { gas, .. } => gas.loc(),
-            Instr::ValueTransfer { address, .. } => address.loc(),
-            Instr::SelfDestruct { recipient } => recipient.loc(),
-            Instr::WriteBuffer { buf, .. } => buf.loc(),
-            Instr::Print { expr } => expr.loc(),
+            Instr::Call { args: arr, .. } | Instr::Return { value: arr } => arr[0].loc(),
+            Instr::EmitEvent { data: expr, .. }
+            | Instr::BranchCond { cond: expr, .. }
+            | Instr::Store { dest: expr, .. }
+            | Instr::SetStorageBytes { storage: expr, .. }
+            | Instr::PushStorage { storage: expr, .. }
+            | Instr::PopStorage { storage: expr, .. }
+            | Instr::LoadStorage { storage: expr, .. }
+            | Instr::ClearStorage { storage: expr, .. }
+            | Instr::ExternalCall { value: expr, .. }
+            | Instr::SetStorage { value: expr, .. }
+            | Instr::Constructor { gas: expr, .. }
+            | Instr::ValueTransfer { address: expr, .. }
+            | Instr::SelfDestruct { recipient: expr }
+            | Instr::WriteBuffer { buf: expr, .. }
+            | Instr::Switch { cond: expr, .. }
+            | Instr::ReturnData { data: expr, .. }
+            | Instr::Print { expr } => expr.loc(),
+
+            Instr::PushMemory { value: expr, .. } => expr.loc(),
+
             Instr::MemCopy {
                 source,
                 destination,
@@ -1483,14 +1494,14 @@ impl CodeLocation for Instr {
                 pt::Loc::File(_, _, _) => source.loc(),
                 _ => destination.loc(),
             },
-            Instr::Switch { cond, .. } => cond.loc(),
-            Instr::ReturnData { data, .. } => data.loc(),
             Instr::Branch { .. }
             | Instr::ReturnCode { .. }
             | Instr::Nop
             | Instr::AssertFailure { .. }
             | Instr::PopMemory { .. }
             | Instr::Unimplemented { .. } => pt::Loc::Codegen,
+
+            Instr::AccountAccess { loc, .. } => *loc,
         }
     }
 }

--- a/src/sema/dotgraphviz.rs
+++ b/src/sema/dotgraphviz.rs
@@ -1436,7 +1436,7 @@ impl Dot {
                     self.add_expression(expr, func, ns, node, format!("entry #{no}"));
                 }
             }
-            Expression::NamedSubscript {
+            Expression::NamedMember {
                 loc, name, array, ..
             } => {
                 let labels = vec![

--- a/src/sema/dotgraphviz.rs
+++ b/src/sema/dotgraphviz.rs
@@ -1436,6 +1436,21 @@ impl Dot {
                     self.add_expression(expr, func, ns, node, format!("entry #{no}"));
                 }
             }
+            Expression::NamedSubscript {
+                loc, name, array, ..
+            } => {
+                let labels = vec![
+                    format!("named array access: {}", name),
+                    ns.loc_to_string(PathDisplay::FullPath, loc),
+                ];
+
+                let node = self.add_node(
+                    Node::new("named_subscript", labels),
+                    Some(parent),
+                    Some(parent_rel),
+                );
+                self.add_expression(array, func, ns, node, format!("member: {}", name));
+            }
         }
     }
 

--- a/src/sema/expression/member_access.rs
+++ b/src/sema/expression/member_access.rs
@@ -252,7 +252,7 @@ pub(super) fn member_access(
                     .borrow()
                     .contains_key(&id.name)
                 {
-                    Ok(Expression::NamedSubscript {
+                    Ok(Expression::NamedMember {
                         loc: *loc,
                         ty: Type::Ref(Box::new(Type::Struct(StructType::AccountInfo))),
                         array: Box::new(expr),

--- a/src/sema/expression/member_access.rs
+++ b/src/sema/expression/member_access.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::sema::ast::{ArrayLength, Builtin, Expression, Namespace, RetrieveType, Symbol, Type};
+use crate::sema::ast::{
+    ArrayLength, Builtin, Expression, Namespace, RetrieveType, StructType, Symbol, Type,
+};
 use crate::sema::builtin;
 use crate::sema::diagnostics::Diagnostics;
 use crate::sema::expression::constructor::circular_reference;
@@ -217,7 +219,7 @@ pub(super) fn member_access(
                 });
             }
         }
-        Type::Array(_, dim) => {
+        Type::Array(elem_ty, dim) => {
             if id.name == "length" {
                 return match dim.last().unwrap() {
                     ArrayLength::Dynamic => Ok(Expression::Builtin {
@@ -241,6 +243,27 @@ pub(super) fn member_access(
                         )
                     }
                     ArrayLength::AnyFixed => unreachable!(),
+                };
+            } else if matches!(*elem_ty, Type::Struct(StructType::AccountInfo))
+                && context.function_no.is_some()
+            {
+                return if ns.functions[context.function_no.unwrap()]
+                    .solana_accounts
+                    .borrow()
+                    .contains_key(&id.name)
+                {
+                    Ok(Expression::NamedSubscript {
+                        loc: *loc,
+                        ty: Type::Ref(Box::new(Type::Struct(StructType::AccountInfo))),
+                        array: Box::new(expr),
+                        name: id.name.clone(),
+                    })
+                } else {
+                    diagnostics.push(Diagnostic::error(
+                        id.loc,
+                        "unrecognized account".to_string(),
+                    ));
+                    Err(())
                 };
             }
         }

--- a/src/sema/expression/retrieve_type.rs
+++ b/src/sema/expression/retrieve_type.rs
@@ -50,15 +50,19 @@ impl RetrieveType for Expression {
             | Expression::PreDecrement { ty, .. }
             | Expression::PostIncrement { ty, .. }
             | Expression::PostDecrement { ty, .. }
-            | Expression::Assign { ty, .. } => ty.clone(),
-            Expression::Subscript { ty, .. } => ty.clone(),
-            Expression::ZeroExt { to, .. }
-            | Expression::SignExt { to, .. }
-            | Expression::Trunc { to, .. }
-            | Expression::CheckingTrunc { to, .. }
-            | Expression::Cast { to, .. }
-            | Expression::BytesCast { to, .. } => to.clone(),
-            Expression::StorageArrayLength { ty, .. } => ty.clone(),
+            | Expression::Assign { ty, .. }
+            | Expression::Subscript { ty, .. }
+            | Expression::ZeroExt { to: ty, .. }
+            | Expression::SignExt { to: ty, .. }
+            | Expression::Trunc { to: ty, .. }
+            | Expression::CheckingTrunc { to: ty, .. }
+            | Expression::Cast { to: ty, .. }
+            | Expression::BytesCast { to: ty, .. }
+            | Expression::UserDefinedOperator { ty, .. }
+            | Expression::InternalFunction { ty, .. }
+            | Expression::ExternalFunction { ty, .. }
+            | Expression::NamedSubscript { ty, .. }
+            | Expression::StorageArrayLength { ty, .. } => ty.clone(),
             Expression::ExternalFunctionCallRaw { .. } => {
                 panic!("two return values");
             }
@@ -76,9 +80,6 @@ impl RetrieveType for Expression {
             Expression::Constructor { contract_no, .. } => Type::Contract(*contract_no),
             Expression::InterfaceId { .. } => Type::FunctionSelector,
             Expression::FormatString { .. } => Type::String,
-            Expression::UserDefinedOperator { ty, .. }
-            | Expression::InternalFunction { ty, .. }
-            | Expression::ExternalFunction { ty, .. } => ty.clone(),
         }
     }
 }

--- a/src/sema/expression/retrieve_type.rs
+++ b/src/sema/expression/retrieve_type.rs
@@ -61,7 +61,7 @@ impl RetrieveType for Expression {
             | Expression::UserDefinedOperator { ty, .. }
             | Expression::InternalFunction { ty, .. }
             | Expression::ExternalFunction { ty, .. }
-            | Expression::NamedSubscript { ty, .. }
+            | Expression::NamedMember { ty, .. }
             | Expression::StorageArrayLength { ty, .. } => ty.clone(),
             Expression::ExternalFunctionCallRaw { .. } => {
                 panic!("two return values");

--- a/tests/codegen_testcases/solidity/constructor_with_metas.sol
+++ b/tests/codegen_testcases/solidity/constructor_with_metas.sol
@@ -10,7 +10,7 @@ contract creator {
             AccountMeta({pubkey: child, is_signer: false, is_writable: false}),
             AccountMeta({pubkey: payer, is_signer: true, is_writable: true})
         ];
-        // CHECK: constructor(no: 4) salt: value: gas:uint64 0 address: seeds: Child encoded buffer: %abi_encoded.temp.16 accounts: %metas
+        // CHECK: constructor(no: 4) salt: value: gas:uint64 0 address: seeds: Child encoded buffer: %abi_encoded.temp.17 accounts: %metas
         c = new Child{accounts: metas}(payer);
 
         c.say_hello();

--- a/tests/codegen_testcases/solidity/payer_access.sol
+++ b/tests/codegen_testcases/solidity/payer_access.sol
@@ -1,0 +1,23 @@
+// RUN: --target solana --emit cfg
+
+@program_id("Seed23VDZ9HFCfKvFwmemB6dpi25n5XjZdP52B2RUmh")
+contract Seed2 {
+
+    @payer(payer)
+    @seed("sunflower")
+    @space(23)
+    // BEGIN-CHECK: Seed2::Seed2::constructor
+    constructor(@seed bytes ss) {
+        // CHECK: ty:struct AccountInfo %temp.1 = (subscript struct AccountInfo[] (builtin Accounts ())[uint32 1])
+        // CHECK: (load (load (struct %temp.1 field 0)))
+        assert(tx.accounts.payer.key == address(this));
+        // CHECK: AccountInfo %temp.2 = (subscript struct AccountInfo[] (builtin Accounts ())[uint32 1])
+        // CHECK: (load (struct %temp.2 field 5))
+        assert(tx.accounts.payer.is_signer);
+        // CHECK: AccountInfo %temp.3 = (subscript struct AccountInfo[] (builtin Accounts ())[uint32 1])
+        // CHECK: (load (struct %temp.3 field 6))
+        assert(tx.accounts.payer.is_writable);
+        print("In Seed2 constructor");
+    }
+
+}

--- a/tests/codegen_testcases/solidity/solana_payer_account.sol
+++ b/tests/codegen_testcases/solidity/solana_payer_account.sol
@@ -5,7 +5,7 @@ contract Builder {
     Built other;
     // BEGIN-CHECK: Builder::Builder::function::build_this__address
     function build_this(address addr) external {
-        // CHECK: constructor(no: 4) salt: value: gas:uint64 0 address: seeds: Built encoded buffer: %abi_encoded.temp.17 accounts: [3] [ struct { (deref (arg #0), true, false }, struct { (load (struct (subscript struct AccountInfo[] (builtin Accounts ())[uint32 1]) field 0)), true, true }, struct { (deref address 0x0, false, false } ]
+        // CHECK: constructor(no: 4) salt: value: gas:uint64 0 address: seeds: Built encoded buffer: %abi_encoded.temp.18 accounts: [3] [ struct { (deref (arg #0), true, false }, struct { (load (struct (subscript struct AccountInfo[] (builtin Accounts ())[uint32 1]) field 0)), true, true }, struct { (deref address 0x0, false, false } ]
         other = new Built{address: addr}("my_seed");
     }
 
@@ -21,7 +21,9 @@ contract Built {
     @payer(payer_account)
     constructor(@seed bytes my_seed) {}
     // BEGIN-CHECK: solang_dispatch
-    // CHECK: ty:struct AccountMeta[2] %metas.temp.10 = [2] [ struct { (load (struct (subscript struct AccountInfo[] (builtin Accounts ())[uint32 1]) field 0)), true, true }, struct { (builtin GetAddress ()), true, true } ]
+    // CHECK: ty:struct AccountInfo %temp.11 = (subscript struct AccountInfo[] (builtin Accounts ())[uint32 1])
+	// CHECK: ty:struct AccountMeta[2] %metas.temp.10 = [2] [ struct { (load (struct %temp.11 field 0)), true, true }, struct { (builtin GetAddress ()), true, true } ]
+	
     // The account metas should have the proper index in the AccountInfo array: 1
 
     function say_this(string text) public pure {

--- a/tests/contract_testcases/solana/accounts/unrecognized_account.sol
+++ b/tests/contract_testcases/solana/accounts/unrecognized_account.sol
@@ -1,0 +1,30 @@
+@program_id("Seed23VDZ9HFCfKvFwmemB6dpi25n5XjZdP52B2RUmh")
+contract Seed2 {
+    bytes my_seed;
+
+    @payer(payer)
+    @seed("sunflower")
+    @space(23)
+    constructor(@seed bytes ss) {
+        my_seed = ss;
+        assert(tx.accounts.payer.key == address(this));
+        assert(tx.accounts.other_account.key == address(this));
+        print("In Seed2 constructor");
+    }
+
+    function foo() public returns (address) {
+        return tx.accounts.my_account.key;
+    }
+
+}
+
+contract Other {
+    constructor(address acc) {
+        assert(tx.accounts.payer.key == address(this));
+    }
+}
+
+// ---- Expect: diagnostics ----
+// error: 11:28-41: unrecognized account
+// error: 16:28-38: unrecognized account
+// error: 23:28-33: unrecognized account

--- a/tests/solana.rs
+++ b/tests/solana.rs
@@ -1476,10 +1476,11 @@ impl VirtualMachine {
     }
 
     fn constructor(&mut self, args: &[BorshToken]) {
-        self.constructor_expected(0, args)
+        let default_metas = self.default_metas();
+        self.constructor_expected(0, &default_metas, args)
     }
 
-    fn constructor_expected(&mut self, expected: u64, args: &[BorshToken]) {
+    fn constructor_expected(&mut self, expected: u64, metas: &[AccountMeta], args: &[BorshToken]) {
         self.return_data = None;
 
         let program = &self.stack[0];
@@ -1498,9 +1499,7 @@ impl VirtualMachine {
             calldata.append(&mut encoded_data);
         };
 
-        let default_metas = self.default_metas();
-
-        let res = self.execute(&default_metas, &calldata);
+        let res = self.execute(metas, &calldata);
 
         if let ProgramResult::Ok(res) = res {
             assert_eq!(res, expected);

--- a/tests/solana_tests/account_access.rs
+++ b/tests/solana_tests/account_access.rs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::borsh_encoding::BorshToken;
+use crate::{account_new, build_solidity, AccountMeta, AccountState, Pubkey};
+
+#[test]
+fn access_payer() {
+    let mut vm = build_solidity(
+        r#"
+        contract Test {
+    @payer(payer)
+    @seed("sunflower")
+    @space(23)
+    constructor(address my_payer) {
+        assert(tx.accounts.payer.key == my_payer);
+        assert(tx.accounts.payer.is_signer);
+        assert(tx.accounts.payer.is_writable);
+    }
+}
+        "#,
+    );
+    let payer = account_new();
+    vm.account_data.insert(
+        payer,
+        AccountState {
+            data: Vec::new(),
+            owner: None,
+            lamports: 10,
+        },
+    );
+
+    let metas = vec![
+        AccountMeta {
+            pubkey: Pubkey(vm.stack[0].data),
+            is_writable: true,
+            is_signer: false,
+        },
+        AccountMeta {
+            pubkey: Pubkey(payer),
+            is_writable: true,
+            is_signer: true,
+        },
+    ];
+
+    vm.constructor_expected(0, &metas, &[BorshToken::Address(payer)]);
+}

--- a/tests/solana_tests/create_contract.rs
+++ b/tests/solana_tests/create_contract.rs
@@ -171,7 +171,7 @@ fn create_contract_wrong_program_id() {
     let program = &vm.programs[0].program;
     vm.account_data.get_mut(program).unwrap().data = code;
 
-    vm.constructor_expected(7 << 32, &[]);
+    vm.constructor_expected(7 << 32, &vm.default_metas(), &[]);
 
     assert_eq!(
         vm.logs,
@@ -316,7 +316,7 @@ fn account_too_small() {
 
     vm.account_data.get_mut(&data).unwrap().data.truncate(100);
 
-    vm.constructor_expected(5 << 32, &[]);
+    vm.constructor_expected(5 << 32, &vm.default_metas(), &[]);
 }
 
 #[test]

--- a/tests/solana_tests/mod.rs
+++ b/tests/solana_tests/mod.rs
@@ -4,6 +4,7 @@ mod abi;
 mod abi_decode;
 mod abi_encode;
 mod accessor;
+mod account_access;
 mod account_info;
 mod account_serialization;
 mod arrays;


### PR DESCRIPTION
This PR creates the infrastructure for accessing accounts with `tx.accounts.account_name`. Presently, we can only access accounts declared with the `@payer` annotation, but our goal is to make this possible for all accounts declared with annotations (this is not implemented yet). 

The documentation I wrote is very terse, because my plan is to add more details when I have the `@reader`, `@mutable`, `@signer` and `@mutableSigner` implemented.