### PR TITLE
Add debug implementations required to print Namespace

### DIFF
--- a/src/codegen/cfg.rs
+++ b/src/codegen/cfg.rs
@@ -32,7 +32,7 @@ use std::{fmt, fmt::Write};
 // IndexMap <ArrayVariable res , res of temp variable>
 pub type ArrayLengthVars = IndexMap<usize, usize>;
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum Instr {
     /// Set variable
@@ -392,7 +392,7 @@ impl fmt::Display for HashTy {
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct BasicBlock {
     pub phis: Option<BTreeSet<usize>>,
     pub name: String,
@@ -402,7 +402,7 @@ pub struct BasicBlock {
     pub transfers: Vec<Vec<reaching_definitions::Transfer>>,
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct ControlFlowGraph {
     pub name: String,
     pub function_no: ASTFunction,
@@ -419,7 +419,7 @@ pub struct ControlFlowGraph {
     pub array_lengths_temps: ArrayLengthVars,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ASTFunction {
     SolidityFunction(usize),
     YulFunction(usize),

--- a/src/codegen/reaching_definitions.rs
+++ b/src/codegen/reaching_definitions.rs
@@ -13,7 +13,7 @@ pub struct Def {
     pub assignment_no: usize,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Transfer {
     Gen { def: Def, var_no: usize },
     Mod { var_no: usize },

--- a/src/codegen/vartable.rs
+++ b/src/codegen/vartable.rs
@@ -8,7 +8,7 @@ use num_bigint::BigInt;
 use solang_parser::pt;
 use std::collections::BTreeSet;
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Variable {
     pub id: pt::Identifier,
     pub ty: Type,
@@ -29,7 +29,7 @@ pub struct DirtyTracker {
     set: BTreeSet<usize>,
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub enum Storage {
     Constant(usize),
     Contract(BigInt),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ use solang_parser::pt;
 use std::{ffi::OsStr, fmt};
 
 /// The target chain you want to compile Solidity for.
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub enum Target {
     /// Solana, see <https://solana.com/>
     Solana,

--- a/src/sema/ast.rs
+++ b/src/sema/ast.rs
@@ -216,6 +216,7 @@ impl fmt::Display for StructDecl {
     }
 }
 
+#[derive(Debug)]
 pub struct EnumDecl {
     pub tags: Vec<Tag>,
     pub name: String,
@@ -298,6 +299,7 @@ impl fmt::Display for Mutability {
     }
 }
 
+#[derive(Debug)]
 pub struct Function {
     pub tags: Vec<Tag>,
     /// The location of the prototype (not body)
@@ -349,6 +351,7 @@ pub struct SolanaAccount {
     pub generated: bool,
 }
 
+#[derive(Debug)]
 pub enum ConstructorAnnotation {
     Seed(Expression),
     Payer(pt::Loc, String),
@@ -577,6 +580,7 @@ impl fmt::Display for UserTypeDecl {
     }
 }
 
+#[derive(Debug)]
 pub struct Variable {
     pub tags: Vec<Tag>,
     pub name: String,
@@ -590,7 +594,7 @@ pub struct Variable {
     pub read: bool,
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Symbol {
     Enum(pt::Loc, usize),
     Function(Vec<(pt::Loc, usize)>),
@@ -664,6 +668,7 @@ pub struct File {
 }
 
 /// When resolving a Solidity file, this holds all the resolved items
+#[derive(Debug)]
 pub struct Namespace {
     pub target: Target,
     pub files: Vec<File>,
@@ -700,6 +705,7 @@ pub struct Namespace {
     pub hover_overrides: HashMap<pt::Loc, String>,
 }
 
+#[derive(Debug)]
 pub struct Layout {
     pub slot: BigInt,
     pub contract_no: usize,
@@ -707,30 +713,35 @@ pub struct Layout {
     pub ty: Type,
 }
 
+#[derive(Debug)]
 pub struct Base {
     pub loc: pt::Loc,
     pub contract_no: usize,
     pub constructor: Option<(usize, Vec<Expression>)>,
 }
 
+#[derive(Debug)]
 pub struct Using {
     pub list: UsingList,
     pub ty: Option<Type>,
     pub file_no: Option<usize>,
 }
 
+#[derive(Debug)]
 pub enum UsingList {
     Library(usize),
     Functions(Vec<UsingFunction>),
 }
 
 /// Using binding for a function, optionally for an operator
+#[derive(Debug)]
 pub struct UsingFunction {
     pub loc: pt::Loc,
     pub function_no: usize,
     pub oper: Option<pt::UserDefinedOperator>,
 }
 
+#[derive(Debug)]
 pub struct Contract {
     pub tags: Vec<Tag>,
     pub loc: pt::Loc,


### PR DESCRIPTION
Derive `Debug` implementations for structs and enums required to print `struct Namespace`. This is of use when one needs to print `Namespace` struct for debugging purposes. 