### PR TITLE
Drop diagnostics on closing the file

### DIFF
--- a/src/bin/languageserver/mod.rs
+++ b/src/bin/languageserver/mod.rs
@@ -1179,7 +1179,7 @@ impl LanguageServer for SolangServer {
         if let Ok(path) = uri.to_file_path() {
             self.files.lock().await.remove(&path);
         }
-        
+
         self.client.publish_diagnostics(uri, vec![], None).await;
     }
 

--- a/src/bin/languageserver/mod.rs
+++ b/src/bin/languageserver/mod.rs
@@ -1179,6 +1179,8 @@ impl LanguageServer for SolangServer {
         if let Ok(path) = uri.to_file_path() {
             self.files.lock().await.remove(&path);
         }
+        
+        self.client.publish_diagnostics(uri, vec![], None).await;
     }
 
     async fn completion(&self, _: CompletionParams) -> Result<Option<CompletionResponse>> {


### PR DESCRIPTION
When closing a file in VS code, all the warnings and errors remain in the list of problems. This removes all diagnostics pertaining to the close file. 