### PR TITLE
Substrate: Implement builtin for `set_code_hash` API

### DIFF
--- a/docs/language/builtins.rst
+++ b/docs/language/builtins.rst
@@ -346,6 +346,28 @@ is_contract(address AccountId) returns (bool)
 
 Only available on Substrate. Checks whether the given address is a contract address. 
 
+set_code_hash(bytes hash) returns (uint32)
+++++++++++++++++++++++++++++++++++++++++++
+
+Only available on Substrate. Replace the contracts code with the code corresponding to ``hash``.
+Implies that the new code was already uploaded, otherwise the operation fails.
+A return value of 0 indicates success; a return value of 7 indicates that there was no corresponding code found.
+
+.. note::
+
+    This is a low level function. We strongly advise consulting the underlying 
+    `API documentation <https://docs.rs/pallet-contracts/latest/pallet_contracts/api_doc/trait.Version0.html#tymethod.set_code_hash>`_ 
+    to obtain a full understanding of its implications.
+
+This functionality is intended to be used for implementing upgradeable contracts. 
+Pitfalls generally applying to writing
+`upgradeable contracts <https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable>`_ 
+must be considered whenever using this builtin function, most notably:
+
+* The contract must safeguard access to this functionality, so that it is only callable by priviledged users.
+* The code you are upgrading to must be storage compatible with the existing code.
+* Constructors and any other initializers, including initial storage value definitions, won't be executed.
+
 Cryptography
 ____________
 

--- a/integration/substrate/set_code_hash.sol
+++ b/integration/substrate/set_code_hash.sol
@@ -1,0 +1,28 @@
+import "substrate";
+
+abstract contract Upgradeable {
+    function set_code(Hash code) external {
+        bytes _code = Hash.unwrap(code);
+        require(set_code_hash(_code) == 0);
+    }
+}
+
+contract SetCodeCounter is Upgradeable {
+    uint public count;
+
+    function inc() external {
+        count += 1;
+    }
+}
+
+contract SetCodeCounter is Upgradeable {
+    uint public count;
+
+    function inc() external {
+        count += 1;
+    }
+
+    function dec() external {
+        count -= 1;
+    }
+}

--- a/integration/substrate/set_code_hash.sol
+++ b/integration/substrate/set_code_hash.sol
@@ -10,6 +10,10 @@ abstract contract Upgradeable {
 contract SetCodeCounterV1 is Upgradeable {
     uint public count;
 
+    constructor(uint _count) {
+        count = _count;
+    }
+
     function inc() external {
         count += 1;
     }
@@ -18,11 +22,11 @@ contract SetCodeCounterV1 is Upgradeable {
 contract SetCodeCounterV2 is Upgradeable {
     uint public count;
 
-    function inc() external {
-        count += 1;
+    constructor(uint _count) {
+        count = _count;
     }
 
-    function dec() external {
+    function inc() external {
         count -= 1;
     }
 }

--- a/integration/substrate/set_code_hash.sol
+++ b/integration/substrate/set_code_hash.sol
@@ -7,7 +7,7 @@ abstract contract Upgradeable {
     }
 }
 
-contract SetCodeCounter is Upgradeable {
+contract SetCodeCounterV1 is Upgradeable {
     uint public count;
 
     function inc() external {
@@ -15,7 +15,7 @@ contract SetCodeCounter is Upgradeable {
     }
 }
 
-contract SetCodeCounter is Upgradeable {
+contract SetCodeCounterV2 is Upgradeable {
     uint public count;
 
     function inc() external {

--- a/integration/substrate/set_code_hash.spec.ts
+++ b/integration/substrate/set_code_hash.spec.ts
@@ -1,0 +1,56 @@
+import expect from 'expect';
+import { createConnection, deploy, aliceKeypair, query, debug_buffer, weight, transaction, } from './index';
+import { ContractPromise } from '@polkadot/api-contract';
+import { ApiPromise } from '@polkadot/api';
+import { KeyringPair } from '@polkadot/keyring/types';
+import { U8aFixed } from '@polkadot/types';
+
+describe('Deploy the SetCodeCounter contracts and test for the upgrade to work', () => {
+    let conn: ApiPromise;
+    let counter: ContractPromise;
+    let hashes: [U8aFixed, U8aFixed];
+    let alice: KeyringPair;
+
+    before(async function () {
+        alice = aliceKeypair();
+        conn = await createConnection();
+
+        const counterV1 = await deploy(conn, alice, 'SetCodeCounterV1.contract', 0n, 1336n);
+        const counterV2 = await deploy(conn, alice, 'SetCodeCounterV2.contract', 0n, 0n);
+        hashes = [counterV1.abi.info.source.wasmHash, counterV2.abi.info.source.wasmHash];
+        counter = new ContractPromise(conn, counterV1.abi, counterV1.address);
+    });
+
+    after(async function () {
+        await conn.disconnect();
+    });
+
+    it('can switch out implementation using set_code_hash', async function () {
+        // Code hash should be V1, expect to increment
+        let gasLimit = await weight(conn, counter, 'inc', []);
+        await transaction(counter.tx.inc({ gasLimit }), alice);
+        let count = await query(conn, alice, counter, "count");
+        expect(BigInt(count.output?.toString() ?? "")).toStrictEqual(1337n);
+
+        // Switching to V2
+        gasLimit = await weight(conn, counter, 'set_code', [hashes[1]]);
+        await transaction(counter.tx.setCode({ gasLimit }, hashes[1]), alice);
+
+        // Code hash should be V2, expect to decrement
+        gasLimit = await weight(conn, counter, 'inc', []);
+        await transaction(counter.tx.inc({ gasLimit }), alice);
+        count = await query(conn, alice, counter, "count");
+        expect(BigInt(count.output?.toString() ?? "")).toStrictEqual(1336n);
+
+        // Switching to V1
+        gasLimit = await weight(conn, counter, 'set_code', [hashes[0]]);
+        await transaction(counter.tx.setCode({ gasLimit }, hashes[0]), alice);
+
+        // Code hash should be V1, expect to increment
+        gasLimit = await weight(conn, counter, 'inc', []);
+        await transaction(counter.tx.inc({ gasLimit }), alice);
+        count = await query(conn, alice, counter, "count");
+        expect(BigInt(count.output?.toString() ?? "")).toStrictEqual(1337n);
+    });
+
+});

--- a/src/emit/substrate/mod.rs
+++ b/src/emit/substrate/mod.rs
@@ -177,6 +177,7 @@ impl SubstrateTarget {
             "deposit_event",
             "transfer",
             "is_contract",
+            "set_code_hash",
         ]);
 
         binary
@@ -307,6 +308,7 @@ impl SubstrateTarget {
         external!("terminate", void_type, u8_ptr);
         external!("deposit_event", void_type, u8_ptr, u32_val, u8_ptr, u32_val);
         external!("is_contract", i32_type, u8_ptr);
+        external!("set_code_hash", i32_type, u8_ptr);
     }
 
     /// Emits the "deploy" function if `init` is `Some`, otherwise emits the "call" function.

--- a/src/emit/substrate/target.rs
+++ b/src/emit/substrate/target.rs
@@ -1646,6 +1646,19 @@ impl<'a> TargetRuntime<'a> for SubstrateTarget {
                     .build_store(args[1].into_pointer_value(), is_contract);
                 None
             }
+            "set_code_hash" => {
+                let ptr = binary.vector_bytes(args[0].into_pointer_value().into());
+                let ret = call!("set_code_hash", &[ptr.into()], "seal_set_code_hash")
+                    .try_as_basic_value()
+                    .left()
+                    .unwrap()
+                    .into_int_value();
+                binary
+                    .builder
+                    .build_store(args[1].into_pointer_value(), ret);
+                log_return_code(binary, "seal_set_code_hash", ret);
+                None
+            }
             _ => unimplemented!(),
         }
     }

--- a/src/sema/builtin.rs
+++ b/src/sema/builtin.rs
@@ -1669,29 +1669,110 @@ impl Namespace {
         assert!(self.add_symbol(file_no, None, &identifier("Hash"), symbol));
 
         // Chain extensions
-        let mut func = Function::new(
-            loc,
-            "chain_extension".to_string(),
-            None,
-            Vec::new(),
-            pt::FunctionTy::Function,
-            None,
-            pt::Visibility::Public(Some(loc)),
-            vec![
-                Parameter {
+        for mut func in [
+            Function::new(
+                loc,
+                "chain_extension".to_string(),
+                None,
+                Vec::new(),
+                pt::FunctionTy::Function,
+                None,
+                pt::Visibility::Public(Some(loc)),
+                vec![
+                    Parameter {
+                        loc,
+                        id: Some(identifier("id")),
+                        ty: Type::Uint(32),
+                        ty_loc: Some(loc),
+                        readonly: false,
+                        indexed: false,
+                        infinite_size: false,
+                        recursive: false,
+                        annotation: None,
+                    },
+                    Parameter {
+                        loc,
+                        id: Some(identifier("input")),
+                        ty: Type::DynamicBytes,
+                        ty_loc: Some(loc),
+                        readonly: false,
+                        indexed: false,
+                        infinite_size: false,
+                        recursive: false,
+                        annotation: None,
+                    },
+                ],
+                vec![
+                    Parameter {
+                        loc,
+                        id: Some(identifier("return_value")),
+                        ty: Type::Uint(32),
+                        ty_loc: Some(loc),
+                        readonly: false,
+                        indexed: false,
+                        infinite_size: false,
+                        recursive: false,
+                        annotation: None,
+                    },
+                    Parameter {
+                        loc,
+                        id: Some(identifier("output")),
+                        ty: Type::DynamicBytes,
+                        ty_loc: Some(loc),
+                        readonly: false,
+                        indexed: false,
+                        infinite_size: false,
+                        recursive: false,
+                        annotation: None,
+                    },
+                ],
+                self,
+            ),
+            // is_contract API
+            Function::new(
+                loc,
+                "is_contract".to_string(),
+                None,
+                Vec::new(),
+                pt::FunctionTy::Function,
+                Some(pt::Mutability::View(loc)),
+                pt::Visibility::Public(Some(loc)),
+                vec![Parameter {
                     loc,
-                    id: Some(identifier("id")),
-                    ty: Type::Uint(32),
+                    id: Some(identifier("address")),
+                    ty: Type::Address(false),
                     ty_loc: Some(loc),
                     readonly: false,
                     indexed: false,
                     infinite_size: false,
                     recursive: false,
                     annotation: None,
-                },
-                Parameter {
+                }],
+                vec![Parameter {
                     loc,
-                    id: Some(identifier("input")),
+                    id: Some(identifier("is_contract")),
+                    ty: Type::Bool,
+                    ty_loc: Some(loc),
+                    readonly: false,
+                    indexed: false,
+                    infinite_size: false,
+                    recursive: false,
+                    annotation: None,
+                }],
+                self,
+            ),
+            // set_code_hash API
+            Function::new(
+                loc,
+                "set_code_hash".to_string(),
+                None,
+                Vec::new(),
+                pt::FunctionTy::Function,
+                None,
+                pt::Visibility::Public(Some(loc)),
+                vec![Parameter {
+                    loc,
+                    id: Some(identifier("code_hash_ptr")),
                     ty: Type::DynamicBytes,
                     ty_loc: Some(loc),
                     readonly: false,
@@ -1699,12 +1780,10 @@ impl Namespace {
                     infinite_size: false,
                     recursive: false,
                     annotation: None,
-                },
-            ],
-            vec![
-                Parameter {
+                }],
+                vec![Parameter {
                     loc,
-                    id: Some(identifier("return_value")),
+                    id: Some(identifier("return_code")),
                     ty: Type::Uint(32),
                     ty_loc: Some(loc),
                     readonly: false,
@@ -1712,68 +1791,15 @@ impl Namespace {
                     infinite_size: false,
                     recursive: false,
                     annotation: None,
-                },
-                Parameter {
-                    loc,
-                    id: Some(identifier("output")),
-                    ty: Type::DynamicBytes,
-                    ty_loc: Some(loc),
-                    readonly: false,
-                    indexed: false,
-                    infinite_size: false,
-                    recursive: false,
-                    annotation: None,
-                },
-            ],
-            self,
-        );
-
-        func.has_body = true;
-        let func_no = self.functions.len();
-        let id = identifier(&func.name);
-        self.functions.push(func);
-
-        assert!(self.add_symbol(file_no, None, &id, Symbol::Function(vec![(loc, func_no)])));
-
-        // is_contract API
-        let mut func = Function::new(
-            loc,
-            "is_contract".to_string(),
-            None,
-            Vec::new(),
-            pt::FunctionTy::Function,
-            Some(pt::Mutability::View(loc)),
-            pt::Visibility::Public(Some(loc)),
-            vec![Parameter {
-                loc,
-                id: Some(identifier("address")),
-                ty: Type::Address(false),
-                ty_loc: Some(loc),
-                readonly: false,
-                indexed: false,
-                infinite_size: false,
-                recursive: false,
-                annotation: None,
-            }],
-            vec![Parameter {
-                loc,
-                id: Some(identifier("is_contract")),
-                ty: Type::Bool,
-                ty_loc: Some(loc),
-                readonly: false,
-                indexed: false,
-                infinite_size: false,
-                recursive: false,
-                annotation: None,
-            }],
-            self,
-        );
-
-        func.has_body = true;
-        let func_no = self.functions.len();
-        let id = identifier(&func.name);
-        self.functions.push(func);
-
-        assert!(self.add_symbol(file_no, None, &id, Symbol::Function(vec![(loc, func_no)])));
+                }],
+                self,
+            ),
+        ] {
+            func.has_body = true;
+            let func_no = self.functions.len();
+            let id = identifier(&func.name);
+            self.functions.push(func);
+            assert!(self.add_symbol(file_no, None, &id, Symbol::Function(vec![(loc, func_no)])));
+        }
     }
 }

--- a/tests/substrate_tests/builtins.rs
+++ b/tests/substrate_tests/builtins.rs
@@ -794,3 +794,54 @@ fn is_contract() {
     runtime.function("test", [0; 32].to_vec());
     assert_eq!(runtime.output(), vec![0]);
 }
+
+#[test]
+fn set_code_hash() {
+    let mut runtime = build_solidity(
+        r##"
+        import "substrate";
+
+        abstract contract SetCode {
+            function set_code(bytes code_hash) external {
+                require(set_code_hash(code_hash) == 0);
+            }
+        }
+        
+        contract CounterV1 is SetCode {
+            uint32 public count;
+        
+            function inc() external {
+                count += 1;
+            }
+        }
+        
+        contract CounterV2 is SetCode {
+            uint32 public count;
+        
+            function inc() external {
+                count -= 1;
+            }
+        }"##,
+    );
+
+    runtime.function("inc", vec![]);
+    runtime.function("count", vec![]);
+    assert_eq!(runtime.output(), 1u32.encode());
+
+    let v2_code_hash = ink_primitives::Hash::default().as_ref().to_vec().encode();
+    runtime.function_expect_failure("set_code", v2_code_hash);
+
+    let v2_code_hash = runtime.blobs()[1].hash;
+    runtime.function("set_code", v2_code_hash.as_ref().to_vec().encode());
+
+    runtime.function("inc", vec![]);
+    runtime.function("count", vec![]);
+    assert_eq!(runtime.output(), 0u32.encode());
+
+    let v1_code_hash = runtime.blobs()[0].hash;
+    runtime.function("set_code", v1_code_hash.as_ref().to_vec().encode());
+
+    runtime.function("inc", vec![]);
+    runtime.function("count", vec![]);
+    assert_eq!(runtime.output(), 1u32.encode());
+}


### PR DESCRIPTION
Exposes a low-level builtin function for calling `seal_set_code_hash`. The code hash arguments is of type `bytes` intentionally (and not of type `Hash`. `bytes32` will internally be represented as an `i256`. I came to the conclusion that, given this conversion can be written in Solidity, we do and should not want to deal with that in the compiler, be in emit or in codegen or elsewhere. Instead, a more high level function, that asks for a `Hash` argument and converts that to `bytes`, should rather be implement in the substrate Solidity library (once we have it).