### PR TITLE
Make import_no Optional

### DIFF
--- a/src/file_resolver.rs
+++ b/src/file_resolver.rs
@@ -206,7 +206,7 @@ impl FileResolver {
                 return Ok(ResolvedFile {
                     full_path,
                     base,
-                    import_no: Some(0),
+                    import_no: import_no.clone(),
                 });
             } else if let Ok(full_path) = base.join(&path).canonicalize() {
                 self.load_file(&full_path)?;
@@ -218,7 +218,7 @@ impl FileResolver {
                 return Ok(ResolvedFile {
                     full_path,
                     base,
-                    import_no: Some(0),
+                    import_no: import_no.clone(),
                 });
             }
 

--- a/src/file_resolver.rs
+++ b/src/file_resolver.rs
@@ -28,14 +28,14 @@ pub struct ResolvedFile {
     /// Full path on the filesystem
     pub full_path: PathBuf,
     /// Which import path was used, if any
-    import_no: usize,
+    import_no: Option<usize>,
     // Base part relative to import
     base: PathBuf,
 }
 
 impl ResolvedFile {
     /// Get the import number associated with this `ResolvedFile`
-    pub fn get_import_no(&self) -> usize {
+    pub fn get_import_no(&self) -> Option<usize> {
         self.import_no
     }
 }
@@ -179,7 +179,7 @@ impl FileResolver {
 
                             return Ok(ResolvedFile {
                                 full_path,
-                                import_no,
+                                import_no: Some(import_no),
                                 base,
                             });
                         }
@@ -206,7 +206,7 @@ impl FileResolver {
                 return Ok(ResolvedFile {
                     full_path,
                     base,
-                    import_no: 0,
+                    import_no: Some(0),
                 });
             } else if let Ok(full_path) = base.join(&path).canonicalize() {
                 self.load_file(&full_path)?;
@@ -218,12 +218,12 @@ impl FileResolver {
                 return Ok(ResolvedFile {
                     full_path,
                     base,
-                    import_no: 0,
+                    import_no: Some(0),
                 });
             }
 
             // start with this import
-            start_import_no = *import_no;
+            start_import_no = import_no.expect("Expected an import_no, got None instead");
         }
 
         if self.cached_paths.contains_key(&path) {
@@ -236,7 +236,7 @@ impl FileResolver {
             return Ok(ResolvedFile {
                 full_path,
                 base,
-                import_no: 0,
+                import_no: Some(0),
             });
         }
 
@@ -254,7 +254,7 @@ impl FileResolver {
 
                     return Ok(ResolvedFile {
                         full_path,
-                        import_no,
+                        import_no: Some(import_no),
                         base,
                     });
                 }

--- a/src/sema/mod.rs
+++ b/src/sema/mod.rs
@@ -99,7 +99,7 @@ fn sema_file(file: &ResolvedFile, resolver: &mut FileResolver, ns: &mut ast::Nam
         file.full_path.clone(),
         &source_code,
         file_cache_no,
-        Some(file.get_import_no()),
+        file.get_import_no(),
     ));
 
     let (pt, comments) = match parse(&source_code, file_no) {


### PR DESCRIPTION
This PR does 2 things:
1. Makes `ResolvedFile::import_no` an `Option<usize>`
2. Improves test suite for import logic

This is a first attempt, I imagine there are a few things that can be improved.

Possible issues include:
1. Some `import_no`s are set to `0` when no import is used [per this conversation](https://github.com/hyperledger/solang/pull/1419#discussion_r1259358226); in this case, the `import_no` should be set to `None`. However, I imagine others are set to 0 because it is the first import that is performed. I currently just changed all literal `import_no: 0` to `import_no: Some(0)` to get it to type check, but I'm guessing they may actually want to be `import_no: None`.
2. @seanyoung you wanted more tests, and in particular for:
    1. when no import path is used, and
    2. "when a file is resolved via relative paths and not via import paths/maps". 
  Could you expand on these more? For (i), how would I set up a case when no import path is used? For (ii), do you mean in an import statement (like `import ./blah.sol`)? I have a test that does this (imports `integrations/polkadots/createpair.sol` which has a relative import), but I'm not sure exactly what we want to test.