### PR TITLE
a.b.selector adds b() as function to current contract

### DIFF
--- a/tests/codegen_testcases/solidity/selector_adds_non_base_function.sol
+++ b/tests/codegen_testcases/solidity/selector_adds_non_base_function.sol
@@ -1,0 +1,19 @@
+// RUN: --target polkadot --emit cfg
+
+// This test makes sure that we're not including the function a in contract C
+
+// CHECK-ABSENT: C::A::function::a
+
+contract C {
+    function ext_func_call(uint128 amount) public payable {
+        A a = new A();
+        (bool ok, bytes b) = address(a).call(
+            bytes4(A.a.selector)
+        );
+	b = abi.encodeCall(A.a);
+    }
+}
+
+contract A {
+    function a() public pure {}
+}


### PR DESCRIPTION
Compile the Solidity below and we end up with the non-base function in our contract.

```bash
$ solang compile --target polkadot --emit cfg
# function C::A::function::a public:true selector:0dbe671f nonpayable:true
# params: 
# returns: 
block0: # entry
	return 
```

```solidity
contract C {
    function ext_func_call(uint128 amount) public payable {
        A a = new A();
        (bool ok, bytes b) = address(a).call(
            bytes4(A.a.selector)
        );
	b = abi.encodeCall(A.a);
    }
}

contract A {
    function a() public pure {}
}
```