### PR TITLE
Bugfix: Type of `Error(string)` selectors should be `bytes4`

### DIFF
--- a/src/codegen/expression.rs
+++ b/src/codegen/expression.rs
@@ -3620,7 +3620,7 @@ pub(super) fn assert_failure(
     let selector = 0x08c3_79a0u32;
     let selector = Expression::NumberLiteral {
         loc: Loc::Codegen,
-        ty: Type::Uint(32),
+        ty: Type::Bytes(4),
         value: BigInt::from(selector),
     };
     let args = vec![selector, arg.unwrap()];

--- a/src/codegen/statements.rs
+++ b/src/codegen/statements.rs
@@ -1291,11 +1291,11 @@ fn try_catch(
 
         // Expect the returned data to match the 4 bytes function selector for "Error(string)"
         let buf = &Expression::ReturnData { loc: Codegen };
-        let tys = &[Uint(32), error_param.ty.clone()];
+        let tys = &[Type::Bytes(4), error_param.ty.clone()];
         let decoded = abi_decode(&Codegen, buf, tys, ns, vartab, cfg, None);
         let err_id = Expression::NumberLiteral {
             loc: Codegen,
-            ty: Uint(32),
+            ty: Type::Bytes(4),
             value: 0x08c3_79a0.into(),
         }
         .into();

--- a/tests/polkadot_tests/calls.rs
+++ b/tests/polkadot_tests/calls.rs
@@ -198,7 +198,7 @@ fn try_catch_external_calls() {
                 try o.test() returns (int32 y, bool) {
                     x = y;
                 } catch (bytes c) {
-                    assert(c == hex"a079c3080c666f6f");
+                    assert(c == hex"08c379a00c666f6f");
                     x = 2;
                 }
                 assert(x == 2);
@@ -457,7 +457,7 @@ fn try_catch_constructor() {
                     x = 1;
                 } catch (bytes c) {
                     print("returns:{}".format(c));
-                    assert(c == hex"a079c3080c666f6f");
+                    assert(c == hex"08c379a00c666f6f");
                     x = 2;
                 }
                 assert(x == 2);


### PR DESCRIPTION
Avoiding using the integer type for [`Error(string)`](https://docs.soliditylang.org/en/latest/control-structures.html#panic-via-assert-and-error-via-require) selectors avoids endianess swaps resulting in the wrong value.