### PR TITLE
Avoid narrowing casts from `size_t` to `uint32_t`

### DIFF
--- a/src/emit/instructions.rs
+++ b/src/emit/instructions.rs
@@ -189,19 +189,12 @@ pub(super) fn process_instruction<'a, T: TargetRuntime<'a> + ?Sized>(
             let size = bin.builder.build_int_mul(elem_size, new_len, "");
             let size = bin.builder.build_int_add(size, vec_size, "");
 
-            let realloc_size = if ns.target == Target::Solana {
-                bin.builder
-                    .build_int_z_extend(size, bin.context.i64_type(), "")
-            } else {
-                size
-            };
-
             // Reallocate and reassign the array pointer
             let new = bin
                 .builder
                 .build_call(
                     bin.module.get_function("__realloc").unwrap(),
-                    &[arr.into(), realloc_size.into()],
+                    &[arr.into(), size.into()],
                     "",
                 )
                 .try_as_basic_value()
@@ -355,19 +348,11 @@ pub(super) fn process_instruction<'a, T: TargetRuntime<'a> + ?Sized>(
             }
 
             // Reallocate and reassign the array pointer
-
-            let realloc_size = if ns.target == Target::Solana {
-                bin.builder
-                    .build_int_z_extend(size, bin.context.i64_type(), "")
-            } else {
-                size
-            };
-
             let new = bin
                 .builder
                 .build_call(
                     bin.module.get_function("__realloc").unwrap(),
-                    &[a.into(), realloc_size.into()],
+                    &[a.into(), size.into()],
                     "",
                 )
                 .try_as_basic_value()

--- a/stdlib/heap.c
+++ b/stdlib/heap.c
@@ -21,8 +21,8 @@
 struct chunk
 {
     struct chunk *next, *prev;
-    size_t length;
-    size_t allocated;
+    uint32_t length;
+    uint32_t allocated;
 };
 
 #ifdef __wasm__
@@ -33,7 +33,7 @@ void __init_heap()
     struct chunk *first = HEAP_START;
     first->next = first->prev = NULL;
     first->allocated = false;
-    first->length = (size_t)(__builtin_wasm_memory_size(0) * 0x10000 - (size_t)first - sizeof(struct chunk));
+    first->length = (uint32_t)(__builtin_wasm_memory_size(0) * 0x10000 - (size_t)first - sizeof(struct chunk));
 }
 #else
 #define HEAP_START ((struct chunk *)0x300000000)
@@ -75,7 +75,7 @@ void __attribute__((noinline)) __free(void *m)
     }
 }
 
-static void shrink_chunk(struct chunk *cur, size_t size)
+static void shrink_chunk(struct chunk *cur, uint32_t size)
 {
     // round up to nearest 8 bytes
     size = (size + 7) & ~7;
@@ -121,7 +121,7 @@ void *__attribute__((noinline)) __malloc(uint32_t size)
     }
 }
 
-void *__realloc(void *m, size_t size)
+void *__realloc(void *m, uint32_t size)
 {
     struct chunk *cur = m;
 

--- a/stdlib/stdlib.c
+++ b/stdlib/stdlib.c
@@ -165,7 +165,7 @@ bool __memcmp(uint8_t *left, uint32_t left_len, uint8_t *right, uint32_t right_l
 struct vector *vector_new(uint32_t members, uint32_t size, uint8_t *initial)
 {
     struct vector *v;
-    size_t size_array = members * size;
+    uint32_t size_array = members * size;
 
     v = __malloc(sizeof(*v) + size_array);
     v->len = members;
@@ -193,7 +193,7 @@ struct vector *vector_new(uint32_t members, uint32_t size, uint8_t *initial)
 
 struct vector *concat(uint8_t *left, uint32_t left_len, uint8_t *right, uint32_t right_len)
 {
-    size_t size_array = left_len + right_len;
+    uint32_t size_array = left_len + right_len;
     struct vector *v = __malloc(sizeof(*v) + size_array);
     v->len = size_array;
     v->size = size_array;

--- a/tests/solana.rs
+++ b/tests/solana.rs
@@ -465,6 +465,11 @@ impl<'a> SyscallContext<'a> {
             u64::from_le_bytes(heap[offset..offset + 8].try_into().unwrap())
         };
 
+        let read_u32 = |offset: u64| {
+            let offset = (offset - HEAP_START) as usize;
+            u32::from_le_bytes(heap[offset..offset + 4].try_into().unwrap())
+        };
+
         if VERBOSE {
             println!("heap verify:");
         }
@@ -472,14 +477,14 @@ impl<'a> SyscallContext<'a> {
         loop {
             let next: u64 = read_u64(current_elem);
             let prev: u64 = read_u64(current_elem + 8);
-            let length: u64 = read_u64(current_elem + 16);
-            let allocated: u64 = read_u64(current_elem + 24);
+            let length: u32 = read_u32(current_elem + 16);
+            let allocated: u32 = read_u32(current_elem + 20);
 
             if VERBOSE {
                 println!("next:{next:08x} prev:{prev:08x} length:{length} allocated:{allocated}");
             }
 
-            let start = (current_elem + 8 * 4 - HEAP_START) as usize;
+            let start = (current_elem + 24 - HEAP_START) as usize;
 
             let buf = &heap[start..start + length as usize];
 

--- a/tests/solana_tests/yul.rs
+++ b/tests/solana_tests/yul.rs
@@ -99,10 +99,10 @@ contract testing  {
     assert_eq!(
         returns,
         vec![
-            // the heap is 0x300000000. The header 32 bytes (sizeof(chunk) in heap.c)
+            // the heap is 0x300000000. The header 24 bytes (sizeof(chunk) in heap.c)
             BorshToken::Uint {
                 width: 256,
-                value: BigInt::from(0x300000020u64)
+                value: BigInt::from(0x300000018u64)
             },
             BorshToken::Uint {
                 width: 256,


### PR DESCRIPTION
I changed all occurrences of `size_t` to `uint32_t`, except for `sol_memset` from `solana_sdk.h`.
Converting from `size_t` to `uint32_t` could cause an overflow on Solana.
