### PR TITLE
Bugfix: Accessing virtual function selectors

### DIFF
--- a/src/codegen/cfg.rs
+++ b/src/codegen/cfg.rs
@@ -2124,7 +2124,10 @@ impl Namespace {
         // If a function is virtual, and it is overriden, do not make it public;
         // Otherwise the runtime function dispatch will have two identical functions to dispatch to.
         if func.is_virtual
-            && Some(self.contracts[contract_no].virtual_functions[&func.signature]) != function_no
+            && self.contracts[contract_no]
+                .virtual_functions
+                .get(&func.signature)
+                != function_no.as_ref()
         {
             return false;
         }


### PR DESCRIPTION
The added test case panics in current `main` because accessing the selector of a virtual function which is not used in any other way will put the function in `all_functions` but not `virtual_functions.`  `check_inheritance` will insert the function into `all_functions` because we have this symbol, however because we only access the selector it's not a virtual function to the contract. The fix is that when we walk `all_functions` to find the externally callable ones, do not assume every function marked `virtual` is present in the `virtual_functions` of this contract.