### PR TITLE
Polkadot does not yet support catching Panics or custom errors

### DIFF
--- a/docs/language/statements.rst
+++ b/docs/language/statements.rst
@@ -123,6 +123,9 @@ An internal function cannot be called from a try catch statement. Not all proble
 for example, out of gas cannot be caught. The ``revert()`` and ``require()`` builtins may
 be passed a reason code, which can be inspected using the ``catch Error(string)`` syntax.
 
+.. note::
+    On Polkadot, catching `Panic(uint256)` or custom errors is not supported yet.
+
 .. warning::
     On Solana, any transaction that fails halts the execution of a contract. The try-catch statement, thus,
     is not supported for Solana contracts and the compiler will raise an error if it detects its usage.

--- a/src/sema/statements.rs
+++ b/src/sema/statements.rs
@@ -2503,13 +2503,10 @@ fn try_catch(
                 Ok(())
             }
             CatchClause::Named(_, id, param, stmt) => {
-                if !matches!(id.name.as_str(), "Error" | "Panic") {
+                if !matches!(id.name.as_str(), "Error") {
                     ns.diagnostics.push(Diagnostic::error(
                         id.loc,
-                        format!(
-                            "only catch 'Error' or 'Panic' is supported, not '{}'",
-                            id.name
-                        ),
+                        format!("only catch 'Error' is supported, not '{}'", id.name),
                     ));
                     return Err(());
                 } else if let Some(annotation) = &param.annotation {
@@ -2520,20 +2517,11 @@ fn try_catch(
                 let (error_ty, ty_loc) =
                     resolve_var_decl_ty(&param.ty, &param.storage, context, ns, diagnostics)?;
 
-                if id.name == "Error" && error_ty != Type::String {
+                if error_ty != Type::String {
                     ns.diagnostics.push(Diagnostic::error(
                         param.ty.loc(),
                         format!(
                             "catch Error(...) can only take 'string memory', not '{}'",
-                            error_ty.to_string(ns)
-                        ),
-                    ));
-                }
-                if id.name == "Panic" && error_ty != Type::Uint(256) {
-                    ns.diagnostics.push(Diagnostic::error(
-                        param.ty.loc(),
-                        format!(
-                            "catch Panic(...) can only take 'uint256', not '{}'",
                             error_ty.to_string(ns)
                         ),
                     ));

--- a/tests/contract_testcases/polkadot/calls/try_catch_constructor_07.sol
+++ b/tests/contract_testcases/polkadot/calls/try_catch_constructor_07.sol
@@ -1,0 +1,12 @@
+contract C {
+    function c() public {
+        try new A() {} catch Panic(uint) {}
+    }
+}
+
+contract A {
+    function a() public pure {}
+}
+
+// ---- Expect: diagnostics ----
+// error: 3:30-35: only catch 'Error' is supported, not 'Panic'

--- a/tests/contract_testcases/polkadot/calls/try_catch_external_calls_04.sol
+++ b/tests/contract_testcases/polkadot/calls/try_catch_external_calls_04.sol
@@ -21,4 +21,4 @@
         }
         
 // ---- Expect: diagnostics ----
-// error: 8:25-28: only catch 'Error' or 'Panic' is supported, not 'Foo'
+// error: 8:25-28: only catch 'Error' is supported, not 'Foo'

--- a/tests/contract_testcases/polkadot/calls/try_catch_external_calls_05.sol
+++ b/tests/contract_testcases/polkadot/calls/try_catch_external_calls_05.sol
@@ -7,8 +7,6 @@
                     x = bla;
                 } catch Error(bytes memory f) {
                     x = 105;
-                } catch Panic(uint128 code) {
-                    x = 106;
                 } catch (string) {
                     x = 2;
                 }
@@ -24,5 +22,4 @@
 
 // ---- Expect: diagnostics ----
 // error: 8:31-36: catch Error(...) can only take 'string memory', not 'bytes'
-// error: 10:31-38: catch Panic(...) can only take 'uint256', not 'uint128'
-// error: 12:26-32: catch can only take 'bytes memory', not 'string'
+// error: 10:26-32: catch can only take 'bytes memory', not 'string'

--- a/tests/evm.rs
+++ b/tests/evm.rs
@@ -248,7 +248,7 @@ fn ethereum_solidity_tests() {
         })
         .sum();
 
-    assert_eq!(errors, 1030);
+    assert_eq!(errors, 1029);
 }
 
 fn set_file_contents(source: &str, path: &Path) -> (FileResolver, Vec<String>) {

--- a/tests/evm.rs
+++ b/tests/evm.rs
@@ -248,7 +248,7 @@ fn ethereum_solidity_tests() {
         })
         .sum();
 
-    assert_eq!(errors, 1029);
+    assert_eq!(errors, 1030);
 }
 
 fn set_file_contents(source: &str, path: &Path) -> (FileResolver, Vec<String>) {


### PR DESCRIPTION
This isn't implemented yet in codegen and it won't make it into the July release (planned for August).