### PR TITLE
Fix compiler output section in solang.toml

### DIFF
--- a/src/bin/cli/mod.rs
+++ b/src/bin/cli/mod.rs
@@ -108,7 +108,10 @@ pub struct Compile {
     pub package: CompilePackage,
 
     #[clap(flatten)]
-    #[serde(default = "CompilerOutput::default", rename(deserialize = "compiler-output"))]
+    #[serde(
+        default = "CompilerOutput::default",
+        rename(deserialize = "compiler-output")
+    )]
     pub compiler_output: CompilerOutput,
 
     #[clap(flatten)]

--- a/src/bin/cli/mod.rs
+++ b/src/bin/cli/mod.rs
@@ -108,7 +108,7 @@ pub struct Compile {
     pub package: CompilePackage,
 
     #[clap(flatten)]
-    #[serde(default = "CompilerOutput::default")]
+    #[serde(default = "CompilerOutput::default", rename(deserialize = "compiler-output"))]
     pub compiler_output: CompilerOutput,
 
     #[clap(flatten)]


### PR DESCRIPTION
The compiler output section was not desterilized correctly from the `solang.toml` file created by `solang new`. this adds a fix for this.