### PR TITLE
Move stdlib build output to `target` folder

### DIFF
--- a/src/emit/binary.rs
+++ b/src/emit/binary.rs
@@ -1097,19 +1097,19 @@ fn load_stdlib<'a>(context: &'a Context, target: &Target) -> Module<'a> {
 }
 
 static BPF_IR: [&[u8]; 6] = [
-    include_bytes!("../../stdlib/bpf/stdlib.bc"),
-    include_bytes!("../../stdlib/bpf/bigint.bc"),
-    include_bytes!("../../stdlib/bpf/format.bc"),
-    include_bytes!("../../stdlib/bpf/solana.bc"),
-    include_bytes!("../../stdlib/bpf/ripemd160.bc"),
-    include_bytes!("../../stdlib/bpf/heap.bc"),
+    include_bytes!("../../target/bpf/stdlib.bc"),
+    include_bytes!("../../target/bpf/bigint.bc"),
+    include_bytes!("../../target/bpf/format.bc"),
+    include_bytes!("../../target/bpf/solana.bc"),
+    include_bytes!("../../target/bpf/ripemd160.bc"),
+    include_bytes!("../../target/bpf/heap.bc"),
 ];
 
 static WASM_IR: [&[u8]; 4] = [
-    include_bytes!("../../stdlib/wasm/stdlib.bc"),
-    include_bytes!("../../stdlib/wasm/heap.bc"),
-    include_bytes!("../../stdlib/wasm/bigint.bc"),
-    include_bytes!("../../stdlib/wasm/format.bc"),
+    include_bytes!("../../target/wasm/stdlib.bc"),
+    include_bytes!("../../target/wasm/heap.bc"),
+    include_bytes!("../../target/wasm/bigint.bc"),
+    include_bytes!("../../target/wasm/format.bc"),
 ];
 
-static RIPEMD160_IR: &[u8] = include_bytes!("../../stdlib/wasm/ripemd160.bc");
+static RIPEMD160_IR: &[u8] = include_bytes!("../../target/wasm/ripemd160.bc");

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -2,14 +2,14 @@ CC=clang
 BIT_INT_FLAGS=-Xclang -fexperimental-max-bitint-width=512
 CFLAGS=$(TARGET_FLAGS) -emit-llvm -O3 -ffreestanding -fno-builtin -Wall -Wno-unused-function $(BIT_INT_FLAGS)
 
-bpf/%.bc: %.c
+../target/bpf/%.bc: %.c
 	$(CC) -c $(CFLAGS) $< -o $@
 
-wasm/%.bc: %.c
+../target/wasm/%.bc: %.c
 	$(CC) -c $(CFLAGS) $< -o $@
 
-SOLANA=$(addprefix bpf/,solana.bc bigint.bc format.bc stdlib.bc ripemd160.bc heap.bc)
-WASM=$(addprefix wasm/,ripemd160.bc stdlib.bc bigint.bc format.bc heap.bc)
+SOLANA=$(addprefix ../target/bpf/,solana.bc bigint.bc format.bc stdlib.bc ripemd160.bc heap.bc)
+WASM=$(addprefix ../target/wasm/,ripemd160.bc stdlib.bc bigint.bc format.bc heap.bc)
 
 all: $(SOLANA) $(WASM)
 
@@ -21,10 +21,10 @@ $(WASM): TARGET_FLAGS=--target=wasm32
 bpf/solana.bc: solana.c solana_sdk.h | outputs_dirs
 
 outputs_dirs:
-	@mkdir -p bpf wasm
+	@mkdir -p ../target/bpf ../target/wasm
 
 clean:
-	rm -rf bpf wasm
+	rm -rf ../target/bpf ../target/wasm
 
 test:
 	clang -DTEST -DSOL_TEST -O3 -Wall solana.c stdlib.c -o test


### PR DESCRIPTION
This is a fix for #1321.