### PR TITLE
Relative imports are only done with relative paths and expose import_no

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to [Solang](https://github.com/hyperledger/solang/)
 will be documented here.
 
+## Unreleased
+
+### Fixed
+- **breaking** Resolving import paths now matches solc more closely, and only resolves relative
+  paths when specified as `./foo` or `../foo`. [seanyoung](https://github.com/seanyoung)
+
 ## v0.3.1 Göttingen
 
 ### Added
@@ -11,7 +17,7 @@ will be documented here.
 - The `wasm-opt` optimizer now optimizes the Wasm bytecode on the Substrate target. [xermicus](https://github.com/xermicus)
 - Call flags are now available for Substrate. [xermicus](https://github.com/xermicus)
 - Read compiler configurations from toml file. [salaheldinsoliman](https://github.com/salaheldinsoliman)
-- Accounts declared with `@payer(my_account)` can be accessed with the 
+- Accounts declared with `@payer(my_account)` can be accessed with the
   syntax `tx.accounts.my_account`. [LucasSte](https://github.com/LucasSte)
 - `delegatecall()` builtin has been added for Substrate. [xermicus](https://github.com/xermicus)
 - `get_contents_of_file_no` for Solang parser. [BenTheKush](https://github.com/BenTheKush)
@@ -52,7 +58,7 @@ will be documented here.
   contract MyContract {
     @payer(acc) // Declares account acc
     @space(2+3) // Only literals or constant expressions allowed
-    constructor(@seed bytes myseed) {} 
+    constructor(@seed bytes myseed) {}
     // When an annotations refers to a parameter, the former must appear right before the latter.
   }
   ```

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ toml = "0.7"
 wasm-opt = { version = "0.112.0", optional = true }
 contract-build = { version = "3.0.1", optional = true }
 primitive-types = { version = "0.12", features = ["codec"] }
-
+normalize-path = "0.2.1"
 
 [dev-dependencies]
 num-derive = "0.4"

--- a/docs/examples/solana/bobcat.sol
+++ b/docs/examples/solana/bobcat.sol
@@ -1,0 +1,5 @@
+anchor_anchor constant bobcat = anchor_anchor(address'z7FbDfQDfucxJz5o8jrGLgvSbdoeSqX5VrxBb5TVjHq');
+interface anchor_anchor {
+	@selector([0xaf, 0xaf, 0x6d, 0x1f, 0x0d, 0x98, 0x9b, 0xed])
+	function pounce() view external returns(int64);
+}

--- a/docs/examples/solana/call_anchor.sol
+++ b/docs/examples/solana/call_anchor.sol
@@ -1,4 +1,4 @@
-import "bobcat.sol";
+import "./bobcat.sol";
 import "solana";
 
 contract example {

--- a/docs/examples/user.sol
+++ b/docs/examples/user.sol
@@ -1,0 +1,5 @@
+struct User { string name; uint count; }
+function clear_count(User memory user) {
+	user.count = 0;
+}
+using {clear_count} for User global;

--- a/docs/examples/using_imports.sol
+++ b/docs/examples/using_imports.sol
@@ -1,4 +1,4 @@
-import {User} from "user.sol";
+import {User} from "./user.sol";
 
 contract c {
     function foo(User memory user) public {

--- a/docs/language/imports.rst
+++ b/docs/language/imports.rst
@@ -74,3 +74,14 @@ There is another syntax, which does exactly the same.
 .. code-block:: solidity
 
     import * as defs from "defines.sol";
+
+Just like string literals, import paths can have escape sequences. This is a confusing way of
+writing `a.sol`:
+
+.. code-block:: solidity
+
+    import "\x61.sol";
+
+It is possible to use ``\`` Windows style path separators on Windows, but it is not recommended
+as they do not work on platforms other than Windows (they do not work on WSL either).
+Note they have to be written as ``\\`` due to escape sequences.

--- a/docs/language/imports.rst
+++ b/docs/language/imports.rst
@@ -26,8 +26,9 @@ or just a select few items. You can also rename the imports. The following direc
 
     import {foo, bar} from "defines.sol";
 
-Solang will look for the file `defines.sol` in the same directory as the current file. You can specify
-more directories to search with the ``--importpath`` commandline option.
+Solang will look for the file `defines.sol` in the paths specified with the ``--importpath``
+commandline option. If the file is relative, e.g. ``import "./defines.sol";`` or
+``import "../defines.sol";``, then the directory relative to the parent file is used.
 Just like with ES6, ``import`` is hoisted to the top and both `foo` and `bar` are usuable
 even before the ``import`` statement. It is also possible to import everything from
 `defines.sol` by leaving the list out. Note that this is different than ES6, which would import nothing

--- a/src/abi/tests.rs
+++ b/src/abi/tests.rs
@@ -16,7 +16,7 @@ use serde_json::json;
 use std::ffi::OsStr;
 
 fn generate_namespace(src: &'static str) -> Namespace {
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
     cache.set_file_contents("test.sol", src.to_string());
     parse_and_resolve(OsStr::new("test.sol"), &mut cache, Target::Solana)
 }

--- a/src/bin/cli/mod.rs
+++ b/src/bin/cli/mod.rs
@@ -52,7 +52,7 @@ pub struct New {
     #[arg(name = "TARGETNAME",required= true, long = "target", value_parser = ["solana", "polkadot", "evm"], help = "Target to build for [possible values: solana, polkadot]", num_args = 1, hide_possible_values = true)]
     pub target_name: String,
 
-    #[arg(name = "INPUT", help = "Name of the project", num_args = 1, value_parser =  ValueParser::os_string())]
+    #[arg(name = "INPUT", help = "Name of the project", num_args = 1, value_parser = ValueParser::os_string())]
     pub project_name: Option<OsString>,
 }
 
@@ -70,10 +70,10 @@ pub struct LanguageServerCommand {
     #[clap(flatten)]
     pub target: TargetArg,
 
-    #[arg(name = "IMPORTPATH", help = "Directory to search for solidity files", value_parser = ValueParser::path_buf() , action = ArgAction::Append, long = "importpath", short = 'I', num_args = 1)]
+    #[arg(name = "IMPORTPATH", help = "Directory to search for solidity files", value_parser = ValueParser::path_buf(), action = ArgAction::Append, long = "importpath", short = 'I', num_args = 1)]
     pub import_path: Option<Vec<PathBuf>>,
 
-    #[arg(name = "IMPORTMAP", help = "Map directory to search for solidity files [format: map=path]",value_parser = ValueParser::new(parse_import_map) , action = ArgAction::Append, long = "importmap", short = 'm', num_args = 1)]
+    #[arg(name = "IMPORTMAP", help = "Map directory to search for solidity files [format: map=path]",value_parser = ValueParser::new(parse_import_map), action = ArgAction::Append, long = "importmap", short = 'm', num_args = 1)]
     pub import_map: Option<Vec<(String, PathBuf)>>,
 }
 
@@ -245,7 +245,7 @@ pub struct CompilerOutput {
     #[serde(deserialize_with = "deserialize_emit", default)]
     pub emit: Option<String>,
 
-    #[arg(name = "STD-JSON",help = "mimic solidity json output on stdout", conflicts_with_all = ["VERBOSE", "OUTPUT", "EMIT"] , action = ArgAction::SetTrue, long = "standard-json")]
+    #[arg(name = "STD-JSON",help = "mimic solidity json output on stdout", conflicts_with_all = ["VERBOSE", "OUTPUT", "EMIT"], action = ArgAction::SetTrue, long = "standard-json")]
     #[serde(default)]
     pub std_json_output: bool,
 
@@ -294,30 +294,30 @@ pub struct DocPackage {
     #[arg(name = "CONTRACT", help = "Contract names to compile (defaults to all)", value_delimiter = ',', action = ArgAction::Append, long = "contract")]
     pub contracts: Option<Vec<String>>,
 
-    #[arg(name = "IMPORTPATH", help = "Directory to search for solidity files",value_parser = ValueParser::path_buf() , action = ArgAction::Append, long = "importpath", short = 'I', num_args = 1)]
+    #[arg(name = "IMPORTPATH", help = "Directory to search for solidity files",value_parser = ValueParser::path_buf(), action = ArgAction::Append, long = "importpath", short = 'I', num_args = 1)]
     pub import_path: Option<Vec<PathBuf>>,
 
-    #[arg(name = "IMPORTMAP", help = "Map directory to search for solidity files [format: map=path]",value_parser = ValueParser::new(parse_import_map) , action = ArgAction::Append, long = "importmap", short = 'm', num_args = 1)]
+    #[arg(name = "IMPORTMAP", help = "Map directory to search for solidity files [format: map=path]",value_parser = ValueParser::new(parse_import_map), action = ArgAction::Append, long = "importmap", short = 'm', num_args = 1)]
     pub import_map: Option<Vec<(String, PathBuf)>>,
 }
 
 #[derive(Args, Deserialize, Debug, PartialEq)]
 pub struct CompilePackage {
-    #[arg(name = "INPUT", help = "Solidity input files",value_parser = ValueParser::path_buf(), num_args = 1..,)]
+    #[arg(name = "INPUT", help = "Solidity input files",value_parser = ValueParser::path_buf(), num_args = 1..)]
     #[serde(rename(deserialize = "input_files"))]
     pub input: Option<Vec<PathBuf>>,
 
     #[arg(name = "CONTRACT", help = "Contract names to compile (defaults to all)", value_delimiter = ',', action = ArgAction::Append, long = "contract")]
     pub contracts: Option<Vec<String>>,
 
-    #[arg(name = "IMPORTPATH", help = "Directory to search for solidity files",value_parser = ValueParser::path_buf() , action = ArgAction::Append, long = "importpath", short = 'I', num_args = 1)]
+    #[arg(name = "IMPORTPATH", help = "Directory to search for solidity files", value_parser = ValueParser::path_buf(), action = ArgAction::Append, long = "importpath", short = 'I', num_args = 1)]
     pub import_path: Option<Vec<PathBuf>>,
 
-    #[arg(name = "IMPORTMAP", help = "Map directory to search for solidity files [format: map=path]",value_parser = ValueParser::new(parse_import_map) , action = ArgAction::Append, long = "importmap", short = 'm', num_args = 1)]
+    #[arg(name = "IMPORTMAP", help = "Map directory to search for solidity files [format: map=path]",value_parser = ValueParser::new(parse_import_map), action = ArgAction::Append, long = "importmap", short = 'm', num_args = 1)]
     #[serde(deserialize_with = "deserialize_inline_table", default)]
     pub import_map: Option<Vec<(String, PathBuf)>>,
 
-    #[arg(name = "AUTHOR", help = "specify contracts authors" , long = "contract-authors", value_delimiter = ',', action = ArgAction::Append)]
+    #[arg(name = "AUTHOR", help = "specify contracts authors", long = "contract-authors", value_delimiter = ',', action = ArgAction::Append)]
     #[serde(default)]
     pub authors: Option<Vec<String>>,
 
@@ -513,17 +513,12 @@ impl PackageTrait for DocPackage {
 }
 
 pub fn imports_arg<T: PackageTrait>(package: &T) -> FileResolver {
-    let mut resolver = FileResolver::new();
+    let mut resolver = FileResolver::default();
 
     for filename in package.get_input() {
         if let Ok(path) = PathBuf::from(filename).canonicalize() {
             let _ = resolver.add_import_path(path.parent().unwrap());
         }
-    }
-
-    if let Err(e) = resolver.add_import_path(&PathBuf::from(".")) {
-        eprintln!("error: cannot add current directory to import path: {e}");
-        exit(1);
     }
 
     if let Some(paths) = package.get_import_path() {
@@ -651,7 +646,7 @@ where
     match str {
         Some(value) => {
             match value.as_str() {
-                "ast-dot"|"cfg"|"llvm-ir"|"llvm-bc" |"object"| "asm" => 
+                "ast-dot"|"cfg"|"llvm-ir"|"llvm-bc"|"object"|"asm" =>
                     Ok(Some(value))
                 ,
                 _ => Err(serde::de::Error::custom("Invalid option for `emit`. Valid options are: `ast-dot`, `cfg`, `llvm-ir`, `llvm-bc`, `object`, `asm`"))

--- a/src/bin/cli/test.rs
+++ b/src/bin/cli/test.rs
@@ -51,7 +51,7 @@ mod tests {
         let mut package_toml = r#"
         input_files = ["flipper.sol"]   # Files to be compiled. You can define multiple files as : input_files = ["file1", "file2", ..]
         contracts = ["flipper"] # Contracts to include from the compiled files
-        import_path = ["path1", "path2"]   
+        import_path = ["path1", "path2"]
         import_map = {map1="path", map2="path2"}    # Maps to import. Define as : import_paths = ["map=path/to/map", "map2=path/to/map2", ..]"#;
 
         let package: cli::CompilePackage = toml::from_str(package_toml).unwrap();

--- a/src/bin/languageserver/mod.rs
+++ b/src/bin/languageserver/mod.rs
@@ -94,7 +94,7 @@ pub async fn start_server(language_args: &LanguageServerCommand) -> ! {
 impl SolangServer {
     /// Parse file
     async fn parse_file(&self, uri: Url) {
-        let mut resolver = FileResolver::new();
+        let mut resolver = FileResolver::default();
         for (path, contents) in &self.files.lock().await.text_buffers {
             resolver.set_file_contents(path.to_str().unwrap(), contents.clone());
         }

--- a/src/file_resolver.rs
+++ b/src/file_resolver.rs
@@ -106,7 +106,7 @@ impl FileResolver {
     /// Atempt to resolve a file, either from the cache or from the filesystem.
     /// Returns Ok(Some(..)) if the file is found and loaded
     /// Returns Ok(None) if no file by this path can be found.
-    /// Returns Err(..) if a file could be found but not could not be read.
+    /// Returns Err(..) if a file was found but could not be read.
     fn try_file(
         &mut self,
         filename: &OsStr,

--- a/src/file_resolver.rs
+++ b/src/file_resolver.rs
@@ -103,7 +103,10 @@ impl FileResolver {
         (self.files[file_no].contents.clone(), file_no)
     }
 
-    /// Atempt to resolve a file, either from the cache or from the filesystem
+    /// Atempt to resolve a file, either from the cache or from the filesystem.
+    /// Returns Ok(Some(..)) if the file is found and loaded
+    /// Returns Ok(None) if no file by this path can be found.
+    /// Returns Err(..) if a file could be found but not could not be read.
     fn try_file(
         &mut self,
         filename: &OsStr,
@@ -181,7 +184,9 @@ impl FileResolver {
     ) -> Result<ResolvedFile, String> {
         let path = PathBuf::from(filename);
 
-        // relative path
+        // Only when the path starts with ./ or ../ are relative paths considered; this means
+        // that `import "b.sol";` will check the import paths for b.sol, while `import "./b.sol";`
+        // will only the path relative to the current file.
         if path.starts_with("./") || path.starts_with("../") {
             if let Some(ResolvedFile {
                 import_no,

--- a/src/sema/expression/literals.rs
+++ b/src/sema/expression/literals.rs
@@ -31,12 +31,7 @@ pub(super) fn string_literal(
     let mut loc = v[0].loc;
 
     for s in v {
-        result.append(&mut unescape(
-            &s.string,
-            s.loc.start(),
-            file_no,
-            diagnostics,
-        ));
+        result.append(&mut unescape(&s.string, s.loc.start(), file_no, diagnostics).1);
         loc.use_end_from(&s.loc);
     }
 

--- a/src/sema/expression/tests.rs
+++ b/src/sema/expression/tests.rs
@@ -8,11 +8,17 @@ use crate::sema::expression::strings::unescape;
 fn test_unescape() {
     let s = r"\u00f3";
     let mut vec = Diagnostics::default();
-    let res = unescape(s, 0, 0, &mut vec);
-    assert!(vec.is_empty());
+    let (valid, res) = unescape(s, 0, 0, &mut vec);
+    assert!(valid && vec.is_empty());
     assert_eq!(res, vec![0xc3, 0xb3]);
+
     let s = r"\xff";
-    let res = unescape(s, 0, 0, &mut vec);
-    assert!(vec.is_empty());
+    let (valid, res) = unescape(s, 0, 0, &mut vec);
+    assert!(valid && vec.is_empty());
     assert_eq!(res, vec![255]);
+
+    let s = r"0\xfg";
+    let (valid, res) = unescape(s, 0, 0, &mut vec);
+    assert!(!valid && !vec.is_empty());
+    assert_eq!(res, b"0");
 }

--- a/src/sema/mod.rs
+++ b/src/sema/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use self::{
+    expression::strings::unescape,
     functions::{resolve_params, resolve_returns},
     symtable::Symtable,
     unused_variable::check_unused_errors,
@@ -14,7 +15,7 @@ use solang_parser::{
     parse,
     pt::{self, CodeLocation},
 };
-use std::ffi::OsStr;
+use std::{ffi::OsString, str};
 
 mod address;
 pub mod ast;
@@ -241,7 +242,22 @@ fn resolve_import(
         return;
     }
 
-    let os_filename = OsStr::new(&filename.string);
+    let (valid, bs) = unescape(
+        &filename.string,
+        filename.loc.start(),
+        filename.loc.file_no(),
+        &mut ns.diagnostics,
+    );
+
+    if !valid {
+        return;
+    }
+
+    let os_filename = if let Some(res) = osstring_from_vec(&filename.loc, bs, ns) {
+        res
+    } else {
+        return;
+    };
 
     let import_file_no = if let Some(builtin_file_no) = ns
         .files
@@ -251,7 +267,7 @@ fn resolve_import(
         // import "solana"
         builtin_file_no
     } else {
-        match resolver.resolve_file(parent, os_filename) {
+        match resolver.resolve_file(parent, &os_filename) {
             Err(message) => {
                 ns.diagnostics
                     .push(ast::Diagnostic::error(filename.loc, message));
@@ -561,4 +577,26 @@ pub trait Recurse {
     type ArgType;
     /// recurse over a structure
     fn recurse<T>(&self, cx: &mut T, f: fn(expr: &Self::ArgType, ctx: &mut T) -> bool);
+}
+
+#[cfg(unix)]
+fn osstring_from_vec(_: &pt::Loc, bs: Vec<u8>, _: &mut ast::Namespace) -> Option<OsString> {
+    use std::os::unix::ffi::OsStringExt;
+
+    Some(OsString::from_vec(bs))
+}
+
+#[cfg(not(unix))]
+fn osstring_from_vec(loc: &pt::Loc, bs: Vec<u8>, ns: &mut ast::Namespace) -> Option<OsString> {
+    match str::from_utf8(&bs) {
+        Ok(s) => Some(OsString::from(s)),
+        Err(_) => {
+            ns.diagnostics.push(ast::Diagnostic::error(
+                *loc,
+                "string is not a valid filename".into(),
+            ));
+
+            None
+        }
+    }
 }

--- a/src/sema/mod.rs
+++ b/src/sema/mod.rs
@@ -99,7 +99,7 @@ fn sema_file(file: &ResolvedFile, resolver: &mut FileResolver, ns: &mut ast::Nam
         file.full_path.clone(),
         &source_code,
         file_cache_no,
-        Some(file.get_import_no()),
+        file.import_no,
     ));
 
     let (pt, comments) = match parse(&source_code, file_no) {
@@ -232,6 +232,14 @@ fn resolve_import(
             return;
         }
     };
+
+    if filename.string.is_empty() {
+        ns.diagnostics.push(ast::Diagnostic::error(
+            filename.loc,
+            "import path empty".into(),
+        ));
+        return;
+    }
 
     let os_filename = OsStr::new(&filename.string);
 

--- a/src/sema/tests/mod.rs
+++ b/src/sema/tests/mod.rs
@@ -9,7 +9,7 @@ use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
 
 pub(crate) fn parse(src: &'static str) -> ast::Namespace {
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
     cache.set_file_contents("test.sol", src.to_string());
 
     let ns = parse_and_resolve(OsStr::new("test.sol"), &mut cache, Target::EVM);
@@ -484,7 +484,7 @@ contract runner {
 }
     "#;
 
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
     cache.set_file_contents("test.sol", file.to_string());
 
     let ns = parse_and_resolve(OsStr::new("test.sol"), &mut cache, Target::Solana);
@@ -517,7 +517,7 @@ fn solana_discriminator_type() {
 }
     "#;
 
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
     cache.set_file_contents("test.sol", src.to_string());
 
     let ns = parse_and_resolve(OsStr::new("test.sol"), &mut cache, Target::Solana);
@@ -571,7 +571,7 @@ contract Child {
     }
 }
     "#;
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
     cache.set_file_contents("test.sol", src.to_string());
 
     let ns = parse_and_resolve(OsStr::new("test.sol"), &mut cache, Target::Solana);
@@ -611,7 +611,7 @@ contract Child {
     }
 }
     "#;
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
     cache.set_file_contents("test.sol", src.to_string());
 
     let ns = parse_and_resolve(OsStr::new("test.sol"), &mut cache, Target::Solana);
@@ -626,7 +626,7 @@ contract Child {
 
 #[test]
 fn get_import_map() {
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
     let map = OsString::from("@openzepellin");
     let example_sol_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("examples")
@@ -643,7 +643,7 @@ fn get_import_map() {
 
 #[test]
 fn get_import_path() {
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
     let examples = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("examples")
         .canonicalize()

--- a/src/sema/yul/expression.rs
+++ b/src/sema/yul/expression.rs
@@ -69,7 +69,7 @@ pub(crate) fn resolve_yul_expression(
 
         pt::YulExpression::StringLiteral(value, ty) => {
             let mut diagnostics = Diagnostics::default();
-            let unescaped_string =
+            let (_, unescaped_string) =
                 unescape(&value.string[..], 0, value.loc.file_no(), &mut diagnostics);
             ns.diagnostics.extend(diagnostics);
             resolve_string_literal(&value.loc, unescaped_string, ty, ns)

--- a/src/sema/yul/tests/expression.rs
+++ b/src/sema/yul/tests/expression.rs
@@ -1584,7 +1584,7 @@ contract foo {
     }
 }
     "#;
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
     cache.set_file_contents("test.sol", file.to_string());
 
     let ns = parse_and_resolve(OsStr::new("test.sol"), &mut cache, Target::Solana);
@@ -1601,7 +1601,7 @@ contract foo {
 }
     "#;
 
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
     cache.set_file_contents("test.sol", file.to_string());
 
     let ns = parse_and_resolve(
@@ -1625,7 +1625,7 @@ contract foo {
 }
     "#;
 
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
     cache.set_file_contents("test.sol", file.to_string());
 
     let ns = parse_and_resolve(OsStr::new("test.sol"), &mut cache, Target::Solana);

--- a/src/sema/yul/tests/mod.rs
+++ b/src/sema/yul/tests/mod.rs
@@ -16,7 +16,7 @@ mod types;
 mod unused_variable;
 
 pub(crate) fn parse(src: &'static str) -> ast::Namespace {
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
     cache.set_file_contents("test.sol", src.to_string());
 
     let ns = parse_and_resolve(OsStr::new("test.sol"), &mut cache, Target::EVM);

--- a/tests/contract.rs
+++ b/tests/contract.rs
@@ -63,7 +63,7 @@ fn recurse_directory(path: PathBuf, target: Target) -> io::Result<()> {
 }
 
 fn parse_file(path: PathBuf, target: Target) -> io::Result<()> {
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
 
     let filename = add_file(&mut cache, &path, target)?;
 
@@ -128,7 +128,7 @@ fn add_file(cache: &mut FileResolver, path: &Path, target: Target) -> io::Result
         if line.starts_with("import") {
             if let (Some(start), Some(end)) = (line.find('"'), line.rfind('"')) {
                 let file = &line[start + 1..end];
-                if file != "solana" {
+                if !file.is_empty() && file != "solana" {
                     let mut import_path = path.parent().unwrap().to_path_buf();
                     import_path.push(file);
                     println!("adding import {}", import_path.display());

--- a/tests/contract_testcases/polkadot/functions/mangling_03.sol
+++ b/tests/contract_testcases/polkadot/functions/mangling_03.sol
@@ -1,4 +1,4 @@
-import "mangling_02.sol" as X;
+import "./mangling_02.sol" as X;
 
 struct A { uint256 foo; }
 

--- a/tests/contract_testcases/solana/empty_import.sol
+++ b/tests/contract_testcases/solana/empty_import.sol
@@ -1,0 +1,3 @@
+import "" as foo;
+// ---- Expect: diagnostics ----
+// error: 1:8-10: import path empty

--- a/tests/contract_testcases/solana/import_contracts_via_object.sol
+++ b/tests/contract_testcases/solana/import_contracts_via_object.sol
@@ -1,4 +1,4 @@
-import "simple.sol" as IMP;
+import "./simple.sol" as IMP;
 
 contract C is IMP.A {
 	using IMP.L for *;

--- a/tests/contract_testcases/solana/import_free_function.sol
+++ b/tests/contract_testcases/solana/import_free_function.sol
@@ -1,7 +1,7 @@
 // ensure free function can be imported (plain, renamed, import symbol)
-import "for_if_no_else.sol";
-import {foo as renamed_foo} from "for_if_no_else.sol";
-import * as X from "for_if_no_else.sol";
+import "./for_if_no_else.sol";
+import {foo as renamed_foo} from "./for_if_no_else.sol";
+import * as X from "./for_if_no_else.sol";
 
 function bar() {
 	int x = foo();

--- a/tests/contract_testcases/solana/import_free_function_chain.sol
+++ b/tests/contract_testcases/solana/import_free_function_chain.sol
@@ -1,5 +1,5 @@
 // ensure free function can be imported via chain
-import "import_free_function.sol" as Y;
+import "./import_free_function.sol" as Y;
 
 function baz() {
 	int x = Y.X.foo();

--- a/tests/contract_testcases/solana/keep_on_resolving.sol
+++ b/tests/contract_testcases/solana/keep_on_resolving.sol
@@ -1,4 +1,4 @@
-import "type_decl_broken.sol";
+import "./type_decl_broken.sol";
 
 struct S {
 	in f1;

--- a/tests/contract_testcases/solana/type_decl_broken_more.sol
+++ b/tests/contract_testcases/solana/type_decl_broken_more.sol
@@ -1,4 +1,4 @@
-import "type_decl.sol";
+import "./type_decl.sol";
 
 function foo(Addr.X x) {}
 

--- a/tests/contract_testcases/solana/type_decl_import.sol
+++ b/tests/contract_testcases/solana/type_decl_import.sol
@@ -1,4 +1,4 @@
-import "type_decl.sol" as IMP;
+import "./type_decl.sol" as IMP;
 
 contract d {
 	function f(IMP.x c) public {

--- a/tests/contract_testcases/solana/using_import.sol
+++ b/tests/contract_testcases/solana/using_import.sol
@@ -1,4 +1,4 @@
-import "simple.sol" as simpels;
+import "./simple.sol" as simpels;
 
 function dec(simpels.S s) pure { s.f1 -= 1; }
 using {dec} for simpels.S;

--- a/tests/imports_testcases/bad_escape.sol
+++ b/tests/imports_testcases/bad_escape.sol
@@ -1,0 +1,4 @@
+
+import "bar\xyf.sol";
+
+import "bar\xff.sol";

--- a/tests/imports_testcases/imports/bar.sol
+++ b/tests/imports_testcases/imports/bar.sol
@@ -1,4 +1,4 @@
-import {rel} from "relative_import.sol";
+import {rel} from "./relative_import.sol";
 
 contract c is rel {
     function exceeds() public {

--- a/tests/imports_testcases/imports/bar.sol
+++ b/tests/imports_testcases/imports/bar.sol
@@ -1,4 +1,6 @@
-import {rel} from "./relative_import.sol";
+
+// \u0061 => 'a', \x6f => 'o'
+import {rel} from "./rel\u0061tive_imp\x6frt.sol";
 
 contract c is rel {
     function exceeds() public {

--- a/tests/imports_testcases/imports/bar_backslash.sol
+++ b/tests/imports_testcases/imports/bar_backslash.sol
@@ -1,0 +1,3 @@
+
+import ".\\relative_import.sol";
+import "..\\import.sol";

--- a/tests/polkadot.rs
+++ b/tests/polkadot.rs
@@ -1038,7 +1038,7 @@ pub fn build_solidity_with_options(src: &str, log_ret: bool, log_err: bool) -> M
 
 pub fn build_wasm(src: &str, log_ret: bool, log_err: bool) -> Vec<(Vec<u8>, String)> {
     let tmp_file = OsStr::new("test.sol");
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
     cache.set_file_contents(tmp_file.to_str().unwrap(), src.to_string());
     let opt = inkwell::OptimizationLevel::Default;
     let target = Target::default_polkadot();

--- a/tests/polkadot_tests/events.rs
+++ b/tests/polkadot_tests/events.rs
@@ -95,7 +95,7 @@ fn emit() {
 
 #[test]
 fn event_imported() {
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
 
     cache.set_file_contents(
         "a.sol",
@@ -123,7 +123,7 @@ fn event_imported() {
 
     assert!(!ns.diagnostics.any_errors());
 
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
 
     cache.set_file_contents(
         "a.sol",
@@ -153,7 +153,7 @@ fn event_imported() {
 
     assert!(!ns.diagnostics.any_errors());
 
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
 
     cache.set_file_contents(
         "a.sol",
@@ -183,7 +183,7 @@ fn event_imported() {
 
     assert!(!ns.diagnostics.any_errors());
 
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
 
     cache.set_file_contents(
         "a.sol",
@@ -235,7 +235,7 @@ fn erc20_ink_example() {
                 address indexed to,
                 uint128 value
             );
-        
+
             function emit_event(address from, address to, uint128 value) public {
                 emit Transfer(from, to, value);
             }

--- a/tests/polkadot_tests/imports.rs
+++ b/tests/polkadot_tests/imports.rs
@@ -6,7 +6,7 @@ use std::ffi::OsStr;
 
 #[test]
 fn enum_import() {
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
 
     cache.set_file_contents(
         "a.sol",
@@ -32,7 +32,7 @@ fn enum_import() {
 
     assert!(!ns.diagnostics.any_errors());
 
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
 
     cache.set_file_contents(
         "a.sol",
@@ -58,7 +58,7 @@ fn enum_import() {
 
     assert!(!ns.diagnostics.any_errors());
 
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
 
     cache.set_file_contents(
         "a.sol",
@@ -84,7 +84,7 @@ fn enum_import() {
 
     assert!(!ns.diagnostics.any_errors());
 
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
 
     cache.set_file_contents(
         "a.sol",
@@ -110,7 +110,7 @@ fn enum_import() {
     );
 
     // from has special handling to avoid making it a keyword
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
 
     cache.set_file_contents(
         "a.sol",
@@ -127,7 +127,7 @@ fn enum_import() {
         "'frum' found where 'from' expected"
     );
 
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
 
     cache.set_file_contents(
         "a.sol",
@@ -147,7 +147,7 @@ fn enum_import() {
 
 #[test]
 fn struct_import() {
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
 
     cache.set_file_contents(
         "a.sol",
@@ -173,7 +173,7 @@ fn struct_import() {
 
     assert!(!ns.diagnostics.any_errors());
 
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
 
     cache.set_file_contents(
         "a.sol",
@@ -202,7 +202,7 @@ fn struct_import() {
 
 #[test]
 fn contract_import() {
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
 
     cache.set_file_contents(
         "a.sol",
@@ -237,7 +237,7 @@ fn contract_import() {
     assert!(!ns.diagnostics.any_errors());
 
     // lets try a importing an import
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
 
     cache.set_file_contents(
         "a.sol",
@@ -280,7 +280,7 @@ fn contract_import() {
     assert!(!ns.diagnostics.any_errors());
 
     // now let's rename an import in a chain
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
 
     cache.set_file_contents(
         "a.sol",
@@ -325,7 +325,7 @@ fn contract_import() {
 
 #[test]
 fn circular_import() {
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
 
     cache.set_file_contents(
         "self.sol",
@@ -349,7 +349,7 @@ fn circular_import() {
 
     assert!(!ns.diagnostics.any_errors());
 
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
 
     cache.set_file_contents(
         "a.sol",
@@ -394,7 +394,7 @@ fn circular_import() {
 #[test]
 fn import_symbol() {
     // import struct via import symbol
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
 
     cache.set_file_contents(
         "a.sol",
@@ -425,7 +425,7 @@ fn import_symbol() {
     assert!(!ns.diagnostics.any_errors());
 
     // import contract via import symbol
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
 
     cache.set_file_contents(
         "a.sol",
@@ -460,7 +460,7 @@ fn import_symbol() {
     assert!(!ns.diagnostics.any_errors());
 
     // import enum in contract via import symbol
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
 
     cache.set_file_contents(
         "a.sol",
@@ -495,7 +495,7 @@ fn import_symbol() {
     assert!(!ns.diagnostics.any_errors());
 
     // import struct in contract via import symbol chain
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
 
     cache.set_file_contents(
         "a.sol",
@@ -543,7 +543,7 @@ fn import_symbol() {
 #[test]
 fn enum_import_chain() {
     // import struct in contract via import symbol chain
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
 
     cache.set_file_contents(
         "a.sol",
@@ -590,7 +590,7 @@ fn enum_import_chain() {
     assert!(!ns.diagnostics.any_errors());
 
     // now with error
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
 
     cache.set_file_contents(
         "a.sol",
@@ -643,7 +643,7 @@ fn enum_import_chain() {
 #[test]
 fn import_base_dir() {
     // if a imports x/b.sol then when x/b.sol imports, it should use x/ as a base
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
 
     cache.set_file_contents(
         "a.sol",
@@ -664,7 +664,7 @@ fn import_base_dir() {
     cache.set_file_contents(
         "x/b.sol",
         r#"
-        import "c.sol";
+        import "x/c.sol";
         "#
         .to_string(),
     );
@@ -688,7 +688,7 @@ fn import_base_dir() {
 
 #[test]
 fn event_resolve() {
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
 
     cache.set_file_contents(
         "IThing.sol",

--- a/tests/polkadot_tests/inheritance.rs
+++ b/tests/polkadot_tests/inheritance.rs
@@ -9,7 +9,7 @@ use std::ffi::OsStr;
 
 #[test]
 fn test_abstract() {
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
 
     cache.set_file_contents(
         "a.sol",
@@ -52,7 +52,7 @@ fn test_abstract() {
 
     assert_eq!(contracts.len(), 1);
 
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
 
     cache.set_file_contents(
         "a.sol",

--- a/tests/solana.rs
+++ b/tests/solana.rs
@@ -156,7 +156,7 @@ impl<'a> VirtualMachineBuilder<'a> {
     }
 
     pub(crate) fn build(self) -> VirtualMachine {
-        let mut cache = FileResolver::new();
+        let mut cache = FileResolver::default();
 
         cache.set_file_contents("test.sol", self.src.to_string());
 
@@ -1620,7 +1620,7 @@ impl VirtualMachine {
 }
 
 pub fn parse_and_resolve(src: &'static str, target: Target) -> ast::Namespace {
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
 
     cache.set_file_contents("test.sol", src.to_string());
 

--- a/tests/solana_tests/simple.rs
+++ b/tests/solana_tests/simple.rs
@@ -331,7 +331,7 @@ fn incrementer() {
 
 #[test]
 fn infinite_loop() {
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
 
     let src = String::from(
         r#"

--- a/tests/undefined_variable_detection.rs
+++ b/tests/undefined_variable_detection.rs
@@ -8,7 +8,7 @@ use solang::{parse_and_resolve, Target};
 use std::ffi::OsStr;
 
 fn parse_and_codegen(src: &'static str) -> Namespace {
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
     cache.set_file_contents("test.sol", src.to_string());
     let mut ns = parse_and_resolve(OsStr::new("test.sol"), &mut cache, Target::EVM);
     let opt = Options {

--- a/tests/unused_variable_detection.rs
+++ b/tests/unused_variable_detection.rs
@@ -6,14 +6,14 @@ use solang::{parse_and_resolve, Target};
 use std::ffi::OsStr;
 
 fn parse(src: &'static str) -> ast::Namespace {
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
     cache.set_file_contents("test.sol", src.to_string());
 
     parse_and_resolve(OsStr::new("test.sol"), &mut cache, Target::EVM)
 }
 
 fn parse_two_files(src1: &'static str, src2: &'static str) -> ast::Namespace {
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
     cache.set_file_contents("test.sol", src1.to_string());
     cache.set_file_contents("test2.sol", src2.to_string());
 


### PR DESCRIPTION
When importing in Solidity, `import "foo";` does not check path relative to the currrent file, only `import "./foo";` does.

This work is also a re-write of https://github.com/hyperledger/solang/pull/1443