### PR TITLE
Substrate: Distinct dispatch CFG for `call` and `deploy`

### DIFF
--- a/integration/substrate/ConstructorDispatch.sol
+++ b/integration/substrate/ConstructorDispatch.sol
@@ -11,7 +11,8 @@ contract ConstructorDispatch {
 }
 
 contract HappyCaller {
-    function call(address callee, bytes input) public {
-        callee.call(input);
+    function call(address callee, bytes input) public returns (bytes ret) {
+        (bool ok, ret) = callee.call(input);
+        require(ok);
     }
 }

--- a/integration/substrate/ConstructorDispatch.sol
+++ b/integration/substrate/ConstructorDispatch.sol
@@ -1,0 +1,17 @@
+contract ConstructorDispatch {
+    address admin;
+
+    constructor() {
+        admin = msg.sender;
+    }
+
+    function boss() public view returns (address) {
+        return admin;
+    }
+}
+
+contract HappyCaller {
+    function call(address callee, bytes input) public {
+        callee.call(input);
+    }
+}

--- a/integration/substrate/UpgradeableProxy.sol
+++ b/integration/substrate/UpgradeableProxy.sol
@@ -119,11 +119,8 @@ contract UpgradeableProxy is Proxy, StorageSlot {
 contract UpgradeableImplV1 {
     uint public count;
 
-    constructor() {
-        count = 1;
-    }
-
     function inc() external {
+        print("v1");
         count += 1;
     }
 }
@@ -133,7 +130,7 @@ contract UpgradeableImplV2 {
     uint public count;
     string public version;
 
-    constructor() {
+    function setVersion() public {
         version = "v2";
     }
 

--- a/integration/substrate/constructor_dispatch.spec.ts
+++ b/integration/substrate/constructor_dispatch.spec.ts
@@ -3,6 +3,7 @@ import { ContractPromise } from '@polkadot/api-contract';
 import { ApiPromise } from '@polkadot/api';
 import { KeyringPair } from '@polkadot/keyring/types';
 import expect from 'expect';
+import { error } from 'console';
 
 describe('Test that the constructor can not be reached from the call function', () => {
     let conn: ApiPromise;
@@ -18,7 +19,6 @@ describe('Test that the constructor can not be reached from the call function', 
         contract = new ContractPromise(conn, contract_deployment.abi, contract_deployment.address);
         const caller_deployment = await deploy(conn, alice, 'HappyCaller.contract', 0n);
         caller = new ContractPromise(conn, caller_deployment.abi, caller_deployment.address);
-
     });
 
     after(async function () {
@@ -26,10 +26,18 @@ describe('Test that the constructor can not be reached from the call function', 
     });
 
     it('Should fail to overwrite the admin account of the target contract', async function () {
-        // "Call" the constructor
-        const input = contract.abi.constructors[0].selector;
-        let gasLimit = await weight(conn, caller, 'call', [contract.address, input]);
-        await transaction(caller.tx.call({ gasLimit }, contract.address, input), alice);
+        // Expect the caller to succeed on normal function 
+        let input = contract.abi.messages[0].selector;
+        let attempt = await query(conn, alice, caller, "call", [contract.address, input]);
+        expect(attempt.result.isOk).toStrictEqual(true);
+
+        // "Calling" the constructor should fail
+        input = contract.abi.constructors[0].selector;
+        attempt = await query(conn, alice, caller, "call", [contract.address, input]);
+        expect(attempt.result.isErr).toStrictEqual(true);
+
+        const gasLimit = await weight(conn, caller, 'call', [contract.address, input]);
+        await expect(transaction(caller.tx.call({ gasLimit }, contract.address, input), alice)).rejects.toBeDefined();
 
         // Alice must still be admin
         let admin = await query(conn, alice, contract, "boss");

--- a/integration/substrate/constructor_dispatch.spec.ts
+++ b/integration/substrate/constructor_dispatch.spec.ts
@@ -1,0 +1,39 @@
+import { createConnection, deploy, aliceKeypair, query, debug_buffer, weight, transaction, daveKeypair, } from './index';
+import { ContractPromise } from '@polkadot/api-contract';
+import { ApiPromise } from '@polkadot/api';
+import { KeyringPair } from '@polkadot/keyring/types';
+import expect from 'expect';
+
+describe('Test that the constructor can not be reached from the call function', () => {
+    let conn: ApiPromise;
+    let contract: ContractPromise;
+    let caller: ContractPromise;
+    let alice: KeyringPair;
+
+    before(async function () {
+        alice = aliceKeypair();
+        conn = await createConnection();
+
+        const contract_deployment = await deploy(conn, alice, 'ConstructorDispatch.contract', 0n);
+        contract = new ContractPromise(conn, contract_deployment.abi, contract_deployment.address);
+        const caller_deployment = await deploy(conn, alice, 'HappyCaller.contract', 0n);
+        caller = new ContractPromise(conn, caller_deployment.abi, caller_deployment.address);
+
+    });
+
+    after(async function () {
+        await conn.disconnect();
+    });
+
+    it('Should fail to overwrite the admin account of the target contract', async function () {
+        // "Call" the constructor
+        const input = contract.abi.constructors[0].selector;
+        let gasLimit = await weight(conn, caller, 'call', [contract.address, input]);
+        await transaction(caller.tx.call({ gasLimit }, contract.address, input), alice);
+
+        // Alice must still be admin
+        let admin = await query(conn, alice, contract, "boss");
+        expect(admin.output?.toString()).toStrictEqual(alice.address.toString());
+    });
+
+});

--- a/integration/substrate/tornado.spec.ts
+++ b/integration/substrate/tornado.spec.ts
@@ -82,6 +82,8 @@ describe('Deploy the tornado contract, create 2 deposits and withdraw them after
     });
 
     it('Withdraws funds deposited by alice to dave', async function () {
+        this.timeout(50000);
+
         const { data: { free: balanceBefore } } = await conn.query.system.account(dave.address);
 
         const parameters = await generateProof(dave, 0);
@@ -96,6 +98,8 @@ describe('Deploy the tornado contract, create 2 deposits and withdraw them after
     });
 
     it('Withdraws funds deposited by dave to alice', async function () {
+        this.timeout(50000);
+
         const { data: { free: balanceBefore } } = await conn.query.system.account(dave.address);
 
         const parameters = await generateProof(dave, 1);
@@ -110,6 +114,8 @@ describe('Deploy the tornado contract, create 2 deposits and withdraw them after
     });
 
     it('Fails to withdraw without a valid proof', async function () {
+        this.timeout(50000);
+
         // Without a corresponding deposit, this merkle root should not exist yet
         deposits.push(createNote({}));
         let parameters = await generateProof(alice, 2);

--- a/integration/substrate/upgradeable_proxy.spec.ts
+++ b/integration/substrate/upgradeable_proxy.spec.ts
@@ -67,7 +67,7 @@ describe('Deploy the upgradable proxy and implementations; expect the upgrade me
         count = await query(conn, alice, counter, "count");
         expect(BigInt(count.output?.toString() ?? "")).toStrictEqual(3n);
 
-        //gasLimit = await weight(conn, counter, 'dec', []);
+        gasLimit = await weight(conn, counter, 'dec', []);
         await transaction(counter.tx.dec({ gasLimit }), alice);
         count = await query(conn, alice, counter, "count");
         expect(BigInt(count.output?.toString() ?? "")).toStrictEqual(2n);

--- a/integration/substrate/upgradeable_proxy.spec.ts
+++ b/integration/substrate/upgradeable_proxy.spec.ts
@@ -6,10 +6,15 @@ import { KeyringPair } from '@polkadot/keyring/types';
 import { DecodedEvent } from '@polkadot/api-contract/types';
 import { AccountId, ContractSelector } from '@polkadot/types/interfaces';
 
+interface IMsg {
+    identifier: string,
+    selector: any,
+};
+
 describe('Deploy the upgradable proxy and implementations; expect the upgrade mechanism to work', () => {
     // Helper: Upgrade implementation and execute a constructor that takes no arguments
-    async function upgrade_and_constructor(impl: AccountId, constructor: ContractSelector) {
-        const params = [impl, constructor];
+    async function upgrade_version(impl: AccountId, input: any) {
+        const params = [impl, input];
         const gasLimit = await weight(conn, proxy, 'upgradeToAndCall', params);
         let result: any = await transaction(proxy.tx.upgradeToAndCall({ gasLimit }, ...params), aliceKeypair());
 
@@ -33,7 +38,8 @@ describe('Deploy the upgradable proxy and implementations; expect the upgrade me
 
         // Pretend the proxy contract to be implementation V1
         const implV1 = await deploy(conn, alice, 'UpgradeableImplV1.contract', 0n);
-        await upgrade_and_constructor(implV1.address, implV1.abi.constructors[0].selector);
+        const selector = implV1.abi.messages.find((m: IMsg) => m.identifier === "inc").selector;
+        await upgrade_version(implV1.address, selector);
         counter = new ContractPromise(conn, implV1.abi, proxy_deployment.address);
         const count = await query(conn, alice, counter, "count");
         expect(BigInt(count.output?.toString() ?? "")).toStrictEqual(1n);
@@ -53,14 +59,15 @@ describe('Deploy the upgradable proxy and implementations; expect the upgrade me
 
         // Upgrade to implementation V2
         const implV2 = await deploy(conn, alice, 'UpgradeableImplV2.contract', 0n);
-        await upgrade_and_constructor(implV2.address, implV2.abi.constructors[0].selector);
+        const selector = implV2.abi.messages.find((m: IMsg) => m.identifier === "setVersion").selector;
+        await upgrade_version(implV2.address, selector);
         counter = new ContractPromise(conn, implV2.abi, proxy.address);
 
         // Test implementation V2
         count = await query(conn, alice, counter, "count");
         expect(BigInt(count.output?.toString() ?? "")).toStrictEqual(3n);
 
-        gasLimit = await weight(conn, counter, 'dec', []);
+        //gasLimit = await weight(conn, counter, 'dec', []);
         await transaction(counter.tx.dec({ gasLimit }), alice);
         count = await query(conn, alice, counter, "count");
         expect(BigInt(count.output?.toString() ?? "")).toStrictEqual(2n);

--- a/src/codegen/dispatch/mod.rs
+++ b/src/codegen/dispatch/mod.rs
@@ -11,9 +11,9 @@ pub(super) fn function_dispatch(
     all_cfg: &[ControlFlowGraph],
     ns: &mut Namespace,
     opt: &Options,
-) -> ControlFlowGraph {
+) -> Vec<ControlFlowGraph> {
     match &ns.target {
-        Target::Solana => solana::function_dispatch(contract_no, all_cfg, ns, opt),
+        Target::Solana => vec![solana::function_dispatch(contract_no, all_cfg, ns, opt)],
         Target::Substrate { .. } | Target::EVM => {
             substrate::function_dispatch(contract_no, all_cfg, ns, opt)
         }

--- a/src/codegen/dispatch/mod.rs
+++ b/src/codegen/dispatch/mod.rs
@@ -4,7 +4,7 @@ use super::{cfg::ControlFlowGraph, Options};
 use crate::{sema::ast::Namespace, Target};
 
 pub(super) mod solana;
-pub(super) mod substrate;
+pub(crate) mod substrate;
 
 pub(super) fn function_dispatch(
     contract_no: usize,

--- a/src/codegen/dispatch/solana.rs
+++ b/src/codegen/dispatch/solana.rs
@@ -16,6 +16,8 @@ use solang_parser::{pt, pt::Loc};
 
 use crate::codegen::encoding::{abi_decode, abi_encode};
 
+pub const SOLANA_DISPATCH_CFG_NAME: &str = "solang_dispatch";
+
 /// Create the dispatch for the Solana target
 pub(crate) fn function_dispatch(
     contract_no: usize,
@@ -24,7 +26,7 @@ pub(crate) fn function_dispatch(
     opt: &Options,
 ) -> ControlFlowGraph {
     let mut vartab = Vartable::new(ns.next_id);
-    let mut cfg = ControlFlowGraph::new("solang_dispatch".into(), ASTFunction::None);
+    let mut cfg = ControlFlowGraph::new(SOLANA_DISPATCH_CFG_NAME.into(), ASTFunction::None);
 
     let switch_block = cfg.new_basic_block("switch".to_string());
     let no_function_matched = cfg.new_basic_block("no_function_matched".to_string());

--- a/src/codegen/dispatch/substrate.rs
+++ b/src/codegen/dispatch/substrate.rs
@@ -28,8 +28,11 @@ pub(crate) fn function_dispatch(
     all_cfg: &[ControlFlowGraph],
     ns: &mut Namespace,
     opt: &Options,
-) -> ControlFlowGraph {
-    Dispatch::new(all_cfg, ns, opt).build()
+) -> Vec<ControlFlowGraph> {
+    vec![
+        Dispatch::new(all_cfg, ns, opt, FunctionTy::Constructor).build(),
+        Dispatch::new(all_cfg, ns, opt, FunctionTy::Function).build(),
+    ]
 }
 
 struct Dispatch<'a> {
@@ -43,10 +46,16 @@ struct Dispatch<'a> {
     ns: &'a mut Namespace,
     selector_len: Box<Expression>,
     opt: &'a Options,
+    ty: FunctionTy,
 }
 
-fn new_cfg(ns: &Namespace) -> ControlFlowGraph {
-    let mut cfg = ControlFlowGraph::new("substrate_dispatch".into(), ASTFunction::None);
+fn new_cfg(ns: &Namespace, ty: FunctionTy) -> ControlFlowGraph {
+    let name = match ty {
+        FunctionTy::Constructor => "substrate_deploy_dispatch",
+        FunctionTy::Function => "substrate_call_dispatch",
+        _ => unreachable!(),
+    };
+    let mut cfg = ControlFlowGraph::new(name.into(), ASTFunction::None);
     let input_ptr = Parameter {
         loc: Codegen,
         id: None,
@@ -70,9 +79,16 @@ fn new_cfg(ns: &Namespace) -> ControlFlowGraph {
 
 impl<'a> Dispatch<'a> {
     /// Create a new `Dispatch` struct that has all the data needed for building the dispatch logic.
-    fn new(all_cfg: &'a [ControlFlowGraph], ns: &'a mut Namespace, opt: &'a Options) -> Self {
+    ///
+    /// `ty` specifies whether to include constructors or functions.
+    fn new(
+        all_cfg: &'a [ControlFlowGraph],
+        ns: &'a mut Namespace,
+        opt: &'a Options,
+        ty: FunctionTy,
+    ) -> Self {
         let mut vartab = Vartable::new(ns.next_id);
-        let mut cfg = new_cfg(ns);
+        let mut cfg = new_cfg(ns, ty);
 
         // Read input length from args
         let input_len = vartab.temp_name("input_len", &Uint(32));
@@ -145,6 +161,7 @@ impl<'a> Dispatch<'a> {
             ns,
             selector_len,
             opt,
+            ty,
         }
     }
 
@@ -175,8 +192,8 @@ impl<'a> Dispatch<'a> {
             .all_cfg
             .iter()
             .enumerate()
-            .filter_map(|(func_no, func_cfg)| match func_cfg.ty {
-                FunctionTy::Function | FunctionTy::Constructor if func_cfg.public => {
+            .filter_map(|(func_no, func_cfg)| {
+                if func_cfg.ty == self.ty && func_cfg.public {
                     let selector = BigInt::from_bytes_le(Sign::Plus, &func_cfg.selector);
                     let case = Expression::NumberLiteral {
                         loc: Codegen,
@@ -184,8 +201,9 @@ impl<'a> Dispatch<'a> {
                         value: selector,
                     };
                     Some((case, self.dispatch_case(func_no)))
+                } else {
+                    None
                 }
-                _ => None,
             })
             .collect();
 

--- a/src/codegen/dispatch/substrate.rs
+++ b/src/codegen/dispatch/substrate.rs
@@ -408,7 +408,7 @@ impl<'a> Dispatch<'a> {
         );
 
         // No need to check value transferred; we will abort either way
-        if fallback_cfg.is_none() && receive_cfg.is_none() {
+        if (fallback_cfg.is_none() && receive_cfg.is_none()) || self.ty == FunctionTy::Constructor {
             return self.selector_invalid();
         }
 

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -5,7 +5,7 @@ pub mod cfg;
 mod constant_folding;
 mod constructor;
 mod dead_storage;
-mod dispatch;
+pub(crate) mod dispatch;
 mod encoding;
 mod events;
 mod expression;
@@ -243,7 +243,6 @@ fn contract(contract_no: usize, ns: &mut Namespace, opt: &Options) {
         }
 
         for dispatch_cfg in function_dispatch(contract_no, &all_cfg, ns, opt) {
-            ns.contracts[contract_no].dispatch_no = all_cfg.len();
             all_cfg.push(dispatch_cfg);
         }
 

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -242,9 +242,10 @@ fn contract(contract_no: usize, ns: &mut Namespace, opt: &Options) {
             ns.contracts[contract_no].default_constructor = Some((func, cfg_no));
         }
 
-        let dispatch_cfg = function_dispatch(contract_no, &all_cfg, ns, opt);
-        ns.contracts[contract_no].dispatch_no = all_cfg.len();
-        all_cfg.push(dispatch_cfg);
+        for dispatch_cfg in function_dispatch(contract_no, &all_cfg, ns, opt) {
+            ns.contracts[contract_no].dispatch_no = all_cfg.len();
+            all_cfg.push(dispatch_cfg);
+        }
 
         ns.contracts[contract_no].cfg = all_cfg;
     }

--- a/src/codegen/solana_accounts/account_management.rs
+++ b/src/codegen/solana_accounts/account_management.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::codegen::cfg::{ControlFlowGraph, Instr};
+use crate::codegen::dispatch::solana::SOLANA_DISPATCH_CFG_NAME;
 use crate::codegen::{Builtin, Expression};
 use crate::sema::ast::{ArrayLength, Function, Namespace, StructType, Type};
 use crate::sema::solana_accounts::BuiltinAccounts;
@@ -32,12 +33,12 @@ pub(crate) fn manage_contract_accounts(contract_no: usize, ns: &mut Namespace) {
     }
 
     if let Some(constructor) = constructor_no {
-        let dispatch = ns.contracts[contract_no].dispatch_no;
-        traverse_cfg(
-            &mut ns.contracts[contract_no].cfg[dispatch],
-            &ns.functions,
-            constructor,
-        );
+        let dispatch = ns.contracts[contract_no]
+            .cfg
+            .iter_mut()
+            .find(|cfg| cfg.name == SOLANA_DISPATCH_CFG_NAME)
+            .expect("dispatch CFG is always generated");
+        traverse_cfg(dispatch, &ns.functions, constructor);
     }
 }
 

--- a/src/codegen/yul/tests/expression.rs
+++ b/src/codegen/yul/tests/expression.rs
@@ -156,7 +156,6 @@ fn contract_constant_variable() {
         cfg: vec![],
         code: OnceCell::new(),
         instantiable: true,
-        dispatch_no: 0,
         program_id: None,
     };
     ns.contracts.push(contract);
@@ -292,7 +291,6 @@ fn slot_suffix() {
         cfg: vec![],
         code: OnceCell::new(),
         instantiable: true,
-        dispatch_no: 0,
         program_id: None,
     };
     ns.contracts.push(contract);

--- a/src/emit/substrate/mod.rs
+++ b/src/emit/substrate/mod.rs
@@ -325,34 +325,22 @@ impl SubstrateTarget {
     /// Emits the "deploy" function if `init` is `Some`, otherwise emits the "call" function.
     fn emit_dispatch(&mut self, init: Option<FunctionValue>, bin: &mut Binary, ns: &Namespace) {
         let ty = bin.context.void_type().fn_type(&[], false);
-        let name = if init.is_some() { "deploy" } else { "call" };
-        let func = bin.module.add_function(name, ty, None);
+        let export_name = if init.is_some() { "deploy" } else { "call" };
+        let func = bin.module.add_function(export_name, ty, None);
         let (input, input_length) = self.public_function_prelude(bin, func);
+        let dispatch_cfg_name = &format!("substrate_{}_dispatch", export_name);
+        let args = vec![
+            BasicMetadataValueEnum::PointerValue(input),
+            BasicMetadataValueEnum::IntValue(input_length),
+            BasicMetadataValueEnum::IntValue(self.value_transferred(bin, ns)),
+            BasicMetadataValueEnum::PointerValue(bin.selector.as_pointer_value()),
+        ];
+        // Call the storage initializers on deploy
         if let Some(initializer) = init {
             bin.builder.build_call(initializer, &[], "");
-            let func = bin
-                .module
-                .get_function("substrate_deploy_dispatch")
-                .unwrap();
-            let args = vec![
-                BasicMetadataValueEnum::PointerValue(input),
-                BasicMetadataValueEnum::IntValue(input_length),
-                BasicMetadataValueEnum::IntValue(self.value_transferred(bin, ns)),
-                BasicMetadataValueEnum::PointerValue(bin.selector.as_pointer_value()),
-            ];
-            bin.builder
-                .build_call(func, &args, "substrate_deploy_dispatch");
-        } else {
-            let func = bin.module.get_function("substrate_call_dispatch").unwrap();
-            let args = vec![
-                BasicMetadataValueEnum::PointerValue(input),
-                BasicMetadataValueEnum::IntValue(input_length),
-                BasicMetadataValueEnum::IntValue(self.value_transferred(bin, ns)),
-                BasicMetadataValueEnum::PointerValue(bin.selector.as_pointer_value()),
-            ];
-            bin.builder
-                .build_call(func, &args, "substrate_call_dispatch");
         }
+        let cfg = bin.module.get_function(dispatch_cfg_name).unwrap();
+        bin.builder.build_call(cfg, &args, dispatch_cfg_name);
 
         bin.builder.build_unreachable();
     }

--- a/src/emit/substrate/mod.rs
+++ b/src/emit/substrate/mod.rs
@@ -317,15 +317,30 @@ impl SubstrateTarget {
         let (input, input_length) = self.public_function_prelude(bin, func);
         if let Some(initializer) = init {
             bin.builder.build_call(initializer, &[], "");
+            let func = bin
+                .module
+                .get_function("substrate_deploy_dispatch")
+                .unwrap();
+            let args = vec![
+                BasicMetadataValueEnum::PointerValue(input),
+                BasicMetadataValueEnum::IntValue(input_length),
+                BasicMetadataValueEnum::IntValue(self.value_transferred(bin, ns)),
+                BasicMetadataValueEnum::PointerValue(bin.selector.as_pointer_value()),
+            ];
+            bin.builder
+                .build_call(func, &args, "substrate_deploy_dispatch");
+        } else {
+            let func = bin.module.get_function("substrate_call_dispatch").unwrap();
+            let args = vec![
+                BasicMetadataValueEnum::PointerValue(input),
+                BasicMetadataValueEnum::IntValue(input_length),
+                BasicMetadataValueEnum::IntValue(self.value_transferred(bin, ns)),
+                BasicMetadataValueEnum::PointerValue(bin.selector.as_pointer_value()),
+            ];
+            bin.builder
+                .build_call(func, &args, "substrate_call_dispatch");
         }
-        let func = bin.module.get_function("substrate_dispatch").unwrap();
-        let args = vec![
-            BasicMetadataValueEnum::PointerValue(input),
-            BasicMetadataValueEnum::IntValue(input_length),
-            BasicMetadataValueEnum::IntValue(self.value_transferred(bin, ns)),
-            BasicMetadataValueEnum::PointerValue(bin.selector.as_pointer_value()),
-        ];
-        bin.builder.build_call(func, &args, "substrate_dispatch");
+
         bin.builder.build_unreachable();
     }
 }

--- a/src/emit/substrate/mod.rs
+++ b/src/emit/substrate/mod.rs
@@ -7,6 +7,7 @@ use inkwell::module::{Linkage, Module};
 use inkwell::values::{BasicMetadataValueEnum, FunctionValue, IntValue, PointerValue};
 use inkwell::AddressSpace;
 
+use crate::codegen::dispatch::substrate::DispatchType;
 use crate::emit::functions::{emit_functions, emit_initializer};
 use crate::emit::{Binary, TargetRuntime};
 
@@ -328,17 +329,20 @@ impl SubstrateTarget {
         let export_name = if init.is_some() { "deploy" } else { "call" };
         let func = bin.module.add_function(export_name, ty, None);
         let (input, input_length) = self.public_function_prelude(bin, func);
-        let dispatch_cfg_name = &format!("substrate_{}_dispatch", export_name);
         let args = vec![
             BasicMetadataValueEnum::PointerValue(input),
             BasicMetadataValueEnum::IntValue(input_length),
             BasicMetadataValueEnum::IntValue(self.value_transferred(bin, ns)),
             BasicMetadataValueEnum::PointerValue(bin.selector.as_pointer_value()),
         ];
-        // Call the storage initializers on deploy
-        if let Some(initializer) = init {
-            bin.builder.build_call(initializer, &[], "");
-        }
+        let dispatch_cfg_name = &init
+            .map(|initializer| {
+                // Call the storage initializers on deploy
+                bin.builder.build_call(initializer, &[], "");
+                DispatchType::Deploy
+            })
+            .unwrap_or(DispatchType::Call)
+            .to_string();
         let cfg = bin.module.get_function(dispatch_cfg_name).unwrap();
         bin.builder.build_call(cfg, &args, dispatch_cfg_name);
 

--- a/src/sema/ast.rs
+++ b/src/sema/ast.rs
@@ -749,8 +749,6 @@ pub struct Contract {
     pub code: OnceCell<Vec<u8>>,
     /// Can the contract be instantiated, i.e. not abstract, no errors, etc.
     pub instantiable: bool,
-    /// CFG number of this contract's dispatch function
-    pub dispatch_no: usize,
     /// Account of deployed program code on Solana
     pub program_id: Option<Vec<u8>>,
 }

--- a/src/sema/contracts.rs
+++ b/src/sema/contracts.rs
@@ -46,7 +46,6 @@ impl ast::Contract {
             cfg: Vec::new(),
             code: OnceCell::new(),
             instantiable,
-            dispatch_no: 0,
             program_id: None,
         }
     }

--- a/tests/codegen_testcases/solidity/constant_folding.sol
+++ b/tests/codegen_testcases/solidity/constant_folding.sol
@@ -28,12 +28,12 @@ contract Enum {
         lenders[Lender.USDC] = usdc;
         lenders[Lender.DAI] = dai;
 
-        // CHECK: ty:address storage %temp.13 = (arg #0)
-        // CHECK: store storage slot(hex"f31349e4056d5e5c8ce6d8359404f2ca89b2a6884691bff0f55ce7629f869af3") ty:address = %temp.13
-        // CHECK: ty:address storage %temp.14 = (arg #1)
-        // CHECK: store storage slot(hex"e062efc721ea447b5e3918617d57f26130f3d8bc01b883eed1efcb4864d73ac1") ty:address = %temp.14
-        // CHECK: ty:address storage %temp.15 = (arg #2)
-        // CHECK: store storage slot(hex"b2573af2738ebd4810a3198e92bab190f29b8718f1d5ed1b83e468f2bb322d10") ty:address = %temp.15
+        // CHECK: ty:address storage %temp.17 = (arg #0)
+        // CHECK: store storage slot(hex"f31349e4056d5e5c8ce6d8359404f2ca89b2a6884691bff0f55ce7629f869af3") ty:address = %temp.17
+        // CHECK: ty:address storage %temp.18 = (arg #1)
+        // CHECK: store storage slot(hex"e062efc721ea447b5e3918617d57f26130f3d8bc01b883eed1efcb4864d73ac1") ty:address = %temp.18
+        // CHECK: ty:address storage %temp.19 = (arg #2)
+        // CHECK: store storage slot(hex"b2573af2738ebd4810a3198e92bab190f29b8718f1d5ed1b83e468f2bb322d10") ty:address = %temp.19
     }
 
     function foo(Lender lender) public view returns (address) {

--- a/tests/codegen_testcases/solidity/dead_storage.sol
+++ b/tests/codegen_testcases/solidity/dead_storage.sol
@@ -4,50 +4,56 @@ contract deadstorage {
 
     // simple test. Two references to "a" must result in a single loadstorage
 
-// BEGIN-CHECK: deadstorage::function::test1
-	function test1() public view returns (int) {
+    // BEGIN-CHECK: deadstorage::function::test1
+    function test1() public view returns (int) {
         return a + a;
-	}
-// CHECK: load storage slot(uint256 0) ty:int256
-// NOT-CHECK: load storage slot(uint256 0) ty:int256
+    }
+
+    // CHECK: load storage slot(uint256 0) ty:int256
+    // NOT-CHECK: load storage slot(uint256 0) ty:int256
 
     // Two references to "a" with a write to A in between must result in two loadstorage
-// BEGIN-CHECK: deadstorage::function::test2
-	function test2() public returns (int) {
+    // BEGIN-CHECK: deadstorage::function::test2
+    function test2() public returns (int) {
         int x = a;
         a = 2;
         x += a;
         return x;
-	}
-// CHECK: load storage slot(uint256 0) ty:int256
-// CHECK: load storage slot(uint256 0) ty:int256
+    }
+
+    // CHECK: load storage slot(uint256 0) ty:int256
+    // CHECK: load storage slot(uint256 0) ty:int256
 
     // make sure that reachable stores are not eliminated
-// BEGIN-CHECK: deadstorage::function::test3
-	function test3(bool c) public {
-		a = 1;
-		if (c) {
-			a = 2;
-		}
-	}
-// CHECK: store storage slot(uint256 0)
-// CHECK: store storage slot(uint256 0)
+    // BEGIN-CHECK: deadstorage::function::test3
+    function test3(bool c) public {
+        a = 1;
+        if (c) {
+            a = 2;
+        }
+    }
 
-   // two successive stores are redundant
-// BEGIN-CHECK: deadstorage::function::test4
+    // CHECK: store storage slot(uint256 0)
+    // CHECK: store storage slot(uint256 0)
+
+    // two successive stores are redundant
+    // BEGIN-CHECK: deadstorage::function::test4
     int b;
-	function test4() public returns (int) {
-		b = 511;
-	    b = 512;
-        return b;
-	}
-// CHECK: store storage slot(uint256 1)
-// NOT-CHECK: store storage slot(uint256 1)
 
-   // stores in a previous block are always redundant
-// BEGIN-CHECK: deadstorage::function::test5
+    function test4() public returns (int) {
+        b = 511;
+        b = 512;
+        return b;
+    }
+
+    // CHECK: store storage slot(uint256 1)
+    // NOT-CHECK: store storage slot(uint256 1)
+
+    // stores in a previous block are always redundant
+    // BEGIN-CHECK: deadstorage::function::test5
     int test5var;
-	function test5(bool c) public returns (int) {
+
+    function test5(bool c) public returns (int) {
         if (c) {
             test5var = 1;
         } else {
@@ -56,48 +62,56 @@ contract deadstorage {
         test5var = 3;
 
         return test5var;
-	}
-// CHECK: store storage slot(uint256 2)
-// NOT-CHECK: store storage slot(uint256 2)
+    }
 
-// BEGIN-CHECK: deadstorage::function::test6
+    // CHECK: store storage slot(uint256 2)
+    // NOT-CHECK: store storage slot(uint256 2)
+
+    // BEGIN-CHECK: deadstorage::function::test6
     // store/load are not merged yet. Make sure that we have a store before a load
     int test6var;
+
     function test6() public returns (int) {
         test6var = 1;
         int f = test6var;
         test6var = 2;
         return test6var + f;
     }
-// CHECK: store storage slot(uint256 3)
-// CHECK: store storage slot(uint256 3)
 
-// BEGIN-CHECK: deadstorage::function::test7
+    // CHECK: store storage slot(uint256 3)
+    // CHECK: store storage slot(uint256 3)
+
+    // BEGIN-CHECK: deadstorage::function::test7
     // storage should be flushed before function call
     int test7var;
+
     function test7() public returns (int) {
         test7var = 1;
         test6();
         test7var = 2;
         return test7var;
     }
-// CHECK: store storage slot(uint256 4)
-// CHECK: store storage slot(uint256 4)
 
-// BEGIN-CHECK: deadstorage::function::test8
+    // CHECK: store storage slot(uint256 4)
+    // CHECK: store storage slot(uint256 4)
+
+    // BEGIN-CHECK: deadstorage::function::test8
     // clear before store is redundant
     int test8var;
+
     function test8() public {
         delete test8var;
         test8var = 2;
     }
-// NOT-CHECK: clear storage slot(uint256 5)
-// CHECK: store storage slot(uint256 5)
 
-// BEGIN-CHECK: deadstorage::function::test9
+    // NOT-CHECK: clear storage slot(uint256 5)
+    // CHECK: store storage slot(uint256 5)
+
+    // BEGIN-CHECK: deadstorage::function::test9
     // push should make both load/stores not redundant
     bytes test9var;
-    function test9() public returns (bytes){
+
+    function test9() public returns (bytes) {
         test9var = "a";
         bytes f = test9var;
         test9var.push(hex"01");
@@ -106,15 +120,17 @@ contract deadstorage {
 
         return f;
     }
-// CHECK: store storage slot(uint256 6)
-// CHECK: load storage slot(uint256 6)
-// CHECK: push storage ty:bytes1 slot:uint256 6
-// CHECK: load storage slot(uint256 6)
-// CHECK: store storage slot(uint256 6)
 
-// BEGIN-CHECK: deadstorage::function::test10
+    // CHECK: store storage slot(uint256 6)
+    // CHECK: load storage slot(uint256 6)
+    // CHECK: push storage ty:bytes1 slot:uint256 6
+    // CHECK: load storage slot(uint256 6)
+    // CHECK: store storage slot(uint256 6)
+
+    // BEGIN-CHECK: deadstorage::function::test10
     // pop should make both load/stores not redundant
     bytes test10var;
+
     function test10() public returns (bytes) {
         test10var = "a";
         bytes f = test10var;
@@ -124,48 +140,53 @@ contract deadstorage {
 
         return f;
     }
-// CHECK: store storage slot(uint256 7)
-// CHECK: load storage slot(uint256 7)
-// CHECK: pop storage ty:bytes1 slot(uint256 7)
-// CHECK: load storage slot(uint256 7)
-// CHECK: store storage slot(uint256 7)
 
-// BEGIN-CHECK: deadstorage::function::test11
+    // CHECK: store storage slot(uint256 7)
+    // CHECK: load storage slot(uint256 7)
+    // CHECK: pop storage ty:bytes1 slot(uint256 7)
+    // CHECK: load storage slot(uint256 7)
+    // CHECK: store storage slot(uint256 7)
+
+    // BEGIN-CHECK: deadstorage::function::test11
     // some array tests
     int[11] test11var;
+
     function test11(uint index, uint index2) public view returns (int) {
         return test11var[index] + test11var[index2];
     }
 
-// CHECK: load storage slot((overflowing uint256 8
-// CHECK: load storage slot((overflowing uint256 8
+    // CHECK: load storage slot((overflowing uint256 8
+    // CHECK: load storage slot((overflowing uint256 8
 
-// BEGIN-CHECK: deadstorage::function::test12
+    // BEGIN-CHECK: deadstorage::function::test12
     // one load needed for this
     int[11] test12var;
+
     function test12(uint index) public view returns (int) {
         return test12var[index] + test12var[index];
-
     }
-// CHECK: load storage slot((overflowing uint256 19
-// NOT-CHECK: load storage slot((overflowing uint256 19
+    // CHECK: load storage slot((overflowing uint256 19
+    // NOT-CHECK: load storage slot((overflowing uint256 19
 }
 
 contract foo {
-    struct S { int32 f1; }
-        S[] arr;
+    struct S {
+        int32 f1;
+    }
+    S[] arr;
 
     function g() private returns (S storage, S storage) {
         return (arr[0], arr[1]);
     }
-// BEGIN-CHECK: foo::foo::function::f
+
+    // BEGIN-CHECK: foo::foo::function::f
     function f() public returns (S, S) {
         S[] storage ptrArr = arr;
         ptrArr.push(S({f1: 1}));
         ptrArr.push(S({f1: 2}));
-// CHECK: %.temp.115, %.temp.116 = call foo::foo::function::g
-// CHECK: %temp.117 = load storage slot(%.temp.115) ty:struct foo.S
-// CHECK: %temp.118 = load storage slot(%.temp.116) ty:struct foo.S
+        // CHECK: %.temp.119, %.temp.120 = call foo::foo::function::g
+        // CHECK: %temp.121 = load storage slot(%.temp.119) ty:struct foo.S
+        // CHECK: %temp.122 = load storage slot(%.temp.120) ty:struct foo.S
         return g();
     }
 }

--- a/tests/codegen_testcases/solidity/scale.sol
+++ b/tests/codegen_testcases/solidity/scale.sol
@@ -63,24 +63,24 @@ contract CompactEncoding {
         // CHECK: branchcond (unsigned more (builtin ArrayLength ((arg #0))) > uint32 1073741823), block6, block7
 
         // CHECK: block1: # small
-        // CHECK: ty:uint32 %temp.19 = uint32 1
+        // CHECK: ty:uint32 %temp.23 = uint32 1
         // CHECK: branch block5
 
         // CHECK: block2: # medium
-        // CHECK: ty:uint32 %temp.19 = uint32 2
+        // CHECK: ty:uint32 %temp.23 = uint32 2
         // CHECK: branch block5
 
         // CHECK: block3: # medium_or_big
         // CHECK: branchcond (unsigned more (builtin ArrayLength ((arg #0))) > uint32 16383), block4, block2
 
         // CHECK: block4: # big
-        // CHECK: ty:uint32 %temp.19 = uint32 4
+        // CHECK: ty:uint32 %temp.23 = uint32 4
         // CHECK: branch block5
 
         // CHECK: block5: # done
-        // CHECK: ty:bytes %abi_encoded.temp.20 = (alloc bytes len (%temp.19 + (builtin ArrayLength ((arg #0)))))
-        // CHECK: ty:uint32 %temp.21 = (builtin ArrayLength ((arg #0)))
-        // CHECK: branchcond (unsigned more %temp.21 > uint32 1073741823), block13, block14
+        // CHECK: ty:bytes %abi_encoded.temp.24 = (alloc bytes len (%temp.23 + (builtin ArrayLength ((arg #0)))))
+        // CHECK: ty:uint32 %temp.25 = (builtin ArrayLength ((arg #0)))
+        // CHECK: branchcond (unsigned more %temp.25 > uint32 1073741823), block13, block14
 
         // CHECK: block6: # fail
         // CHECK: assert-failure
@@ -89,29 +89,29 @@ contract CompactEncoding {
         // CHECK: branchcond (unsigned more (builtin ArrayLength ((arg #0))) > uint32 63), block3, block1
 
         // CHECK: block8: # small
-        // CHECK: writebuffer buffer:%abi_encoded.temp.20 offset:uint32 0 value:uint8((%temp.21 * uint32 4))
-        // CHECK: ty:uint32 %temp.22 = uint32 1
+        // CHECK: writebuffer buffer:%abi_encoded.temp.24 offset:uint32 0 value:uint8((%temp.25 * uint32 4))
+        // CHECK: ty:uint32 %temp.26 = uint32 1
         // CHECK: branch block12
 
         // CHECK: block9: # medium
-        // CHECK: writebuffer buffer:%abi_encoded.temp.20 offset:uint32 0 value:uint16(((%temp.21 * uint32 4) | uint32 1))
-        // CHECK: ty:uint32 %temp.22 = uint32 2
+        // CHECK: writebuffer buffer:%abi_encoded.temp.24 offset:uint32 0 value:uint16(((%temp.25 * uint32 4) | uint32 1))
+        // CHECK: ty:uint32 %temp.26 = uint32 2
         // CHECK: branch block12
 
         // CHECK: block10: # medium_or_big
-        // CHECK: branchcond (unsigned more %temp.21 > uint32 16383), block11, block9
+        // CHECK: branchcond (unsigned more %temp.25 > uint32 16383), block11, block9
 
         // CHECK: block11: # big
-        // CHECK: writebuffer buffer:%abi_encoded.temp.20 offset:uint32 0 value:((%temp.21 * uint32 4) | uint32 2)
-        // CHECK: ty:uint32 %temp.22 = uint32 4
+        // CHECK: writebuffer buffer:%abi_encoded.temp.24 offset:uint32 0 value:((%temp.25 * uint32 4) | uint32 2)
+        // CHECK: ty:uint32 %temp.26 = uint32 4
         // CHECK: branch block12
 
         // CHECK: block12: # done
-        // CHECK: memcpy src: (arg #0), dest: (advance ptr: %abi_encoded.temp.20, by: (uint32 0 + %temp.22)), bytes_len: %temp.21
-        // CHECK: ty:bytes %enc = %abi_encoded.temp.20
-        // CHECK: ty:uint32 %temp.23 = (builtin ArrayLength (%enc))
-        // CHECK: ty:uint32 %temp.25 = (zext uint32 (builtin ReadFromBuffer (%enc, uint32 0)))
-        // CHECK: switch (%temp.25 & uint32 3):
+        // CHECK: memcpy src: (arg #0), dest: (advance ptr: %abi_encoded.temp.24, by: (uint32 0 + %temp.26)), bytes_len: %temp.25
+        // CHECK: ty:bytes %enc = %abi_encoded.temp.24
+        // CHECK: ty:uint32 %temp.27 = (builtin ArrayLength (%enc))
+        // CHECK: ty:uint32 %temp.29 = (zext uint32 (builtin ReadFromBuffer (%enc, uint32 0)))
+        // CHECK: switch (%temp.29 & uint32 3):
         // CHECK:         case uint32 0: goto block #15
         // CHECK:         case uint32 1: goto block #16
         // CHECK:         case uint32 2: goto block #17
@@ -121,39 +121,39 @@ contract CompactEncoding {
         // CHECK: assert-failure
 
         // CHECK: block14: # prepare
-        // CHECK: branchcond (unsigned more %temp.21 > uint32 63), block10, block8
+        // CHECK: branchcond (unsigned more %temp.25 > uint32 63), block10, block8
 
         // CHECK: block15: # case_0
-        // CHECK: ty:uint32 %temp.24 = (%temp.25 >> uint32 2)
-        // CHECK: ty:uint32 %temp.25 = uint32 1
+        // CHECK: ty:uint32 %temp.28 = (%temp.29 >> uint32 2)
+        // CHECK: ty:uint32 %temp.29 = uint32 1
         // CHECK: branch block19
 
         // CHECK: block16: # case_1
-        // CHECK: ty:uint32 %temp.24 = ((zext uint32 (builtin ReadFromBuffer (%enc, uint32 0))) >> uint32 2)
-        // CHECK: ty:uint32 %temp.25 = uint32 2
+        // CHECK: ty:uint32 %temp.28 = ((zext uint32 (builtin ReadFromBuffer (%enc, uint32 0))) >> uint32 2)
+        // CHECK: ty:uint32 %temp.29 = uint32 2
         // CHECK: branch block19
 
         // CHECK: block17: # case_2
-        // CHECK: ty:uint32 %temp.24 = ((builtin ReadFromBuffer (%enc, uint32 0)) >> uint32 2)
-        // CHECK: ty:uint32 %temp.25 = uint32 4
+        // CHECK: ty:uint32 %temp.28 = ((builtin ReadFromBuffer (%enc, uint32 0)) >> uint32 2)
+        // CHECK: ty:uint32 %temp.29 = uint32 4
         // CHECK: branch block19
 
         // CHECK: block18: # case_default
         // CHECK: assert-failure
 
         // CHECK: block19: # done
-        // CHECK: branchcond (unsigned (uint32 0 + %temp.25) <= %temp.23), block20, block21
+        // CHECK: branchcond (unsigned (uint32 0 + %temp.29) <= %temp.27), block20, block21
 
         // CHECK: block20: # inbounds
-        // CHECK: branchcond (unsigned (uint32 0 + (%temp.24 + %temp.25)) <= %temp.23), block22, block23
+        // CHECK: branchcond (unsigned (uint32 0 + (%temp.28 + %temp.29)) <= %temp.27), block22, block23
 
         // CHECK: block21: # out_of_bounds
         // CHECK: assert-failure
 
         // CHECK: block22: # inbounds
-        // CHECK: ty:string %temp.26 = (alloc string len %temp.24)
-        // CHECK: memcpy src: (advance ptr: %enc, by: (uint32 0 + %temp.25)), dest: %temp.26, bytes_len: %temp.24
-        // CHECK: branchcond (unsigned less (uint32 0 + (%temp.24 + %temp.25)) < %temp.23), block24, block25
+        // CHECK: ty:string %temp.30 = (alloc string len %temp.28)
+        // CHECK: memcpy src: (advance ptr: %enc, by: (uint32 0 + %temp.29)), dest: %temp.30, bytes_len: %temp.28
+        // CHECK: branchcond (unsigned less (uint32 0 + (%temp.28 + %temp.29)) < %temp.27), block24, block25
 
         // CHECK: block23: # out_of_bounds
         // CHECK: assert-failure

--- a/tests/codegen_testcases/solidity/substrate_dispatch.sol
+++ b/tests/codegen_testcases/solidity/substrate_dispatch.sol
@@ -181,7 +181,6 @@ contract is_payable {
 	// CHECK: block3: # func_0_dispatch
 	// CHECK: 	branchcond (unsigned more %value.temp.30 > uint128 0), block4, block5
 	// CHECK: block4: # func_0_got_value
-	// CHECK: 	print (format string ( hex"72756e74696d655f6572726f723a206e6f6e2070617961626c652066756e6374696f6e20666f6f2072656365697665642076616c75652c0a"))
 	// CHECK: 	assert-failure
 	// CHECK: block5: # func_0_no_value
 	// CHECK: 	 = call is_payable::is_payable::function::foo 
@@ -242,7 +241,6 @@ contract overloaded {
 	// CHECK: block4: # func_3_dispatch
 	// CHECK: 	branchcond (unsigned more %value.temp.38 > uint128 0), block5, block6
 	// CHECK: block5: # func_3_got_value
-	// CHECK: 	print (format string ( hex"72756e74696d655f6572726f723a206e6f6e2070617961626c652066756e6374696f6e20665f5f75696e743235362072656365697665642076616c75652c0a"))
 	// CHECK: 	assert-failure
 	// CHECK: block6: # func_3_no_value
 	// CHECK: 	ty:uint32 %temp.40 = (trunc uint32 (%input_len.temp.37 - uint32 4))
@@ -314,7 +312,6 @@ contract simple {
 	// CHECK: block3: # func_0_dispatch
 	// CHECK: 	branchcond (unsigned more %value.temp.48 > uint128 0), block4, block5
 	// CHECK: block4: # func_0_got_value
-	// CHECK: 	print (format string ( hex"72756e74696d655f6572726f723a206e6f6e2070617961626c652066756e6374696f6e20666f6f2072656365697665642076616c75652c0a"))
 	// CHECK: 	assert-failure
 	// CHECK: block5: # func_0_no_value
 	// CHECK: 	 = call simple::simple::function::foo 

--- a/tests/codegen_testcases/solidity/substrate_dispatch.sol
+++ b/tests/codegen_testcases/solidity/substrate_dispatch.sol
@@ -286,6 +286,7 @@ contract simple {
 	// CHECK: 	store (arg #3), %selector.temp.46
 	// CHECK: 	switch %selector.temp.46:
 	// CHECK: 		case uint32 3576764294: goto block #3
+	// NOT-CHECK: 	case uint32 2018875586: goto block #3
 	// CHECK: 		default: goto block #2
 	// CHECK: block2: # fb_or_recv
 	// CHECK: 	return code: function selector invalid
@@ -306,6 +307,7 @@ contract simple {
 	// CHECK: 	store (arg #3), %selector.temp.50
 	// CHECK: 	switch %selector.temp.50:
 	// CHECK: 		case uint32 2018875586: goto block #3
+	// NOT-CHECK: 	case uint32 3576764294: goto block #3
 	// CHECK: 		default: goto block #2
 	// CHECK: block2: # fb_or_recv
 	// CHECK: 	return code: function selector invalid

--- a/tests/codegen_testcases/solidity/substrate_dispatch.sol
+++ b/tests/codegen_testcases/solidity/substrate_dispatch.sol
@@ -2,169 +2,268 @@
 
 contract has_fallback_and_receive {
 	// BEGIN-CHECK: Contract: has_fallback_and_receive
+
+	// CHECK: # function substrate_deploy_dispatch public:false selector: nonpayable:false
 	// CHECK: block0: # entry
-	// CHECK:         ty:uint32 %input_len.temp.1 = (arg #1)
-	// CHECK:         ty:uint128 %value.temp.2 = (arg #2)
-	// CHECK:         ty:buffer_pointer %input_ptr.temp.3 = (arg #0)
-	// CHECK:         branchcond (unsigned less %input_len.temp.1 < uint32 4), block2, block1
+	// CHECK: 	ty:uint32 %input_len.temp.1 = (arg #1)
+	// CHECK: 	ty:uint128 %value.temp.2 = (arg #2)
+	// CHECK: 	ty:buffer_pointer %input_ptr.temp.3 = (arg #0)
+	// CHECK: 	branchcond (unsigned less %input_len.temp.1 < uint32 4), block2, block1
 	// CHECK: block1: # start_dispatch
-	// CHECK:         ty:uint32 %selector.temp.4 = (builtin ReadFromBuffer ((arg #0), uint32 0))
-	// CHECK:         store (arg #3), %selector.temp.4
-	// CHECK:         switch %selector.temp.4:
-	// CHECK:                 case uint32 3576764294: goto block #3
-	// CHECK:                 default: goto block #2
+	// CHECK: 	ty:uint32 %selector.temp.4 = (builtin ReadFromBuffer ((arg #0), uint32 0))
+	// CHECK: 	store (arg #3), %selector.temp.4
+	// CHECK: 	switch %selector.temp.4:
+	// CHECK: 		case uint32 3576764294: goto block #3
+	// CHECK: 		default: goto block #2
 	// CHECK: block2: # fb_or_recv
-	// CHECK:         branchcond (unsigned more %value.temp.2 > uint128 0), block5, block4
+	// CHECK: 	return code: function selector invalid
 	// CHECK: block3: # func_3_dispatch
-	// CHECK:          = call has_fallback_and_receive::has_fallback_and_receive::constructor::861731d5 
-	// CHECK:         return data (alloc bytes len uint32 0), data length: uint32 0
-	// CHECK: block4: # fallback
-	// CHECK:          = call has_fallback_and_receive::has_fallback_and_receive::fallback 
-	// CHECK:         return data (alloc bytes len uint32 0), data length: uint32 0
-	// CHECK: block5: # receive
-	// CHECK:          = call has_fallback_and_receive::has_fallback_and_receive::receive 
-	// CHECK:         return data (alloc bytes len uint32 0), data length: uint32 0
+	// CHECK: 	 = call has_fallback_and_receive::has_fallback_and_receive::constructor::861731d5 
+	// CHECK: 	return data (alloc bytes len uint32 0), data length: uint32 0
+
+	// CHECK: # function substrate_call_dispatch public:false selector: nonpayable:false
+	// CHECK: block0: # entry
+	// CHECK: 	ty:uint32 %input_len.temp.5 = (arg #1)
+	// CHECK: 	ty:uint128 %value.temp.6 = (arg #2)
+	// CHECK: 	ty:buffer_pointer %input_ptr.temp.7 = (arg #0)
+	// CHECK: 	branchcond (unsigned less %input_len.temp.5 < uint32 4), block2, block1
+	// CHECK: block1: # start_dispatch
+	// CHECK: 	ty:uint32 %selector.temp.8 = (builtin ReadFromBuffer ((arg #0), uint32 0))
+	// CHECK: 	store (arg #3), %selector.temp.8
+	// CHECK: 	switch %selector.temp.8:
+	// CHECK: 		default: goto block #2
+	// CHECK: block2: # fb_or_recv
+	// CHECK: 	branchcond (unsigned more %value.temp.6 > uint128 0), block4, block3
+	// CHECK: block3: # fallback
+	// CHECK: 	 = call has_fallback_and_receive::has_fallback_and_receive::fallback 
+	// CHECK: 	return data (alloc bytes len uint32 0), data length: uint32 0
+	// CHECK: block4: # receive
+	// CHECK: 	 = call has_fallback_and_receive::has_fallback_and_receive::receive 
+	// CHECK: 	return data (alloc bytes len uint32 0), data length: uint32 0
+
 	fallback() external {}
 	receive() payable external {}
 }
 
 contract has_fallback {
 	// BEGIN-CHECK: Contract: has_fallback
+
+	// CHECK: # function substrate_deploy_dispatch public:false selector: nonpayable:false
+	// CHECK: # params: buffer_pointer,uint32,uint128,uint32
+	// CHECK: # returns: 
 	// CHECK: block0: # entry
-	// CHECK:         ty:uint32 %input_len.temp.5 = (arg #1)
-	// CHECK:         ty:uint128 %value.temp.6 = (arg #2)
-	// CHECK:         ty:buffer_pointer %input_ptr.temp.7 = (arg #0)
-	// CHECK:         branchcond (unsigned less %input_len.temp.5 < uint32 4), block2, block1
+	// CHECK: 	ty:uint32 %input_len.temp.9 = (arg #1)
+	// CHECK: 	ty:uint128 %value.temp.10 = (arg #2)
+	// CHECK: 	ty:buffer_pointer %input_ptr.temp.11 = (arg #0)
+	// CHECK: 	branchcond (unsigned less %input_len.temp.9 < uint32 4), block2, block1
 	// CHECK: block1: # start_dispatch
-	// CHECK:         ty:uint32 %selector.temp.8 = (builtin ReadFromBuffer ((arg #0), uint32 0))
-	// CHECK:         store (arg #3), %selector.temp.8
-	// CHECK:         switch %selector.temp.8:
-	// CHECK:                 case uint32 3576764294: goto block #3
-	// CHECK:                 default: goto block #2
+	// CHECK: 	ty:uint32 %selector.temp.12 = (builtin ReadFromBuffer ((arg #0), uint32 0))
+	// CHECK: 	store (arg #3), %selector.temp.12
+	// CHECK: 	switch %selector.temp.12:
+	// CHECK: 		case uint32 3576764294: goto block #3
+	// CHECK: 		default: goto block #2
 	// CHECK: block2: # fb_or_recv
-	// CHECK:         branchcond (unsigned more %value.temp.6 > uint128 0), block5, block4
+	// CHECK: 	return code: function selector invalid
 	// CHECK: block3: # func_2_dispatch
-	// CHECK:          = call has_fallback::has_fallback::constructor::861731d5 
-	// CHECK:         return data (alloc bytes len uint32 0), data length: uint32 0
-	// CHECK: block4: # fallback
-	// CHECK:          = call has_fallback::has_fallback::fallback 
-	// CHECK:         return data (alloc bytes len uint32 0), data length: uint32 0
-	// CHECK: block5: # receive
-	// CHECK:         return code: function selector invalid
+	// CHECK: 	 = call has_fallback::has_fallback::constructor::861731d5 
+	// CHECK: 	return data (alloc bytes len uint32 0), data length: uint32 0
+
+	// CHECK: # function substrate_call_dispatch public:false selector: nonpayable:false
+	// CHECK: block0: # entry
+	// CHECK: 	ty:uint32 %input_len.temp.13 = (arg #1)
+	// CHECK: 	ty:uint128 %value.temp.14 = (arg #2)
+	// CHECK: 	ty:buffer_pointer %input_ptr.temp.15 = (arg #0)
+	// CHECK: 	branchcond (unsigned less %input_len.temp.13 < uint32 4), block2, block1
+	// CHECK: block1: # start_dispatch
+	// CHECK: 	ty:uint32 %selector.temp.16 = (builtin ReadFromBuffer ((arg #0), uint32 0))
+	// CHECK: 	store (arg #3), %selector.temp.16
+	// CHECK: 	switch %selector.temp.16:
+	// CHECK: 		default: goto block #2
+	// CHECK: block2: # fb_or_recv
+	// CHECK: 	branchcond (unsigned more %value.temp.14 > uint128 0), block4, block3
+	// CHECK: block3: # fallback
+	// CHECK: 	 = call has_fallback::has_fallback::fallback 
+	// CHECK: 	return data (alloc bytes len uint32 0), data length: uint32 0
+	// CHECK: block4: # receive
+	// CHECK: 	return code: function selector invalid
+
 	fallback() external {}
 }
 
 contract has_receive {
 	// BEGIN-CHECK: Contract: has_receive
+
+	// CHECK: # function substrate_deploy_dispatch public:false selector: nonpayable:false
+	// CHECK: # params: buffer_pointer,uint32,uint128,uint32
+	// CHECK: # returns: 
 	// CHECK: block0: # entry
-	// CHECK:         ty:uint32 %input_len.temp.9 = (arg #1)
-	// CHECK:         ty:uint128 %value.temp.10 = (arg #2)
-	// CHECK:         ty:buffer_pointer %input_ptr.temp.11 = (arg #0)
-	// CHECK:         branchcond (unsigned less %input_len.temp.9 < uint32 4), block2, block1
+	// CHECK: 	ty:uint32 %input_len.temp.17 = (arg #1)
+	// CHECK: 	ty:uint128 %value.temp.18 = (arg #2)
+	// CHECK: 	ty:buffer_pointer %input_ptr.temp.19 = (arg #0)
+	// CHECK: 	branchcond (unsigned less %input_len.temp.17 < uint32 4), block2, block1
 	// CHECK: block1: # start_dispatch
-	// CHECK:         ty:uint32 %selector.temp.12 = (builtin ReadFromBuffer ((arg #0), uint32 0))
-	// CHECK:         store (arg #3), %selector.temp.12
-	// CHECK:         switch %selector.temp.12:
-	// CHECK:                 case uint32 3576764294: goto block #3
-	// CHECK:                 default: goto block #2
+	// CHECK: 	ty:uint32 %selector.temp.20 = (builtin ReadFromBuffer ((arg #0), uint32 0))
+	// CHECK: 	store (arg #3), %selector.temp.20
+	// CHECK: 	switch %selector.temp.20:
+	// CHECK: 		case uint32 3576764294: goto block #3
+	// CHECK: 		default: goto block #2
 	// CHECK: block2: # fb_or_recv
-	// CHECK:         branchcond (unsigned more %value.temp.10 > uint128 0), block5, block4
+	// CHECK: 	return code: function selector invalid
 	// CHECK: block3: # func_2_dispatch
-	// CHECK:          = call has_receive::has_receive::constructor::861731d5 
-	// CHECK:         return data (alloc bytes len uint32 0), data length: uint32 0
-	// CHECK: block4: # fallback
-	// CHECK:         return code: function selector invalid
-	// CHECK: block5: # receive
-	// CHECK:          = call has_receive::has_receive::receive 
-	// CHECK:         return data (alloc bytes len uint32 0), data length: uint32 0
+	// CHECK: 	 = call has_receive::has_receive::constructor::861731d5 
+	// CHECK: 	return data (alloc bytes len uint32 0), data length: uint32 0
+
+	// CHECK: # function substrate_call_dispatch public:false selector: nonpayable:false
+	// CHECK: # params: buffer_pointer,uint32,uint128,uint32
+	// CHECK: # returns: 
+	// CHECK: block0: # entry
+	// CHECK: 	ty:uint32 %input_len.temp.21 = (arg #1)
+	// CHECK: 	ty:uint128 %value.temp.22 = (arg #2)
+	// CHECK: 	ty:buffer_pointer %input_ptr.temp.23 = (arg #0)
+	// CHECK: 	branchcond (unsigned less %input_len.temp.21 < uint32 4), block2, block1
+	// CHECK: block1: # start_dispatch
+	// CHECK: 	ty:uint32 %selector.temp.24 = (builtin ReadFromBuffer ((arg #0), uint32 0))
+	// CHECK: 	store (arg #3), %selector.temp.24
+	// CHECK: 	switch %selector.temp.24:
+	// CHECK: 		default: goto block #2
+	// CHECK: block2: # fb_or_recv
+	// CHECK: 	branchcond (unsigned more %value.temp.22 > uint128 0), block4, block3
+	// CHECK: block3: # fallback
+	// CHECK: 	return code: function selector invalid
+	// CHECK: block4: # receive
+	// CHECK: 	 = call has_receive::has_receive::receive 
+	// CHECK: 	return data (alloc bytes len uint32 0), data length: uint32 0
+
 	receive() payable external {}
 }
 
 
 contract is_payable {
 	// BEGIN-CHECK: Contract: is_payable
+
+	// CHECK: # function substrate_deploy_dispatch public:false selector: nonpayable:false
+	// CHECK: # params: buffer_pointer,uint32,uint128,uint32
+	// CHECK: # returns: 
 	// CHECK: block0: # entry
-	// CHECK:         ty:uint32 %input_len.temp.13 = (arg #1)
-	// CHECK:         ty:uint128 %value.temp.14 = (arg #2)
-	// CHECK:         ty:buffer_pointer %input_ptr.temp.15 = (arg #0)
-	// CHECK:         branchcond (unsigned less %input_len.temp.13 < uint32 4), block2, block1
+	// CHECK: 	ty:uint32 %input_len.temp.25 = (arg #1)
+	// CHECK: 	ty:uint128 %value.temp.26 = (arg #2)
+	// CHECK: 	ty:buffer_pointer %input_ptr.temp.27 = (arg #0)
+	// CHECK: 	branchcond (unsigned less %input_len.temp.25 < uint32 4), block2, block1
 	// CHECK: block1: # start_dispatch
-	// CHECK:         ty:uint32 %selector.temp.16 = (builtin ReadFromBuffer ((arg #0), uint32 0))
-	// CHECK:         store (arg #3), %selector.temp.16
-	// CHECK:         switch %selector.temp.16:
-	// CHECK:                 case uint32 2018875586: goto block #3
-	// CHECK:                 case uint32 2114960382: goto block #6
-	// CHECK:                 case uint32 3576764294: goto block #7
-	// CHECK:                 default: goto block #2
+	// CHECK: 	ty:uint32 %selector.temp.28 = (builtin ReadFromBuffer ((arg #0), uint32 0))
+	// CHECK: 	store (arg #3), %selector.temp.28
+	// CHECK: 	switch %selector.temp.28:
+	// CHECK: 		case uint32 3576764294: goto block #3
+	// CHECK: 		default: goto block #2
 	// CHECK: block2: # fb_or_recv
-	// CHECK:         return code: function selector invalid
+	// CHECK: 	return code: function selector invalid
+	// CHECK: block3: # func_3_dispatch
+	// CHECK: 	 = call is_payable::is_payable::constructor::861731d5 
+	// CHECK: 	return data (alloc bytes len uint32 0), data length: uint32 0
+
+	// CHECK: # function substrate_call_dispatch public:false selector: nonpayable:false
+	// CHECK: # params: buffer_pointer,uint32,uint128,uint32
+	// CHECK: # returns: 
+	// CHECK: block0: # entry
+	// CHECK: 	ty:uint32 %input_len.temp.29 = (arg #1)
+	// CHECK: 	ty:uint128 %value.temp.30 = (arg #2)
+	// CHECK: 	ty:buffer_pointer %input_ptr.temp.31 = (arg #0)
+	// CHECK: 	branchcond (unsigned less %input_len.temp.29 < uint32 4), block2, block1
+	// CHECK: block1: # start_dispatch
+	// CHECK: 	ty:uint32 %selector.temp.32 = (builtin ReadFromBuffer ((arg #0), uint32 0))
+	// CHECK: 	store (arg #3), %selector.temp.32
+	// CHECK: 	switch %selector.temp.32:
+	// CHECK: 		case uint32 2018875586: goto block #3
+	// CHECK: 		case uint32 2114960382: goto block #6
+	// CHECK: 		default: goto block #2
+	// CHECK: block2: # fb_or_recv
+	// CHECK: 	return code: function selector invalid
 	// CHECK: block3: # func_0_dispatch
-	// CHECK:         branchcond (unsigned more %value.temp.14 > uint128 0), block4, block5
+	// CHECK: 	branchcond (unsigned more %value.temp.30 > uint128 0), block4, block5
 	// CHECK: block4: # func_0_got_value
-	// CHECK:         assert-failure
+	// CHECK: 	print (format string ( hex"72756e74696d655f6572726f723a206e6f6e2070617961626c652066756e6374696f6e20666f6f2072656365697665642076616c75652c0a"))
+	// CHECK: 	assert-failure
 	// CHECK: block5: # func_0_no_value
-	// CHECK:          = call is_payable::is_payable::function::foo 
-	// CHECK:         return data (alloc bytes len uint32 0), data length: uint32 0
+	// CHECK: 	 = call is_payable::is_payable::function::foo 
+	// CHECK: 	return data (alloc bytes len uint32 0), data length: uint32 0
 	// CHECK: block6: # func_1_dispatch
-	// CHECK:          = call is_payable::is_payable::function::bar 
-	// CHECK:         return data (alloc bytes len uint32 0), data length: uint32 0
-	// CHECK: block7: # func_3_dispatch
-	// CHECK:          = call is_payable::is_payable::constructor::861731d5 
-	// CHECK:         return data (alloc bytes len uint32 0), data length: uint32 0
+	// CHECK: 	 = call is_payable::is_payable::function::bar 
+	// CHECK: 	return data (alloc bytes len uint32 0), data length: uint32 0
+	
 	function foo() public pure {}
 	function bar() public payable { require(msg.value > 0); }
 }
 
 contract overloaded {
 	// BEGIN-CHECK: Contract: overloaded
+
+	// CHECK: # function substrate_deploy_dispatch public:false selector: nonpayable:false
 	// CHECK: block0: # entry
-	// CHECK:         ty:uint32 %input_len.temp.17 = (arg #1)
-	// CHECK:         ty:uint128 %value.temp.18 = (arg #2)
-	// CHECK:         ty:buffer_pointer %input_ptr.temp.19 = (arg #0)
-	// CHECK:         branchcond (unsigned less %input_len.temp.17 < uint32 4), block2, block1
+	// CHECK: 	ty:uint32 %input_len.temp.33 = (arg #1)
+	// CHECK: 	ty:uint128 %value.temp.34 = (arg #2)
+	// CHECK: 	ty:buffer_pointer %input_ptr.temp.35 = (arg #0)
+	// CHECK: 	branchcond (unsigned less %input_len.temp.33 < uint32 4), block2, block1
 	// CHECK: block1: # start_dispatch
-	// CHECK:         ty:uint32 %selector.temp.22 = (builtin ReadFromBuffer ((arg #0), uint32 0))
-	// CHECK:         store (arg #3), %selector.temp.22
-	// CHECK:         switch %selector.temp.22:
-	// CHECK:                 case uint32 2018875586: goto block #3
-	// CHECK:                 case uint32 2114960382: goto block #4
-	// CHECK:                 case uint32 4028568102: goto block #5
-	// CHECK:                 case uint32 2338643635: goto block #6
-	// CHECK:                 default: goto block #2
+	// CHECK: 	ty:uint32 %selector.temp.36 = (builtin ReadFromBuffer ((arg #0), uint32 0))
+	// CHECK: 	store (arg #3), %selector.temp.36
+	// CHECK: 	switch %selector.temp.36:
+	// CHECK: 		case uint32 2018875586: goto block #3
+	// CHECK: 		case uint32 2114960382: goto block #4
+	// CHECK: 		default: goto block #2
 	// CHECK: block2: # fb_or_recv
-	// CHECK:         branchcond (unsigned more %value.temp.18 > uint128 0), block14, block13
+	// CHECK: 	return code: function selector invalid
 	// CHECK: block3: # func_0_dispatch
-	// CHECK:          = call overloaded::overloaded::constructor::c2985578 
-	// CHECK:         return data (alloc bytes len uint32 0), data length: uint32 0
+	// CHECK: 	 = call overloaded::overloaded::constructor::c2985578 
+	// CHECK: 	return data (alloc bytes len uint32 0), data length: uint32 0
 	// CHECK: block4: # func_1_dispatch
-	// CHECK:          = call overloaded::overloaded::constructor::febb0f7e 
-	// CHECK:         return data (alloc bytes len uint32 0), data length: uint32 0
-	// CHECK: block5: # func_2_dispatch
-	// CHECK:          = call overloaded::overloaded::function::f 
-	// CHECK:         return data (alloc bytes len uint32 0), data length: uint32 0
-	// CHECK: block6: # func_3_dispatch
-	// CHECK:         branchcond (unsigned more %value.temp.18 > uint128 0), block7, block8
-	// CHECK: block7: # func_3_got_value
-	// CHECK:         assert-failure
-	// CHECK: block8: # func_3_no_value
-	// CHECK:         ty:uint32 %temp.20 = (trunc uint32 (%input_len.temp.17 - uint32 4))
-	// CHECK:         branchcond (unsigned (uint32 0 + uint32 32) <= %temp.20), block9, block10
-	// CHECK: block9: # inbounds
-	// CHECK:         ty:uint256 %temp.21 = (builtin ReadFromBuffer ((advance ptr: %input_ptr.temp.19, by: uint32 4), uint32 0))
-	// CHECK:         branchcond (unsigned less (uint32 0 + uint32 32) < %temp.20), block11, block12
-	// CHECK: block10: # out_of_bounds
-	// CHECK:         assert-failure
-	// CHECK: block11: # not_all_bytes_read
-	// CHECK:         assert-failure
-	// CHECK: block12: # buffer_read
-	// CHECK:          = call overloaded::overloaded::function::f__uint256 %temp.21
-	// CHECK:         return data (alloc bytes len uint32 0), data length: uint32 0
-	// CHECK: block13: # fallback
-	// CHECK:          = call overloaded::overloaded::fallback 
-	// CHECK:         return data (alloc bytes len uint32 0), data length: uint32 0
-	// CHECK: block14: # receive
-	// CHECK:          = call overloaded::overloaded::receive 
-	// CHECK:         return data (alloc bytes len uint32 0), data length: uint32 0
+	// CHECK: 	 = call overloaded::overloaded::constructor::febb0f7e 
+	// CHECK: 	return data (alloc bytes len uint32 0), data length: uint32 0
+
+	// CHECK: # function substrate_call_dispatch public:false selector: nonpayable:false
+	// CHECK: # params: buffer_pointer,uint32,uint128,uint32
+	// CHECK: # returns: 
+	// CHECK: block0: # entry
+	// CHECK: 	ty:uint32 %input_len.temp.37 = (arg #1)
+	// CHECK: 	ty:uint128 %value.temp.38 = (arg #2)
+	// CHECK: 	ty:buffer_pointer %input_ptr.temp.39 = (arg #0)
+	// CHECK: 	branchcond (unsigned less %input_len.temp.37 < uint32 4), block2, block1
+	// CHECK: block1: # start_dispatch
+	// CHECK: 	ty:uint32 %selector.temp.42 = (builtin ReadFromBuffer ((arg #0), uint32 0))
+	// CHECK: 	store (arg #3), %selector.temp.42
+	// CHECK: 	switch %selector.temp.42:
+	// CHECK: 		case uint32 4028568102: goto block #3
+	// CHECK: 		case uint32 2338643635: goto block #4
+	// CHECK: 		default: goto block #2
+	// CHECK: block2: # fb_or_recv
+	// CHECK: 	branchcond (unsigned more %value.temp.38 > uint128 0), block12, block11
+	// CHECK: block3: # func_2_dispatch
+	// CHECK: 	 = call overloaded::overloaded::function::f 
+	// CHECK: 	return data (alloc bytes len uint32 0), data length: uint32 0
+	// CHECK: block4: # func_3_dispatch
+	// CHECK: 	branchcond (unsigned more %value.temp.38 > uint128 0), block5, block6
+	// CHECK: block5: # func_3_got_value
+	// CHECK: 	print (format string ( hex"72756e74696d655f6572726f723a206e6f6e2070617961626c652066756e6374696f6e20665f5f75696e743235362072656365697665642076616c75652c0a"))
+	// CHECK: 	assert-failure
+	// CHECK: block6: # func_3_no_value
+	// CHECK: 	ty:uint32 %temp.40 = (trunc uint32 (%input_len.temp.37 - uint32 4))
+	// CHECK: 	branchcond (unsigned (uint32 0 + uint32 32) <= %temp.40), block7, block8
+	// CHECK: block7: # inbounds
+	// CHECK: 	ty:uint256 %temp.41 = (builtin ReadFromBuffer ((advance ptr: %input_ptr.temp.39, by: uint32 4), uint32 0))
+	// CHECK: 	branchcond (unsigned less (uint32 0 + uint32 32) < %temp.40), block9, block10
+	// CHECK: block8: # out_of_bounds
+	// CHECK: 	assert-failure
+	// CHECK: block9: # not_all_bytes_read
+	// CHECK: 	assert-failure
+	// CHECK: block10: # buffer_read
+	// CHECK: 	 = call overloaded::overloaded::function::f__uint256 %temp.41
+	// CHECK: 	return data (alloc bytes len uint32 0), data length: uint32 0
+	// CHECK: block11: # fallback
+	// CHECK: 	 = call overloaded::overloaded::fallback 
+	// CHECK: 	return data (alloc bytes len uint32 0), data length: uint32 0
+	// CHECK: block12: # receive
+	// CHECK: 	 = call overloaded::overloaded::receive 
+	// CHECK: 	return data (alloc bytes len uint32 0), data length: uint32 0
+
 	constructor foo() {}
 	constructor bar() {}
 	function f() public payable {}
@@ -175,29 +274,51 @@ contract overloaded {
 
 contract simple {
 	// BEGIN-CHECK: Contract: simple
+
+	// CHECK: # function substrate_deploy_dispatch public:false selector: nonpayable:false
+	// CHECK: # params: buffer_pointer,uint32,uint128,uint32
+	// CHECK: # returns: 
 	// CHECK: block0: # entry
-	// CHECK:         ty:uint32 %input_len.temp.23 = (arg #1)
-	// CHECK:         ty:uint128 %value.temp.24 = (arg #2)
-	// CHECK:         ty:buffer_pointer %input_ptr.temp.25 = (arg #0)
-	// CHECK:         branchcond (unsigned less %input_len.temp.23 < uint32 4), block2, block1
+	// CHECK: 	ty:uint32 %input_len.temp.43 = (arg #1)
+	// CHECK: 	ty:uint128 %value.temp.44 = (arg #2)
+	// CHECK: 	ty:buffer_pointer %input_ptr.temp.45 = (arg #0)
+	// CHECK: 	branchcond (unsigned less %input_len.temp.43 < uint32 4), block2, block1
 	// CHECK: block1: # start_dispatch
-	// CHECK:         ty:uint32 %selector.temp.26 = (builtin ReadFromBuffer ((arg #0), uint32 0))
-	// CHECK:         store (arg #3), %selector.temp.26
-	// CHECK:         switch %selector.temp.26:
-	// CHECK:                 case uint32 2018875586: goto block #3
-	// CHECK:                 case uint32 3576764294: goto block #6
-	// CHECK:                 default: goto block #2
+	// CHECK: 	ty:uint32 %selector.temp.46 = (builtin ReadFromBuffer ((arg #0), uint32 0))
+	// CHECK: 	store (arg #3), %selector.temp.46
+	// CHECK: 	switch %selector.temp.46:
+	// CHECK: 		case uint32 3576764294: goto block #3
+	// CHECK: 		default: goto block #2
 	// CHECK: block2: # fb_or_recv
-	// CHECK:         return code: function selector invalid
+	// CHECK: 	return code: function selector invalid
+	// CHECK: block3: # func_2_dispatch
+	// CHECK: 	 = call simple::simple::constructor::861731d5 
+	// CHECK: 	return data (alloc bytes len uint32 0), data length: uint32 0
+
+	// CHECK: # function substrate_call_dispatch public:false selector: nonpayable:false
+	// CHECK: # params: buffer_pointer,uint32,uint128,uint32
+	// CHECK: # returns: 
+	// CHECK: block0: # entry
+	// CHECK: 	ty:uint32 %input_len.temp.47 = (arg #1)
+	// CHECK: 	ty:uint128 %value.temp.48 = (arg #2)
+	// CHECK: 	ty:buffer_pointer %input_ptr.temp.49 = (arg #0)
+	// CHECK: 	branchcond (unsigned less %input_len.temp.47 < uint32 4), block2, block1
+	// CHECK: block1: # start_dispatch
+	// CHECK: 	ty:uint32 %selector.temp.50 = (builtin ReadFromBuffer ((arg #0), uint32 0))
+	// CHECK: 	store (arg #3), %selector.temp.50
+	// CHECK: 	switch %selector.temp.50:
+	// CHECK: 		case uint32 2018875586: goto block #3
+	// CHECK: 		default: goto block #2
+	// CHECK: block2: # fb_or_recv
+	// CHECK: 	return code: function selector invalid
 	// CHECK: block3: # func_0_dispatch
-	// CHECK:         branchcond (unsigned more %value.temp.24 > uint128 0), block4, block5
+	// CHECK: 	branchcond (unsigned more %value.temp.48 > uint128 0), block4, block5
 	// CHECK: block4: # func_0_got_value
-	// CHECK:         assert-failure
+	// CHECK: 	print (format string ( hex"72756e74696d655f6572726f723a206e6f6e2070617961626c652066756e6374696f6e20666f6f2072656365697665642076616c75652c0a"))
+	// CHECK: 	assert-failure
 	// CHECK: block5: # func_0_no_value
-	// CHECK:          = call simple::simple::function::foo 
-	// CHECK:         return data (alloc bytes len uint32 0), data length: uint32 0
-	// CHECK: block6: # func_2_dispatch
-	// CHECK:          = call simple::simple::constructor::861731d5 
-	// CHECK:         return data (alloc bytes len uint32 0), data length: uint32 0
+	// CHECK: 	 = call simple::simple::function::foo 
+	// CHECK: 	return data (alloc bytes len uint32 0), data length: uint32 0
+
 	function foo() public pure {}
 }

--- a/tests/codegen_testcases/solidity/unused_variable_elimination.sol
+++ b/tests/codegen_testcases/solidity/unused_variable_elimination.sol
@@ -66,7 +66,7 @@ contract c {
         x = 102 + t*y/(t+5*y) + g + test3() - vec.push(2) + ct.sum(1, 2);
 		return 2;
 // CHECK: push array ty:int32[] value:int32 2
-// CHECK: _ = external call::regular address:%ct payload:%abi_encoded.temp.90 value:uint128 0 gas:uint64 0 accounts: seeds:
+// CHECK: _ = external call::regular address:%ct payload:%abi_encoded.temp.94 value:uint128 0 gas:uint64 0 accounts: seeds:
 }
 
 }
@@ -77,13 +77,13 @@ contract c3 {
         c2 ct = new c2();
 
         return 3;
-// CHECK: constructor(no: ) salt: value: gas:uint64 0 address: seeds: c2 encoded buffer: %abi_encoded.temp.109 accounts: 
+// CHECK: constructor(no: ) salt: value: gas:uint64 0 address: seeds: c2 encoded buffer: %abi_encoded.temp.117 accounts: 
     }
 
 // BEGIN-CHECK: c3::function::test7
     function test7() public returns (int32) {
         c2 ct = new c2();
-// constructor salt: value: gas:uint64 0 address: seeds: c2 (encoded buffer: %abi_encoded.temp.110, buffer len: uint32 4)
+// constructor salt: value: gas:uint64 0 address: seeds: c2 (encoded buffer: %abi_encoded.temp.119, buffer len: uint32 4)
         address ad = address(ct);
         (bool p, ) = ad.call(hex'ba');
 // CHECK: external call::regular address:%ad payload:(alloc bytes uint32 1 hex"ba") value:uint128 0 gas:uint64 0
@@ -136,7 +136,7 @@ return 3;
         int f = 4;
 
         int c = 32 +4 *(f = it1+it2);
-// CHECK: ty:int256 %c = (int256 32 + (sext int256 (int64 4 * (trunc int64 (%temp.118 + %temp.119)))))
+// CHECK: ty:int256 %c = (int256 32 + (sext int256 (int64 4 * (trunc int64 (%temp.126 + %temp.127)))))
 // NOT-CHECK: ty:int256 %f = (%temp.10 + %temp.11)
         return c;
     }
@@ -177,7 +177,7 @@ return 3;
     function test14() public returns (int) {
         int[] storage ptrArr = testArr;
 
-// CHECK: store storage slot(%temp.138) ty:int256 storage = int256 3
+// CHECK: store storage slot(%temp.146) ty:int256 storage = int256 3
         ptrArr.push(3);
 
         return ptrArr[0];

--- a/tests/substrate.rs
+++ b/tests/substrate.rs
@@ -904,13 +904,8 @@ impl MockSubstrate {
         self.invoke("call", input).unwrap();
     }
 
-    /// Call the "call" function with the given input and expect the contract to trap.
-    ///
-    /// `input` must contain the desired function selector.
-    ///
-    /// Only traps caused by an `unreachable` instruction are allowed. Other traps will panic instead.
-    pub fn raw_function_failure(&mut self, input: Vec<u8>) {
-        match self.invoke("call", input) {
+    fn raw_failure(&mut self, export: &str, input: Vec<u8>) {
+        match self.invoke(export, input) {
             Err(wasmi::Error::Trap(trap)) => match trap.trap_code() {
                 Some(TrapCode::UnreachableCodeReached) => (),
                 _ => panic!("trap: {trap:?}"),
@@ -918,6 +913,24 @@ impl MockSubstrate {
             Err(err) => panic!("unexpected error: {err:?}"),
             Ok(_) => panic!("unexpected return from main"),
         }
+    }
+
+    /// Call the "call" function with the given input and expect the contract to trap.
+    ///
+    /// `input` must contain the desired function selector.
+    ///
+    /// Only traps caused by an `unreachable` instruction are allowed. Other traps will panic instead.
+    pub fn raw_function_failure(&mut self, input: Vec<u8>) {
+        self.raw_failure("call", input);
+    }
+
+    /// Call the "deploy" function with the given input and expect the contract to trap.
+    ///
+    /// `input` must contain the desired function selector.
+    ///
+    /// Only traps caused by an `unreachable` instruction are allowed. Other traps will panic instead.
+    pub fn raw_constructor_failure(&mut self, input: Vec<u8>) {
+        self.raw_failure("deploy", input);
     }
 
     pub fn heap_verify(&mut self) {

--- a/tests/substrate_tests/calls.rs
+++ b/tests/substrate_tests/calls.rs
@@ -1055,13 +1055,13 @@ fn constructors_and_messages_distinct_in_dispatcher() {
         }"##,
     );
 
-    let constructor = 0x00010203u32.to_be_bytes().to_vec();
+    let constructor = vec![0, 1, 2, 3];
     // Given this constructor selector works as intended
     runtime.raw_constructor(constructor.clone());
     // Expect calling the constructor via "call" to trap the contract
     runtime.raw_function_failure(constructor);
 
-    let function = 0x04050607u32.to_be_bytes().to_vec();
+    let function = vec![4, 5, 6, 7];
     // Given this function selector works as intended
     runtime.raw_function(function.clone());
     // Expect calling the function via "deploy" to trap the contract

--- a/tests/substrate_tests/calls.rs
+++ b/tests/substrate_tests/calls.rs
@@ -1041,3 +1041,26 @@ contract Flagger {
     );
     assert_eq!(u32::decode(&mut &runtime.output()[..]).unwrap(), voyager);
 }
+
+#[test]
+fn constructors_and_messages_distinct_in_dispatcher() {
+    let mut runtime = build_solidity(
+        r##"
+        contract c {
+            constructor() {}
+            function foo() public pure {}
+        }"##,
+    );
+
+    let constructor = 0xcdbf608du32.to_be_bytes().to_vec();
+    // Given this constructor selector works as intended
+    runtime.raw_constructor(constructor.clone());
+    // Expect calling the constructor via "call" to trap the contract
+    runtime.raw_function_failure(constructor);
+
+    let function = 0xc2985578u32.to_be_bytes().to_vec();
+    // Given this function selector works as intended
+    runtime.raw_function(function.clone());
+    // Expect calling the function via "deploy" to trap the contract
+    runtime.raw_constructor_failure(function);
+}

--- a/tests/substrate_tests/calls.rs
+++ b/tests/substrate_tests/calls.rs
@@ -1047,18 +1047,21 @@ fn constructors_and_messages_distinct_in_dispatcher() {
     let mut runtime = build_solidity(
         r##"
         contract c {
+            @selector([0, 1, 2, 3])
             constructor() {}
+
+            @selector([4, 5, 6, 7])
             function foo() public pure {}
         }"##,
     );
 
-    let constructor = 0xcdbf608du32.to_be_bytes().to_vec();
+    let constructor = 0x00010203u32.to_be_bytes().to_vec();
     // Given this constructor selector works as intended
     runtime.raw_constructor(constructor.clone());
     // Expect calling the constructor via "call" to trap the contract
     runtime.raw_function_failure(constructor);
 
-    let function = 0xc2985578u32.to_be_bytes().to_vec();
+    let function = 0x04050607u32.to_be_bytes().to_vec();
     // Given this function selector works as intended
     runtime.raw_function(function.clone());
     // Expect calling the function via "deploy" to trap the contract


### PR DESCRIPTION
Fix an oversight form #1249. The dispatch logic can not be the same for `call` and `deploy` as constructors must _not_ be allowed to be accessed from the `call` function.