### PR TITLE
Fix undefined variable detection

### DIFF
--- a/src/codegen/undefined_variable.rs
+++ b/src/codegen/undefined_variable.rs
@@ -43,9 +43,10 @@ pub fn find_undefined_variables(
     }
 
     let mut all_diagnostics: Vec<Diagnostic> = diagnostics.into_values().collect();
+    let has_diagnostic = !all_diagnostics.is_empty();
     ns.diagnostics.append(&mut all_diagnostics);
 
-    !all_diagnostics.is_empty()
+    has_diagnostic
 }
 
 /// Checks for undefined variables in an expression associated to an instruction

--- a/tests/contract_testcases/solana/unused_variable.sol
+++ b/tests/contract_testcases/solana/unused_variable.sol
@@ -1,0 +1,37 @@
+import "solana";
+
+contract MyTest {
+    function test_this(uint32 i, address addr) public view returns (uint32) {
+        AccountInfo info ; tx.accounts[i];
+        if (info.key == addr) {
+            return 0;
+        } else if (info.lamports == 90) {
+            return 1;
+        } else if (info.data.length == 5) {
+            return info.data.readUint32LE(4);
+        } else if (info.owner == addr) {
+            return 3;
+        } else if (info.rent_epoch == 45) {
+            return 4;
+        } else if (info.is_signer) {
+            return 5;
+        } else if (info.is_writable) {
+            return 6;
+        } else if (info.executable) {
+            return 7;
+        }
+    }
+}
+
+
+// ---- Expect: diagnostics ----
+// warning: 4:31-32: function parameter 'i' is unused
+// error: 5:21-25: Variable 'info' is undefined
+// 	note 6:13-17: Variable read before being defined
+// 	note 8:20-24: Variable read before being defined
+// 	note 12:20-24: Variable read before being defined
+// 	note 11:20-24: Variable read before being defined
+// 	note 14:20-24: Variable read before being defined
+// 	note 16:20-24: Variable read before being defined
+// 	note 18:20-24: Variable read before being defined
+// 	note 20:20-24: Variable read before being defined


### PR DESCRIPTION
The contract I added in the tests was working properly in Solang v0.3.0, but it caused a panic in [this line](https://github.com/hyperledger/solang/blob/a84b0ad3b67a17b524ef6b7437fd4c5376833807/src/codegen/strength_reduce/expression_values.rs#L79) on the main branch. 

I couldn't identify what has changed from the release till now, but I deemed the logic for reporting undefined variables and stop optimizations erroneous.