### PR TITLE
Added get_contents_of_file_no

### DIFF
--- a/src/file_resolver.rs
+++ b/src/file_resolver.rs
@@ -82,7 +82,7 @@ impl FileResolver {
     }
 
     /// Get the file contents of `file_no`th file if it exists
-    pub fn get_file_contents_of_file_no(&self, file_no: usize) -> Option<Arc<str>> {
+    pub fn get_contents_of_file_no(&self, file_no: usize) -> Option<Arc<str>> {
         self.files.get(file_no).cloned()
     }
 

--- a/src/file_resolver.rs
+++ b/src/file_resolver.rs
@@ -81,6 +81,11 @@ impl FileResolver {
         self.cached_paths.insert(PathBuf::from(path), pos);
     }
 
+    /// Get the file contents of `file_no`th file if it exists
+    pub fn get_file_contents_of_file_no(&self, file_no: usize) -> Option<Arc<str>> {
+        self.files.get(file_no).cloned()
+    }
+
     /// Get file with contents. This must be a file which was previously
     /// add to the cache
     pub fn get_file_contents_and_number(&self, file: &Path) -> (Arc<str>, usize) {


### PR DESCRIPTION
This PR adds a public way to get the file contents from a file number. I've defaulted to a verbose function name, but happy to change that if folks like (e.g., maybe just `get_contents(file_no: usize)`, but that's a little awkward because of `set_contents(path: &str, contents: String)`... I feel like `get_XXX` and `set_XXX` should have the same type for `XXX` (in this case `file_no`'s `usize` would conflict with `path`'s `&str`)