### PR TITLE
Ensure that a constructor cannot be run twice on the same data account

### DIFF
--- a/integration/solana/simple.spec.ts
+++ b/integration/solana/simple.spec.ts
@@ -9,6 +9,11 @@ describe('Simple solang tests', function () {
     it('flipper', async function () {
         let { program, storage } = await loadContract('flipper', [true]);
 
+        // make sure we can't run the constructor twice
+        await expect(program.methods.new(false)
+            .accounts({ dataAccount: storage.publicKey })
+            .rpc()).rejects.toThrow();
+
         let res = await program.methods.get().accounts({ dataAccount: storage.publicKey }).view();
 
         expect(res).toStrictEqual(true);

--- a/tests/solana_tests/create_contract.rs
+++ b/tests/solana_tests/create_contract.rs
@@ -180,6 +180,20 @@ fn create_contract_wrong_program_id() {
 }
 
 #[test]
+fn call_constructor_twice() {
+    let mut vm = build_solidity(
+        r#"
+        @program_id("CPDgqnhHDCsjFkJKMturRQ1QeM9EXZg3EYCeDoRP8pdT")
+        contract bar0 {}
+        "#,
+    );
+
+    vm.constructor(&[]);
+
+    vm.constructor_expected(2, &vm.default_metas(), &[]);
+}
+
+#[test]
 fn create_contract_with_payer() {
     let mut vm = build_solidity(
         r#"


### PR DESCRIPTION
The constructor code path was not checking that the data account magic number is not populated.

The change also exposed another issue: when a pure function is called, there should be no load of data magic number, this may result in a access violation.