### PR TITLE
add option to set trace level

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -42,6 +42,12 @@
 					"type": "string",
 					"default": "",
 					"description": "Use the executable at this path and do not download or update solang. Leave this empty for automatic download."
+				},
+				"solidity.trace.server": {
+					"scope": "window",
+                    			"type": "string",
+                    			"enum": ["off","messages","verbose"],
+                    			"default": "verbose"
 				}
 			}
 		},


### PR DESCRIPTION
This allows the user to configure the verbosity of trace of messages exchanged between client and the server.
The user can set this in `User Settings` (press ctrl/cmd+,) and then searching for solidity related configuration. 