### PR TITLE
add contract author and version flags

### DIFF
--- a/docs/running.rst
+++ b/docs/running.rst
@@ -154,6 +154,17 @@ Options:
 \-\-wasm-opt
    wasm-opt passes for Wasm targets (0, 1, 2, 3, 4, s or z; see the wasm-opt help for more details).
 
+\-\-contract-authors
+   Specify authors for all contracts. If a `@author` tag is present, it will override this argument for the targeted contract.
+   For specifying multiple authors, use this format: `--contract-authors author1,author2,..`
+
+  .. note::
+
+      This will only affect the metadata in case of substrate target.
+
+\-\-version
+   Specify contracts version. According to `semver <https://semver.org/>`_ A normal version number must take the form X.Y.Z where X, Y, and Z are non-negative integers, and must not contain leading zeroes.
+
 .. warning::
 
     If multiple Solidity source files define the same contract name, you will get a single

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -163,7 +163,7 @@ Options:
       This will only affect the metadata in case of substrate target.
 
 \-\-version
-   Specify contracts version. According to `semver <https://semver.org/>`_ A normal version number must take the form X.Y.Z where X, Y, and Z are non-negative integers, and must not contain leading zeroes.
+   Specify contracts version. According to `semver <https://semver.org/>`_, a normal version number must take the form X.Y.Z where X, Y, and Z are non-negative integers, and must not contain leading zeroes.
 
 .. warning::
 

--- a/examples/polkadot/substrate_config.toml
+++ b/examples/polkadot/substrate_config.toml
@@ -1,4 +1,6 @@
 [package]
+authors = ["sesa"]
+version = "0.1.0"
 input_files = ["flipper.sol"]   # Files to be compiled. You can define multiple files as : input_files = ["file1", "file2", ..]
 contracts = ["flipper"] # Contracts to include from the compiled files
 import_path = []   

--- a/examples/solana/solana_config.toml
+++ b/examples/solana/solana_config.toml
@@ -1,4 +1,5 @@
 [package]
+version = "0.1.0"
 input_files = ["flipper.sol"]   # Files to be compiled. You can define multiple files as : input_files = ["file1", "file2", ..]
 contracts = ["flipper"] # Contracts to include from the compiled files
 import_path = []   

--- a/src/abi/anchor.rs
+++ b/src/abi/anchor.rs
@@ -33,7 +33,7 @@ pub fn discriminator(namespace: &'static str, name: &str) -> Vec<u8> {
 }
 
 /// Generate an Anchor IDL for a Solidity contract.
-pub fn generate_anchor_idl(contract_no: usize, ns: &Namespace) -> Idl {
+pub fn generate_anchor_idl(contract_no: usize, ns: &Namespace, contract_version: &str) -> Idl {
     let contract = &ns.contracts[contract_no];
     let docs = idl_docs(&contract.tags);
     let mut type_manager = TypeManager::new(ns, contract_no);
@@ -48,9 +48,7 @@ pub fn generate_anchor_idl(contract_no: usize, ns: &Namespace) -> Idl {
         .map(|id| json!({"address": id.to_base58()}));
 
     Idl {
-        version: Version::parse(env!("CARGO_PKG_VERSION"))
-            .unwrap()
-            .to_string(),
+        version: Version::parse(contract_version).unwrap().to_string(),
         name: ns.contracts[contract_no].name.clone(),
         docs,
         constants: vec![],

--- a/src/abi/mod.rs
+++ b/src/abi/mod.rs
@@ -13,6 +13,8 @@ pub fn generate_abi(
     ns: &Namespace,
     code: &[u8],
     verbose: bool,
+    default_authors: &Vec<String>,
+    version: &str,
 ) -> (String, &'static str) {
     match ns.target {
         Target::Polkadot { .. } => {
@@ -23,7 +25,7 @@ pub fn generate_abi(
                 );
             }
 
-            let metadata = polkadot::metadata(contract_no, code, ns);
+            let metadata = polkadot::metadata(contract_no, code, ns, default_authors, version);
 
             (serde_json::to_string_pretty(&metadata).unwrap(), "contract")
         }
@@ -35,7 +37,7 @@ pub fn generate_abi(
                 );
             }
 
-            let idl = anchor::generate_anchor_idl(contract_no, ns);
+            let idl = anchor::generate_anchor_idl(contract_no, ns, version);
 
             (serde_json::to_string_pretty(&idl).unwrap(), "json")
         }

--- a/src/abi/polkadot.rs
+++ b/src/abi/polkadot.rs
@@ -512,8 +512,14 @@ fn tags(contract_no: usize, tagname: &str, ns: &ast::Namespace) -> Vec<String> {
         .collect()
 }
 
-/// Generate the metadata for ink! 4.0
-pub fn metadata(contract_no: usize, code: &[u8], ns: &ast::Namespace) -> Value {
+/// Generate the metadata for Substrate 4.0
+pub fn metadata(
+    contract_no: usize,
+    code: &[u8],
+    ns: &ast::Namespace,
+    default_authors: &Vec<String>,
+    contract_version: &str,
+) -> Value {
     let hash = blake2_rfc::blake2b::blake2b(32, &[], code);
     let version = Version::parse(env!("CARGO_PKG_VERSION")).unwrap();
     let language = SourceLanguage::new(Language::Solidity, version.clone());
@@ -539,9 +545,9 @@ pub fn metadata(contract_no: usize, code: &[u8], ns: &ast::Namespace) -> Value {
     if !authors.is_empty() {
         builder.authors(authors);
     } else {
-        builder.authors(vec!["unknown"]);
+        builder.authors(default_authors);
     }
-    builder.version(Version::new(0, 0, 1));
+    builder.version(Version::parse(contract_version).unwrap());
     let contract = builder.build().unwrap();
 
     let project_json = serde_json::to_value(gen_project(contract_no, ns)).unwrap();

--- a/src/abi/tests.rs
+++ b/src/abi/tests.rs
@@ -43,13 +43,8 @@ contract caller {
 
     let mut ns = generate_namespace(src);
     codegen(&mut ns, &Options::default());
-    let idl = generate_anchor_idl(0, &ns);
-    assert_eq!(
-        idl.version,
-        Version::parse(env!("CARGO_PKG_VERSION"))
-            .unwrap()
-            .to_string()
-    );
+    let idl = generate_anchor_idl(0, &ns, "0.1.0");
+    assert_eq!(idl.version, Version::parse("0.1.0").unwrap().to_string());
     assert_eq!(idl.name, "caller");
     assert!(idl.docs.is_some());
     assert_eq!(idl.docs.as_ref().unwrap().len(), 2);
@@ -78,7 +73,7 @@ fn constants_and_types() {
     "#;
     let mut ns = generate_namespace(src);
     codegen(&mut ns, &Options::default());
-    let idl = generate_anchor_idl(0, &ns);
+    let idl = generate_anchor_idl(0, &ns, "0.1.0");
 
     assert!(idl.constants.is_empty());
 
@@ -186,7 +181,7 @@ fn instructions_and_types() {
 
     let mut ns = generate_namespace(src);
     codegen(&mut ns, &Options::default());
-    let idl = generate_anchor_idl(0, &ns);
+    let idl = generate_anchor_idl(0, &ns, "0.1.0");
 
     assert_eq!(idl.instructions.len(), 7);
 
@@ -393,7 +388,7 @@ contract caller {
     // We need this to populate Contract.emit_events
     codegen::codegen(&mut ns, &Options::default());
 
-    let idl = generate_anchor_idl(0, &ns);
+    let idl = generate_anchor_idl(0, &ns, "0.1.0");
 
     assert_eq!(idl.instructions.len(), 2);
 
@@ -548,7 +543,7 @@ fn types() {
 
     let mut ns = generate_namespace(src);
     codegen(&mut ns, &Options::default());
-    let idl = generate_anchor_idl(0, &ns);
+    let idl = generate_anchor_idl(0, &ns, "0.1.0");
 
     assert_eq!(idl.instructions.len(), 2);
 
@@ -649,7 +644,7 @@ fn constructor() {
     "#;
     let mut ns = generate_namespace(src);
     codegen(&mut ns, &Options::default());
-    let idl = generate_anchor_idl(0, &ns);
+    let idl = generate_anchor_idl(0, &ns, "0.1.0");
 
     assert_eq!(idl.name, "caller");
     assert!(idl.docs.is_none());
@@ -716,7 +711,7 @@ contract Testing {
 
     let mut ns = generate_namespace(src);
     codegen(&mut ns, &Options::default());
-    let idl = generate_anchor_idl(0, &ns);
+    let idl = generate_anchor_idl(0, &ns, "0.1.0");
 
     assert_eq!(idl.instructions.len(), 2);
 
@@ -801,7 +796,7 @@ contract Testing {
 
     let mut ns = generate_namespace(src);
     codegen(&mut ns, &Options::default());
-    let idl = generate_anchor_idl(0, &ns);
+    let idl = generate_anchor_idl(0, &ns, "0.1.0");
 
     assert_eq!(idl.instructions.len(), 3);
 
@@ -931,7 +926,7 @@ fn name_collision() {
 
     let mut ns = generate_namespace(str);
     codegen(&mut ns, &Options::default());
-    let idl = generate_anchor_idl(0, &ns);
+    let idl = generate_anchor_idl(0, &ns, "0.1.0");
 
     assert_eq!(idl.types.len(), 3);
 
@@ -1025,7 +1020,7 @@ fn double_name_collision() {
 
     let mut ns = generate_namespace(str);
     codegen(&mut ns, &Options::default());
-    let idl = generate_anchor_idl(0, &ns);
+    let idl = generate_anchor_idl(0, &ns, "0.1.0");
 
     assert_eq!(idl.types.len(), 4);
 
@@ -1126,7 +1121,7 @@ fn deduplication() {
     // We need this to populate Contract.emit_events
     codegen::codegen(&mut ns, &Options::default());
 
-    let idl = generate_anchor_idl(0, &ns);
+    let idl = generate_anchor_idl(0, &ns, "0.1.0");
 
     assert_eq!(idl.instructions.len(), 2);
     assert_eq!(idl.instructions[0].name, "new");
@@ -1230,7 +1225,7 @@ contract C {
 
     let mut ns = generate_namespace(src);
     codegen(&mut ns, &Options::default());
-    let idl = generate_anchor_idl(1, &ns);
+    let idl = generate_anchor_idl(1, &ns, "0.1.0");
 
     assert_eq!(idl.types.len(), 2);
     assert_eq!(idl.types[0].name, "D_Foo");
@@ -1249,7 +1244,7 @@ contract C {
 
     let mut ns = generate_namespace(src);
     codegen(&mut ns, &Options::default());
-    let idl = generate_anchor_idl(1, &ns);
+    let idl = generate_anchor_idl(1, &ns, "0.1.0");
 
     assert_eq!(idl.types.len(), 2);
     assert_eq!(idl.types[0].name, "Foo");
@@ -1270,7 +1265,7 @@ contract C {
 
     let mut ns = generate_namespace(src);
     codegen(&mut ns, &Options::default());
-    let idl = generate_anchor_idl(1, &ns);
+    let idl = generate_anchor_idl(1, &ns, "0.1.0");
     assert_eq!(idl.types.len(), 2);
     assert_eq!(idl.types[0].name, "Foo");
     assert_eq!(idl.types[1].name, "D_Foo");
@@ -1290,7 +1285,7 @@ contract C {
 
     let mut ns = generate_namespace(src);
     codegen(&mut ns, &Options::default());
-    let idl = generate_anchor_idl(1, &ns);
+    let idl = generate_anchor_idl(1, &ns, "0.1.0");
 
     assert_eq!(idl.types.len(), 2);
     assert_eq!(idl.types[0].name, "D_Foo");
@@ -1314,7 +1309,7 @@ contract C {
 
     let mut ns = generate_namespace(src);
     codegen(&mut ns, &Options::default());
-    let idl = generate_anchor_idl(1, &ns);
+    let idl = generate_anchor_idl(1, &ns, "0.1.0");
 
     assert_eq!(idl.types.len(), 3);
     assert_eq!(idl.types[0].name, "Foo");
@@ -1338,7 +1333,7 @@ contract C {
     "#;
     let mut ns = generate_namespace(src);
     codegen(&mut ns, &Options::default());
-    let idl = generate_anchor_idl(1, &ns);
+    let idl = generate_anchor_idl(1, &ns, "0.1.0");
 
     assert_eq!(idl.types.len(), 3);
     assert_eq!(idl.types[0].name, "Foo");
@@ -1362,7 +1357,7 @@ contract C {
     "#;
     let mut ns = generate_namespace(src);
     codegen(&mut ns, &Options::default());
-    let idl = generate_anchor_idl(1, &ns);
+    let idl = generate_anchor_idl(1, &ns, "0.1.0");
 
     assert_eq!(idl.types.len(), 3);
     assert_eq!(idl.types[0].name, "D_Foo");
@@ -1391,7 +1386,7 @@ contract C {
 
     let mut ns = generate_namespace(src);
     codegen(&mut ns, &Options::default());
-    let idl = generate_anchor_idl(1, &ns);
+    let idl = generate_anchor_idl(1, &ns, "0.1.0");
 
     assert_eq!(idl.types.len(), 4);
     assert_eq!(idl.types[0].name, "D_Foo");
@@ -1421,7 +1416,7 @@ contract C {
 
     let mut ns = generate_namespace(src);
     codegen(&mut ns, &Options::default());
-    let idl = generate_anchor_idl(1, &ns);
+    let idl = generate_anchor_idl(1, &ns, "0.1.0");
 
     assert_eq!(idl.types.len(), 4);
     assert_eq!(idl.types[0].name, "D_Foo_1");
@@ -1451,7 +1446,7 @@ contract C {
 
     let mut ns = generate_namespace(src);
     codegen(&mut ns, &Options::default());
-    let idl = generate_anchor_idl(1, &ns);
+    let idl = generate_anchor_idl(1, &ns, "0.1.0");
 
     assert_eq!(idl.types.len(), 4);
     assert_eq!(idl.types[0].name, "D_Foo");
@@ -1481,7 +1476,7 @@ contract C {
 
     let mut ns = generate_namespace(src);
     codegen(&mut ns, &Options::default());
-    let idl = generate_anchor_idl(1, &ns);
+    let idl = generate_anchor_idl(1, &ns, "0.1.0");
 
     assert_eq!(idl.types.len(), 4);
     assert_eq!(idl.types[0].name, "D_Foo");
@@ -1509,7 +1504,7 @@ contract C {
 
     let mut ns = generate_namespace(src);
     codegen(&mut ns, &Options::default());
-    let idl = generate_anchor_idl(0, &ns);
+    let idl = generate_anchor_idl(0, &ns, "0.1.0");
 
     assert!(idl.metadata.is_some());
     assert_eq!(
@@ -1529,7 +1524,7 @@ fn data_account_signer() {
 
     let mut ns = generate_namespace(src);
     codegen(&mut ns, &Options::default());
-    let idl = generate_anchor_idl(0, &ns);
+    let idl = generate_anchor_idl(0, &ns, "0.1.0");
 
     assert_eq!(idl.instructions.len(), 1);
 
@@ -1581,7 +1576,7 @@ fn data_account_signer() {
 
     let mut ns = generate_namespace(src);
     codegen(&mut ns, &Options::default());
-    let idl = generate_anchor_idl(0, &ns);
+    let idl = generate_anchor_idl(0, &ns, "0.1.0");
 
     assert_eq!(idl.instructions.len(), 1);
 
@@ -1642,7 +1637,7 @@ fn accounts_call_chain() {
     "#;
     let mut ns = generate_namespace(src);
     codegen(&mut ns, &Options::default());
-    let idl = generate_anchor_idl(0, &ns);
+    let idl = generate_anchor_idl(0, &ns, "0.1.0");
 
     assert_eq!(idl.instructions[0].name, "new");
     assert_eq!(
@@ -1723,7 +1718,7 @@ fn accounts_on_recursion() {
 
     let mut ns = generate_namespace(src);
     codegen(&mut ns, &Options::default());
-    let idl = generate_anchor_idl(0, &ns);
+    let idl = generate_anchor_idl(0, &ns, "0.1.0");
 
     assert_eq!(idl.instructions[0].name, "new");
     assert_eq!(
@@ -1813,7 +1808,7 @@ fn system_account_for_payer_annotation() {
     "#;
     let mut ns = generate_namespace(src);
     codegen(&mut ns, &Options::default());
-    let idl = generate_anchor_idl(0, &ns);
+    let idl = generate_anchor_idl(0, &ns, "0.1.0");
 
     assert_eq!(idl.instructions[0].name, "new");
     assert_eq!(
@@ -1882,7 +1877,7 @@ contract Test {
 
     let mut ns = generate_namespace(src);
     codegen(&mut ns, &Options::default());
-    let idl = generate_anchor_idl(1, &ns);
+    let idl = generate_anchor_idl(1, &ns, "0.1.0");
 
     assert_eq!(idl.instructions[0].name, "new");
 
@@ -1943,7 +1938,7 @@ contract Test {
     "#;
     let mut ns = generate_namespace(src);
     codegen(&mut ns, &Options::default());
-    let idl = generate_anchor_idl(1, &ns);
+    let idl = generate_anchor_idl(1, &ns, "0.1.0");
 
     assert_eq!(idl.instructions[0].name, "new");
 
@@ -2037,7 +2032,7 @@ contract Test {
 
     let mut ns = generate_namespace(src);
     codegen(&mut ns, &Options::default());
-    let idl = generate_anchor_idl(4, &ns);
+    let idl = generate_anchor_idl(4, &ns, "0.1.0");
 
     assert_eq!(idl.instructions[0].name, "new");
     assert_eq!(
@@ -2214,7 +2209,7 @@ contract Child {
 
     let mut ns = generate_namespace(src);
     codegen(&mut ns, &Options::default());
-    let idl = generate_anchor_idl(0, &ns);
+    let idl = generate_anchor_idl(0, &ns, "0.1.0");
 
     assert_eq!(idl.instructions[0].name, "new");
     assert_eq!(idl.instructions[1].name, "c");
@@ -2293,7 +2288,7 @@ contract BeingBuilt {
 
     let mut ns = generate_namespace(src);
     codegen(&mut ns, &Options::default());
-    let idl = generate_anchor_idl(0, &ns);
+    let idl = generate_anchor_idl(0, &ns, "0.1.0");
 
     assert_eq!(idl.instructions[0].name, "new");
     assert_eq!(

--- a/src/bin/cli/test.rs
+++ b/src/bin/cli/test.rs
@@ -175,7 +175,9 @@ mod tests {
                     input: Some(vec![PathBuf::from("flipper.sol")]),
                     contracts: Some(vec!["flipper".to_owned()]),
                     import_path: Some(vec![]),
-                    import_map: Some(vec![])
+                    import_map: Some(vec![]),
+                    authors: None,
+                    version: Some("0.1.0".to_string())
                 },
                 compiler_output: cli::CompilerOutput {
                     emit: None,
@@ -209,7 +211,7 @@ mod tests {
             }
         );
 
-        let command = "solang compile flipper.sol sesa.sol --config-file solang.toml --target polkadot --value-length=31 --address-length=33 --no-dead-storage --no-constant-folding --no-strength-reduce --no-vector-to-slice --no-cse -O aggressive".split(' ');
+        let command = "solang compile flipper.sol sesa.sol --config-file solang.toml --contract-authors not_sesa --target polkadot --value-length=31 --address-length=33 --no-dead-storage --no-constant-folding --no-strength-reduce --no-vector-to-slice --no-cse -O aggressive".split(' ');
 
         let matches = Cli::command().get_matches_from(command);
 
@@ -228,7 +230,9 @@ mod tests {
                     ]),
                     contracts: Some(vec!["flipper".to_owned()]),
                     import_path: Some(vec![]),
-                    import_map: Some(vec![])
+                    import_map: Some(vec![]),
+                    authors: Some(vec!["not_sesa".to_owned()]),
+                    version: Some("0.1.0".to_string())
                 },
                 compiler_output: cli::CompilerOutput {
                     emit: None,

--- a/src/bin/solang_new_examples/polkadot/polkadot_config.toml
+++ b/src/bin/solang_new_examples/polkadot/polkadot_config.toml
@@ -1,4 +1,6 @@
 [package]
+authors = ["sesa"]
+version = "0.1.0"
 input_files = ["flipper.sol"]   # Files to be compiled. You can define multiple files as : input_files = ["file1", "file2", ..]
 contracts = ["flipper"] # Contracts to include from the compiled files
 import_path = []   

--- a/src/bin/solang_new_examples/solana/solana_config.toml
+++ b/src/bin/solang_new_examples/solana/solana_config.toml
@@ -1,4 +1,6 @@
 [package]
+authors = ["sesa"]
+version = "0.1.0"
 input_files = ["flipper.sol"]   # Files to be compiled. You can define multiple files as : input_files = ["file1", "file2", ..]
 contracts = ["flipper"] # Contracts to include from the compiled files
 import_path = []   

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,8 @@ pub fn compile(
     log_api_return_codes: bool,
     log_runtime_errors: bool,
     log_prints: bool,
+    authors: Vec<String>,
+    version: &str,
     #[cfg(feature = "wasm_opt")] wasm_opt: Option<contract_build::OptimizationPasses>,
 ) -> (Vec<(Vec<u8>, String)>, sema::ast::Namespace) {
     let mut ns = parse_and_resolve(filename, resolver, target);
@@ -158,7 +160,7 @@ pub fn compile(
         if contract.instantiable {
             let code = contract.emit(&ns, &opts);
 
-            let (abistr, _) = abi::generate_abi(contract_no, &ns, &code, false);
+            let (abistr, _) = abi::generate_abi(contract_no, &ns, &code, false, &authors, version);
 
             results.push((code, abistr));
         };

--- a/tests/polkadot.rs
+++ b/tests/polkadot.rs
@@ -1047,6 +1047,8 @@ pub fn build_wasm(src: &str, log_ret: bool, log_err: bool) -> Vec<(Vec<u8>, Stri
         log_ret,
         log_err,
         true,
+        vec!["unknown".to_string()],
+        "0.0.1",
         #[cfg(feature = "wasm_opt")]
         Some(contract_build::OptimizationPasses::Z),
     );

--- a/tests/polkadot_tests/inheritance.rs
+++ b/tests/polkadot_tests/inheritance.rs
@@ -38,6 +38,8 @@ fn test_abstract() {
         false,
         false,
         true,
+        vec!["unknown".to_string()],
+        "0.0.1",
         #[cfg(feature = "wasm_opt")]
         Some(contract_build::OptimizationPasses::Z),
     );
@@ -80,6 +82,8 @@ fn test_abstract() {
         false,
         false,
         true,
+        vec!["unknown".to_string()],
+        "0.0.1",
         #[cfg(feature = "wasm_opt")]
         Some(contract_build::OptimizationPasses::Z),
     );

--- a/tests/solana.rs
+++ b/tests/solana.rs
@@ -148,6 +148,8 @@ fn build_solidity(src: &str) -> VirtualMachine {
         false,
         true,
         true,
+        vec!["unknown".to_string()],
+        "0.0.1",
         #[cfg(feature = "wasm_opt")]
         None,
     );
@@ -167,7 +169,7 @@ fn build_solidity(src: &str) -> VirtualMachine {
         }
 
         let code = contract.code.get().unwrap();
-        let idl = generate_anchor_idl(contract_no, &ns);
+        let idl = generate_anchor_idl(contract_no, &ns, "0.1.0");
 
         let program = if let Some(program_id) = &contract.program_id {
             program_id.clone().try_into().unwrap()

--- a/tests/solana_tests/tags.rs
+++ b/tests/solana_tests/tags.rs
@@ -21,7 +21,7 @@ fn contract() {
             @selector([1,2,3,4,5,6,7,8])
             constructor() {}
         }"#,
-        Target::default_substrate(),
+        Target::default_polkadot(),
     );
 
     assert_eq!(ns.contracts[0].tags[0].tag, "notice");
@@ -56,7 +56,7 @@ fn contract() {
          * a contract
          */
         contract test {}"#,
-        Target::default_substrate(),
+        Target::default_polkadot(),
     );
 
     assert_eq!(ns.contracts[0].tags[0].tag, "notice");
@@ -82,7 +82,7 @@ fn struct_tag() {
             uint32 f1;
             uint32 f2;
         }"#,
-        Target::default_substrate(),
+        Target::default_polkadot(),
     );
 
     assert_eq!(ns.diagnostics.len(), 0);
@@ -106,7 +106,7 @@ fn event_tag() {
             uint32 f1,
             uint32 f2
         );"#,
-        Target::default_substrate(),
+        Target::default_polkadot(),
     );
 
     //Event never emitted generates a warning
@@ -131,7 +131,7 @@ fn event_tag() {
                 uint32 f2
             );
         }"#,
-        Target::default_substrate(),
+        Target::default_polkadot(),
     );
 
     //Event never emitted generates a warning
@@ -158,7 +158,7 @@ fn enum_tag() {
          *  @dev bla bla bla
          * @author f2 bar */
         enum x { x1 }"#,
-        Target::default_substrate(),
+        Target::default_polkadot(),
     );
 
     assert_eq!(ns.diagnostics.len(), 0);
@@ -184,7 +184,7 @@ fn functions() {
         }
 
         contract b {}"#,
-        Target::default_substrate(),
+        Target::default_polkadot(),
     );
 
     assert_eq!(ns.diagnostics.len(), 3);
@@ -214,7 +214,7 @@ fn variables() {
         }
 
         contract b {}"#,
-        Target::default_substrate(),
+        Target::default_polkadot(),
     );
 
     //Variable 'y' has never been used (one item error in diagnostic)


### PR DESCRIPTION
This PR implements a way to specify the author and version of all contracts via the CLI or via "solang.toml"