### PR TITLE
Do not overwrite accounts' signer and writer flags

### DIFF
--- a/src/abi/tests.rs
+++ b/src/abi/tests.rs
@@ -2333,3 +2333,65 @@ contract BeingBuilt {
         ]
     );
 }
+
+#[test]
+fn modifier() {
+    let src1 = r#"
+import "solana";
+
+@program_id("CU8sqXecq7pxweQnJq6CARonEApGN2DXcv9ukRBRgnRf")
+contract starter {
+    bool private value = true;
+
+    modifier test_modifier() {
+        print("modifier");
+        _;
+    }
+
+    @payer(payer)
+    constructor() {
+        print("Hello, World!");
+    }
+
+    function flip() public test_modifier {
+            value = !value;
+    }
+
+    function get() public view returns (bool) {
+            return value;
+    }
+}
+    "#;
+
+    let src2 = r#"
+import "solana";
+
+@program_id("CU8sqXecq7pxweQnJq6CARonEApGN2DXcv9ukRBRgnRf")
+contract starter {
+    bool private value = true;
+
+    @payer(payer)
+    constructor() {
+        print("Hello, World!");
+    }
+
+    function flip() public {
+            value = !value;
+    }
+
+    function get() public view returns (bool) {
+            return value;
+    }
+}
+    "#;
+
+    let mut ns1 = generate_namespace(src1);
+    codegen(&mut ns1, &Options::default());
+    let idl1 = generate_anchor_idl(0, &ns1, "0.1.0");
+
+    let mut ns2 = generate_namespace(src2);
+    codegen(&mut ns2, &Options::default());
+    let idl2 = generate_anchor_idl(0, &ns2, "0.1.0");
+
+    assert_eq!(idl1, idl2);
+}

--- a/src/codegen/solana_accounts/account_collection.rs
+++ b/src/codegen/solana_accounts/account_collection.rs
@@ -34,6 +34,13 @@ struct RecurseData<'a> {
 impl RecurseData<'_> {
     /// Add an account to the function's indexmap
     fn add_account(&mut self, account_name: String, account: SolanaAccount) {
+        let (is_signer, is_writer) = self.functions[self.ast_no]
+            .solana_accounts
+            .borrow()
+            .get(&account_name)
+            .map(|acc| (acc.is_signer, acc.is_writer))
+            .unwrap_or((false, false));
+
         if self.functions[self.ast_no]
             .solana_accounts
             .borrow_mut()
@@ -41,8 +48,8 @@ impl RecurseData<'_> {
                 account_name,
                 SolanaAccount {
                     loc: account.loc,
-                    is_signer: account.is_signer,
-                    is_writer: account.is_writer,
+                    is_signer: account.is_signer || is_signer,
+                    is_writer: account.is_writer || is_writer,
                     generated: true,
                 },
             )


### PR DESCRIPTION
When we traverse a functions to collect accounts, we may add the same account multiple times. IndexMap overwrites the entry in the table, whenever we add the same key again. We should not overwrite the writer and signer flags, however.