### PR TITLE
Do not return arguments of revert

### DIFF
--- a/src/codegen/expression.rs
+++ b/src/codegen/expression.rs
@@ -3612,7 +3612,8 @@ pub(super) fn assert_failure(
     cfg: &mut ControlFlowGraph,
     vartab: &mut Vartable,
 ) {
-    if arg.is_none() {
+    // On Solana, returning the encoded arguments has no effect
+    if arg.is_none() || ns.target == Target::Solana {
         cfg.add(vartab, Instr::AssertFailure { encoded_args: None });
         return;
     }

--- a/tests/codegen_testcases/solidity/revert_require_solana.sol
+++ b/tests/codegen_testcases/solidity/revert_require_solana.sol
@@ -1,0 +1,18 @@
+// RUN: --target solana --emit cfg
+
+contract Foo {
+    // BEGIN-CHECK: Foo::Foo::function::test__uint32
+    function test(uint32 c) public pure  {
+        if (c == 6) {
+            // CHECK: print
+            // NOT-CHECK: writebuffer
+            // CHECK: assert-failure
+            revert("Hello");
+        } else if (c == 9) {
+            // CHECK: print
+            // NOT-CHECK: writebuffer
+            // CHECK: assert-failure
+            require(c == 7, "failed");
+        }
+    }
+}

--- a/tests/solana_tests/runtime_errors.rs
+++ b/tests/solana_tests/runtime_errors.rs
@@ -107,6 +107,10 @@ contract RuntimeErrors {
         return b32;
     }
 
+    function revert_with_message() public pure {
+        revert("I reverted!");
+    }
+
 }
 
 @program_id("Crea1hXZv5Snuvs38GW2SJ1vJQ2Z5uBavUnwPwpiaDiQ")
@@ -306,4 +310,11 @@ contract calle_contract {
     );
 
     vm.logs.clear();
+
+    _res = vm.function_must_fail("revert_with_message", &[]);
+    assert_eq!(
+        vm.logs,
+        "runtime_error: I reverted! revert encountered in test.sol:103:9-30,\n"
+    );
+    assert!(vm.return_data.is_none());
 }


### PR DESCRIPTION
This PR solves #1152. @salaheldinsoliman has already done most of the job. I certified that the parameter string in `revert` is indeed printed and removed all returns on Solana, as they have no effect (Anchor does not decode return data when a function reverts).