### PR TITLE
Ensure build works with latest contract-build and contract-metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,8 +61,8 @@ petgraph = "0.6.3"
 wasmparser = "0.107.0"
 wasm-encoder = "0.29"
 toml = "0.7"
-wasm-opt = { version = "0.112.0", optional = true }
-contract-build = { version = "3.0.1", optional = true }
+wasm-opt = { version = "0.113.0", optional = true }
+contract-build = { version = "3.1", optional = true }
 
 
 [dev-dependencies]

--- a/src/abi/polkadot.rs
+++ b/src/abi/polkadot.rs
@@ -537,5 +537,5 @@ pub fn metadata(
     let project_json = serde_json::to_value(gen_project(contract_no, ns)).unwrap();
     let abi = serde_json::from_value(project_json).unwrap();
 
-    serde_json::to_value(ContractMetadata::new(source, contract, None, abi)).unwrap()
+    serde_json::to_value(ContractMetadata::new(source, contract, None, None, abi)).unwrap()
 }


### PR DESCRIPTION
The build is failing with errors about missing argument. The argument is for a container image name which we don't support.