### PR TITLE
Decouple data account from contract in the Solana mock VM

### DIFF
--- a/tests/solana_tests/abi.rs
+++ b/tests/solana_tests/abi.rs
@@ -45,12 +45,27 @@ fn packed() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let account = vm.initialize_data_account();
 
-    vm.function("test", &[]);
-    vm.function("test2", &[]);
-    vm.function("test3", &[]);
-    vm.function("test4", &[]);
+    vm.function("new")
+        .accounts(vec![("dataAccount", account)])
+        .call();
+
+    vm.function("test")
+        .accounts(vec![("dataAccount", account)])
+        .call();
+
+    vm.function("test2")
+        .accounts(vec![("dataAccount", account)])
+        .call();
+
+    vm.function("test3")
+        .accounts(vec![("dataAccount", account)])
+        .call();
+
+    vm.function("test4")
+        .accounts(vec![("dataAccount", account)])
+        .call();
 }
 
 #[test]
@@ -65,9 +80,14 @@ fn inherited() {
         contract bar is foo { }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function("test", &[]);
+    vm.function("test")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let mut vm = build_solidity(
         r#"
@@ -78,7 +98,12 @@ fn inherited() {
             contract bar is foo { }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function("test", &[]);
+    vm.function("test")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 }

--- a/tests/solana_tests/abi_decode.rs
+++ b/tests/solana_tests/abi_decode.rs
@@ -67,7 +67,10 @@ fn integers_bool_enum() {
         "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
     let input = Res1 {
         a: 45,
         b: 9965956609890,
@@ -78,7 +81,10 @@ fn integers_bool_enum() {
         h: false,
     };
     let encoded = input.try_to_vec().unwrap();
-    let _ = vm.function("decodeTest1", &[BorshToken::Bytes(encoded)]);
+    let _ = vm
+        .function("decodeTest1")
+        .arguments(&[BorshToken::Bytes(encoded)])
+        .call();
 
     let input = Res2 {
         item_1: WeekDay::Sunday,
@@ -86,7 +92,10 @@ fn integers_bool_enum() {
         item_3: WeekDay::Friday,
     };
     let encoded = input.try_to_vec().unwrap();
-    let _ = vm.function("decodeTest2", &[BorshToken::Bytes(encoded)]);
+    let _ = vm
+        .function("decodeTest2")
+        .arguments(&[BorshToken::Bytes(encoded)])
+        .call();
 }
 
 #[test]
@@ -110,13 +119,21 @@ fn decode_address() {
         "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+
     let input = Data {
-        address: vm.programs[0].data,
-        this: vm.programs[0].data,
+        address: data_account,
+        this: data_account,
     };
     let encoded = input.try_to_vec().unwrap();
-    let _ = vm.function("testAddress", &[BorshToken::Bytes(encoded)]);
+    let _ = vm
+        .function("testAddress")
+        .arguments(&[BorshToken::Bytes(encoded)])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 }
 
 #[test]
@@ -140,13 +157,20 @@ fn string_and_bytes() {
         "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
     let data = Data {
         a: "coffee".to_string(),
         b: b"tea".to_vec(),
     };
     let encoded = data.try_to_vec().unwrap();
-    let _ = vm.function("testStringAndBytes", &[BorshToken::Bytes(encoded)]);
+    let _ = vm
+        .function("testStringAndBytes")
+        .arguments(&[BorshToken::Bytes(encoded)])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 }
 
 #[test]
@@ -194,10 +218,16 @@ fn primitive_struct() {
         "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
     let data = NoPadStruct { a: 1238, b: 87123 };
     let encoded = data.try_to_vec().unwrap();
-    let _ = vm.function("testNoPadStruct", &[BorshToken::Bytes(encoded)]);
+    let _ = vm
+        .function("testNoPadStruct")
+        .arguments(&[BorshToken::Bytes(encoded)])
+        .call();
 
     let mut elem = b"tea_is_good".to_vec();
     elem.append(&mut vec![0; 21]);
@@ -207,7 +237,10 @@ fn primitive_struct() {
         c: <[u8; 32]>::try_from(&elem[0..32]).unwrap(),
     };
     let encoded = data.try_to_vec().unwrap();
-    let _ = vm.function("testPaddedStruct", &[BorshToken::Bytes(encoded)]);
+    let _ = vm
+        .function("testPaddedStruct")
+        .arguments(&[BorshToken::Bytes(encoded)])
+        .call();
 }
 
 #[test]
@@ -227,13 +260,18 @@ fn returned_string() {
     }
         "#,
     );
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
     let data = Input {
         rr: "cortado".to_string(),
     };
     let encoded = data.try_to_vec().unwrap();
     let returns = vm
-        .function("returnedString", &[BorshToken::Bytes(encoded)])
+        .function("returnedString")
+        .arguments(&[BorshToken::Bytes(encoded)])
+        .call()
         .unwrap();
     let string = returns.into_string().unwrap();
     assert_eq!(string, "cortado");
@@ -257,7 +295,10 @@ fn test_string_array() {
         "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
     let data = Input {
         a: vec![
             "coffee".to_string(),
@@ -267,7 +308,9 @@ fn test_string_array() {
     };
     let encoded = data.try_to_vec().unwrap();
     let returns = vm
-        .function("testStringVector", &[BorshToken::Bytes(encoded)])
+        .function("testStringVector")
+        .arguments(&[BorshToken::Bytes(encoded)])
+        .call()
         .unwrap();
     let vec = returns.into_array().unwrap();
 
@@ -337,7 +380,10 @@ fn struct_within_struct() {
         "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
     let no_pad = NoPadStruct { a: 89123, b: 12354 };
     let mut tea_is_good = b"tea_is_good".to_vec();
     tea_is_good.append(&mut vec![0; 21]);
@@ -353,7 +399,10 @@ fn struct_within_struct() {
         pad,
     };
     let encoded = data.try_to_vec().unwrap();
-    let _ = vm.function("testStruct", &[BorshToken::Bytes(encoded)]);
+    let _ = vm
+        .function("testStruct")
+        .arguments(&[BorshToken::Bytes(encoded)])
+        .call();
 }
 
 #[test]
@@ -449,7 +498,10 @@ fn struct_in_array() {
         "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
     let mut bytes_string = b"there_is_padding_here".to_vec();
     bytes_string.append(&mut vec![0; 11]);
     let input = Input1 {
@@ -461,7 +513,10 @@ fn struct_in_array() {
         },
     };
     let encoded = input.try_to_vec().unwrap();
-    let _ = vm.function("twoStructs", &[BorshToken::Bytes(encoded)]);
+    let _ = vm
+        .function("twoStructs")
+        .arguments(&[BorshToken::Bytes(encoded)])
+        .call();
 
     let input = Input2 {
         item_1: [1, -298, 3, -434],
@@ -473,13 +528,19 @@ fn struct_in_array() {
         ],
     };
     let encoded = input.try_to_vec().unwrap();
-    let _ = vm.function("fixedArrays", &[BorshToken::Bytes(encoded)]);
+    let _ = vm
+        .function("fixedArrays")
+        .arguments(&[BorshToken::Bytes(encoded)])
+        .call();
 
     let input = Input3 {
         vec: vec![NoPadStruct { a: 5, b: 6 }, NoPadStruct { a: 7, b: 8 }],
     };
     let encoded = input.try_to_vec().unwrap();
-    let _ = vm.function("primitiveDynamic", &[BorshToken::Bytes(encoded)]);
+    let _ = vm
+        .function("primitiveDynamic")
+        .arguments(&[BorshToken::Bytes(encoded)])
+        .call();
 }
 
 #[test]
@@ -552,7 +613,10 @@ fn arrays() {
         "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
     let input = Input1 {
         complex_array: vec![
             NonConstantStruct {
@@ -566,19 +630,31 @@ fn arrays() {
         ],
     };
     let encoded = input.try_to_vec().unwrap();
-    let _ = vm.function("decodeComplex", &[BorshToken::Bytes(encoded)]);
+    let _ = vm
+        .function("decodeComplex")
+        .arguments(&[BorshToken::Bytes(encoded)])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let input = Input2 {
         vec: vec![-90, 5523, -89],
     };
     let encoded = input.try_to_vec().unwrap();
-    let _ = vm.function("dynamicArray", &[BorshToken::Bytes(encoded)]);
+    let _ = vm
+        .function("dynamicArray")
+        .arguments(&[BorshToken::Bytes(encoded)])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let input = Input3 {
         multi_dim: [[1, 2], [4, 5], [6, 7]],
     };
     let encoded = input.try_to_vec().unwrap();
-    let _ = vm.function("decodeMultiDim", &[BorshToken::Bytes(encoded)]);
+    let _ = vm
+        .function("decodeMultiDim")
+        .arguments(&[BorshToken::Bytes(encoded)])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 }
 
 #[test]
@@ -687,7 +763,10 @@ fn multi_dimensional_arrays() {
     }
         "#,
     );
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
     let mut response: Vec<u8> = vec![0; 32];
 
     let input = Input1 {
@@ -732,7 +811,10 @@ fn multi_dimensional_arrays() {
         item_2: -90,
     };
     let encoded = input.try_to_vec().unwrap();
-    let _ = vm.function("multiDimStruct", &[BorshToken::Bytes(encoded)]);
+    let _ = vm
+        .function("multiDimStruct")
+        .arguments(&[BorshToken::Bytes(encoded)])
+        .call();
 
     let input = Input2 {
         vec: vec![
@@ -741,13 +823,19 @@ fn multi_dimensional_arrays() {
         ],
     };
     let encoded = input.try_to_vec().unwrap();
-    let _ = vm.function("multiDimInt", &[BorshToken::Bytes(encoded)]);
+    let _ = vm
+        .function("multiDimInt")
+        .arguments(&[BorshToken::Bytes(encoded)])
+        .call();
 
     let input = Input3 {
         vec: vec![9, 3, 4, 90, 834],
     };
     let encoded = input.try_to_vec().unwrap();
-    let _ = vm.function("uniqueDim", &[BorshToken::Bytes(encoded)]);
+    let _ = vm
+        .function("uniqueDim")
+        .arguments(&[BorshToken::Bytes(encoded)])
+        .call();
 }
 
 #[test]
@@ -781,14 +869,20 @@ fn empty_arrays() {
     }
         "#,
     );
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let input = Input {
         vec_1: vec![],
         vec_2: vec![],
     };
     let encoded = input.try_to_vec().unwrap();
-    let _ = vm.function("testEmpty", &[BorshToken::Bytes(encoded)]);
+    let _ = vm
+        .function("testEmpty")
+        .arguments(&[BorshToken::Bytes(encoded)])
+        .call();
 }
 
 #[test]
@@ -810,7 +904,10 @@ fn external_function() {
         "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
     let input = Input {
         selector: [1, 2, 3, 4, 5, 6, 7, 8],
         address: [
@@ -821,7 +918,10 @@ fn external_function() {
     let encoded = input.try_to_vec().unwrap();
 
     let returns = vm
-        .function("testExternalFunction", &[BorshToken::Bytes(encoded)])
+        .function("testExternalFunction")
+        .arguments(&[BorshToken::Bytes(encoded)])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap()
         .unwrap_tuple();
 
@@ -857,13 +957,20 @@ fn bytes_arrays() {
         "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
     let input = Input {
         item_1: [b"abcd".to_owned(), b"efgh".to_owned()],
         item_2: vec![b"12345".to_owned(), b"67890".to_owned()],
     };
     let encoded = input.try_to_vec().unwrap();
-    let _ = vm.function("testByteArrays", &[BorshToken::Bytes(encoded)]);
+    let _ = vm
+        .function("testByteArrays")
+        .arguments(&[BorshToken::Bytes(encoded)])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 }
 
 #[test]
@@ -892,10 +999,17 @@ fn different_types() {
         "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
     let input = Input1 { a: -789, b: 14234 };
     let encoded = input.try_to_vec().unwrap();
-    let _ = vm.function("testByteArrays", &[BorshToken::Bytes(encoded)]);
+    let _ = vm
+        .function("testByteArrays")
+        .arguments(&[BorshToken::Bytes(encoded)])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 }
 
 #[test]
@@ -918,11 +1032,18 @@ fn more_elements() {
         "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let input = Input { vec: [1, 4, 5, 6] };
     let encoded = input.try_to_vec().unwrap();
-    let _ = vm.function("wrongNumber", &[BorshToken::Bytes(encoded)]);
+    let _ = vm
+        .function("wrongNumber")
+        .arguments(&[BorshToken::Bytes(encoded)])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 }
 
 #[test]
@@ -946,13 +1067,19 @@ fn extra_element() {
         "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
     let input = Input {
         vec: vec![-90, 89, -2341],
     };
 
     let encoded = input.try_to_vec().unwrap();
-    let _ = vm.function("extraElement", &[BorshToken::Bytes(encoded)]);
+    let _ = vm
+        .function("extraElement")
+        .arguments(&[BorshToken::Bytes(encoded)])
+        .call();
 }
 
 #[test]
@@ -975,11 +1102,17 @@ fn invalid_type() {
     "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let input = Input { item: 5 };
     let encoded = input.try_to_vec().unwrap();
-    let _ = vm.function("invalidType", &[BorshToken::Bytes(encoded)]);
+    let _ = vm
+        .function("invalidType")
+        .arguments(&[BorshToken::Bytes(encoded)])
+        .call();
 }
 
 #[test]
@@ -1003,14 +1136,21 @@ fn longer_buffer() {
         "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let input = Input {
         item_1: 4,
         item_2: 5,
     };
     let encoded = input.try_to_vec().unwrap();
-    let _ = vm.function("testLongerBuffer", &[BorshToken::Bytes(encoded)]);
+    let _ = vm
+        .function("testLongerBuffer")
+        .arguments(&[BorshToken::Bytes(encoded)])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 }
 
 #[test]
@@ -1035,14 +1175,21 @@ fn longer_buffer_array() {
             }
         }        "#,
     );
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let input = Input {
         item_1: 23434,
         item_2: [1, 2, 3, 4],
     };
     let encoded = input.try_to_vec().unwrap();
-    let _ = vm.function("testLongerBuffer", &[BorshToken::Bytes(encoded)]);
+    let _ = vm
+        .function("testLongerBuffer")
+        .arguments(&[BorshToken::Bytes(encoded)])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 }
 
 #[test]
@@ -1069,12 +1216,18 @@ fn dynamic_array_of_array() {
         "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
     let input = Input {
         vec: vec![[0, 1], [2, -3]],
     };
     let encoded = input.try_to_vec().unwrap();
-    let _ = vm.function("testArrayAssign", &[BorshToken::Bytes(encoded)]);
+    let _ = vm
+        .function("testArrayAssign")
+        .arguments(&[BorshToken::Bytes(encoded)])
+        .call();
 }
 
 #[test]
@@ -1114,7 +1267,10 @@ fn test_struct_validation() {
         "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
     let mut bytes_string = b"struct".to_vec();
     bytes_string.append(&mut vec![0; 26]);
 
@@ -1127,7 +1283,10 @@ fn test_struct_validation() {
         },
     };
     let encoded = input.try_to_vec().unwrap();
-    let _ = vm.function("test", &[BorshToken::Bytes(encoded)]);
+    let _ = vm
+        .function("test")
+        .arguments(&[BorshToken::Bytes(encoded)])
+        .call();
 }
 
 #[test]
@@ -1167,7 +1326,10 @@ fn test_struct_validation_invalid() {
         "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
     let mut bytes_string = b"struct".to_vec();
     bytes_string.append(&mut vec![0; 26]);
 
@@ -1179,7 +1341,10 @@ fn test_struct_validation_invalid() {
         },
     };
     let encoded = input.try_to_vec().unwrap();
-    let _ = vm.function("test", &[BorshToken::Bytes(encoded)]);
+    let _ = vm
+        .function("test")
+        .arguments(&[BorshToken::Bytes(encoded)])
+        .call();
 }
 
 #[test]
@@ -1197,7 +1362,10 @@ fn string_fixed_array() {
 }
         "#,
     );
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     #[derive(Debug, BorshSerialize)]
     struct Input {
@@ -1213,7 +1381,10 @@ fn string_fixed_array() {
         ],
     };
     let encoded = input.try_to_vec().unwrap();
-    let _ = vm.function("testing", &[BorshToken::Bytes(encoded)]);
+    let _ = vm
+        .function("testing")
+        .arguments(&[BorshToken::Bytes(encoded)])
+        .call();
 }
 
 #[test]
@@ -1233,7 +1404,10 @@ fn double_dynamic_array() {
     }
         "#,
     );
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     #[derive(Debug, BorshSerialize)]
     struct Input {
@@ -1248,5 +1422,8 @@ fn double_dynamic_array() {
         item_3: -755,
     };
     let encoded = input.try_to_vec().unwrap();
-    let _ = vm.function("testThis", &[BorshToken::Bytes(encoded)]);
+    let _ = vm
+        .function("testThis")
+        .arguments(&[BorshToken::Bytes(encoded)])
+        .call();
 }

--- a/tests/solana_tests/abi_encode.rs
+++ b/tests/solana_tests/abi_encode.rs
@@ -67,8 +67,11 @@ contract Testing {
         "#,
     );
 
-    vm.constructor(&[]);
-    let returns = vm.function("getThis", &[]).unwrap();
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    let returns = vm.function("getThis").call().unwrap();
     let encoded = returns.into_bytes().unwrap();
     let decoded = Res1::try_from_slice(&encoded).unwrap();
 
@@ -80,7 +83,7 @@ contract Testing {
     assert_eq!(decoded.day, WeekDay::Wednesday);
     assert!(!decoded.h);
 
-    let returns = vm.function("encodeEnum", &[]).unwrap();
+    let returns = vm.function("encodeEnum").call().unwrap();
     let encoded = returns.into_bytes().unwrap();
     let decoded = Res2::try_from_slice(&encoded).unwrap();
 
@@ -108,12 +111,19 @@ contract Testing {
 }
         "#,
     );
-    vm.constructor(&[]);
-    let returns = vm.function("getThis", &[]).unwrap();
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    let returns = vm
+        .function("getThis")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
     let encoded = returns.into_bytes().unwrap();
     let decoded = Response::try_from_slice(&encoded).unwrap();
-    assert_eq!(decoded.address, vm.programs[0].data);
-    assert_eq!(decoded.this, vm.programs[0].data);
+    assert_eq!(decoded.address, data_account);
+    assert_eq!(decoded.this, data_account);
 }
 
 #[test]
@@ -138,8 +148,11 @@ contract Testing {
       "#,
     );
 
-    vm.constructor(&[]);
-    let returns = vm.function("getThis", &[]).unwrap();
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    let returns = vm.function("getThis").call().unwrap();
     let encoded = returns.into_bytes().unwrap();
     let decoded = MyStruct::try_from_slice(&encoded).unwrap();
     assert_eq!(decoded.a, "coffe");
@@ -190,15 +203,19 @@ fn primitive_structs() {
 }
         "#,
     );
-    vm.constructor(&[]);
-    let returns = vm.function("getThis", &[]).unwrap();
+
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    let returns = vm.function("getThis").call().unwrap();
     let encoded = returns.into_bytes().unwrap();
 
     let decoded = NoPadStruct::try_from_slice(&encoded).unwrap();
     assert_eq!(decoded.a, 1238);
     assert_eq!(decoded.b, 87123);
 
-    let returns = vm.function("getThat", &[]).unwrap();
+    let returns = vm.function("getThat").call().unwrap();
     let encoded = returns.into_bytes().unwrap();
     let decoded = PaddedStruct::try_from_slice(&encoded).unwrap();
     assert_eq!(decoded.a, 12998);
@@ -226,10 +243,15 @@ contract Testing {
       "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let returns = vm
-        .function("testStruct", &[BorshToken::String("nihao".to_string())])
+        .function("testStruct")
+        .arguments(&[BorshToken::String("nihao".to_string())])
+        .call()
         .unwrap();
     let encoded = returns.into_bytes().unwrap();
     let decoded = Response::try_from_slice(&encoded).unwrap();
@@ -261,14 +283,29 @@ fn test_string_array() {
         "#,
     );
 
-    vm.constructor(&[]);
-    let returns = vm.function("encode", &[]).unwrap();
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+
+    let returns = vm
+        .function("encode")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
     let encoded = returns.into_bytes().unwrap();
     let decoded = Response::try_from_slice(&encoded).unwrap();
     assert_eq!(decoded.a.len(), 0);
 
-    let _ = vm.function("insertStrings", &[]);
-    let returns = vm.function("encode", &[]).unwrap();
+    let _ = vm
+        .function("insertStrings")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    let returns = vm
+        .function("encode")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
     let encoded = returns.into_bytes().unwrap();
     let decoded = Response::try_from_slice(&encoded).unwrap();
     assert_eq!(decoded.a.len(), 2);
@@ -338,8 +375,16 @@ contract Testing {
         "#,
     );
 
-    vm.constructor(&[]);
-    let returns = vm.function("testStruct", &[]).unwrap();
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+
+    let returns = vm
+        .function("testStruct")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
     let encoded = returns.into_bytes().unwrap();
     let decoded = NonConstantStruct::try_from_slice(&encoded).unwrap();
 
@@ -441,9 +486,20 @@ fn struct_in_array() {
         "#,
     );
 
-    vm.constructor(&[]);
-    let _ = vm.function("addData", &[]);
-    let returns = vm.function("encodeStruct", &[]).unwrap();
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+
+    let _ = vm
+        .function("addData")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    let returns = vm
+        .function("encodeStruct")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
     let encoded = returns.into_bytes().unwrap();
     let decoded = Res1::try_from_slice(&encoded).unwrap();
 
@@ -454,7 +510,11 @@ fn struct_in_array() {
     let b: [u8; 21] = b"there_is_padding_here".to_owned();
     assert_eq!(&decoded.item_2.c[0..21], b);
 
-    let returns = vm.function("primitiveStruct", &[]).unwrap();
+    let returns = vm
+        .function("primitiveStruct")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
     let encoded = returns.into_bytes().unwrap();
     let decoded = Res2::try_from_slice(&encoded).unwrap();
 
@@ -466,7 +526,11 @@ fn struct_in_array() {
     assert_eq!(decoded.item_3[0], NoPadStruct { a: 1, b: 2 });
     assert_eq!(decoded.item_3[1], NoPadStruct { a: 3, b: 4 });
 
-    let returns = vm.function("primitiveDynamicArray", &[]).unwrap();
+    let returns = vm
+        .function("primitiveDynamicArray")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
     let encoded = returns.into_bytes().unwrap();
     let decoded = Res3::try_from_slice(&encoded).unwrap();
 
@@ -541,9 +605,19 @@ fn arrays() {
       "#,
     );
 
-    vm.constructor(&[]);
-    let _ = vm.function("addData", &[]);
-    let returns = vm.function("encodeArray", &[]).unwrap();
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    let _ = vm
+        .function("addData")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    let returns = vm
+        .function("encodeArray")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
     let encoded = returns.into_bytes().unwrap();
     let decoded = Res1::try_from_slice(&encoded).unwrap();
 
@@ -552,7 +626,11 @@ fn arrays() {
     assert_eq!(decoded.vec_1[1], 5523);
     assert_eq!(decoded.vec_1[2], -89);
 
-    let returns = vm.function("encodeComplex", &[]).unwrap();
+    let returns = vm
+        .function("encodeComplex")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
     let encoded = returns.into_bytes().unwrap();
     let decoded = Res2::try_from_slice(&encoded).unwrap();
 
@@ -568,7 +646,7 @@ fn arrays() {
         vec!["cortado".to_string(), "cappuccino".to_string()]
     );
 
-    let returns = vm.function("multiDimArrays", &[]).unwrap();
+    let returns = vm.function("multiDimArrays").call().unwrap();
     let encoded = returns.into_bytes().unwrap();
     let decoded = Res3::try_from_slice(&encoded).unwrap();
 
@@ -654,8 +732,11 @@ contract Testing {
         "#,
     );
 
-    vm.constructor(&[]);
-    let returns = vm.function("getThis", &[]).unwrap();
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    let returns = vm.function("getThis").call().unwrap();
     let encoded = returns.into_bytes().unwrap();
     let decoded = Res1::try_from_slice(&encoded).unwrap();
 
@@ -713,7 +794,7 @@ contract Testing {
     );
     assert_eq!(decoded.item_2, 5);
 
-    let returns = vm.function("multiDim", &[]).unwrap();
+    let returns = vm.function("multiDim").call().unwrap();
     let encoded = returns.into_bytes().unwrap();
     let decoded = Res2::try_from_slice(&encoded).unwrap();
 
@@ -721,7 +802,7 @@ contract Testing {
     assert_eq!(decoded.item[0][0], [1, 2, 3, 4]);
     assert_eq!(decoded.item[0][1], [5, 6, 7, 8]);
 
-    let returns = vm.function("uniqueDim", &[]).unwrap();
+    let returns = vm.function("uniqueDim").call().unwrap();
     let encoded = returns.into_bytes().unwrap();
     let decoded = Res3::try_from_slice(&encoded).unwrap();
 
@@ -775,8 +856,11 @@ fn null_pointer() {
         "#,
     );
 
-    vm.constructor(&[]);
-    let returns = vm.function("test1", &[]).unwrap();
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    let returns = vm.function("test1").call().unwrap();
     let encoded = returns.into_bytes().unwrap();
     let decoded = Res1::try_from_slice(&encoded).unwrap();
 
@@ -786,7 +870,7 @@ fn null_pointer() {
         assert!(decoded.item[i].f2.is_empty())
     }
 
-    let returns = vm.function("test2", &[]).unwrap();
+    let returns = vm.function("test2").call().unwrap();
     let encoded = returns.into_bytes().unwrap();
     let decoded = Res2::try_from_slice(&encoded).unwrap();
 
@@ -822,9 +906,17 @@ fn external_function() {
         "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("doThat", &[]).unwrap().unwrap_tuple();
+    let returns = vm
+        .function("doThat")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap()
+        .unwrap_tuple();
     let encoded = returns[2].clone().into_bytes().unwrap();
     let decoded = Res::try_from_slice(&encoded).unwrap();
 
@@ -857,8 +949,13 @@ fn bytes_arrays() {
     }
         "#,
     );
-    vm.constructor(&[]);
-    let returns = vm.function("testBytesArray", &[]).unwrap();
+
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+
+    let returns = vm.function("testBytesArray").call().unwrap();
     let encoded = returns.into_bytes().unwrap();
     let decoded = Res::try_from_slice(&encoded).unwrap();
 
@@ -896,8 +993,11 @@ fn uint8_arrays() {
     }"#,
     );
 
-    vm.constructor(&[]);
-    let returns = vm.function("testBytesArray", &[]).unwrap();
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    let returns = vm.function("testBytesArray").call().unwrap();
     let encoded = returns.into_bytes().unwrap();
     let decoded = Res::try_from_slice(&encoded).unwrap();
 
@@ -921,15 +1021,26 @@ contract caller {
         return b + 3;
     }
 
-    function do_call() pure public returns (int64, int32) {
+    function do_call() view public returns (int64, int32) {
         return (this.doThis(5), this.doThat(3));
     }
 }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("do_call", &[]).unwrap().unwrap_tuple();
+    let returns = vm
+        .function("do_call")
+        .accounts(vec![
+            ("dataAccount", data_account),
+            ("systemProgram", [0; 32]),
+        ])
+        .call()
+        .unwrap()
+        .unwrap_tuple();
     assert_eq!(returns.len(), 2);
     assert_eq!(
         returns[0],
@@ -977,9 +1088,12 @@ contract Testing {
         "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("testThis", &[]).unwrap();
+    let returns = vm.function("testThis").call().unwrap();
     let encoded = returns.into_bytes().unwrap();
     let decoded = Res::try_from_slice(&encoded).unwrap();
     assert_eq!(decoded.item_1, 99);

--- a/tests/solana_tests/accessor.rs
+++ b/tests/solana_tests/accessor.rs
@@ -13,9 +13,16 @@ fn types() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("f1", &[]).unwrap();
+    let returns = vm
+        .function("f1")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -32,16 +39,19 @@ fn types() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let returns = vm
-        .function(
-            "f1",
-            &[BorshToken::Uint {
-                width: 256,
-                value: BigInt::from(2u8),
-            }],
-        )
+        .function("f1")
+        .arguments(&[BorshToken::Uint {
+            width: 256,
+            value: BigInt::from(2u8),
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
 
     assert_eq!(
@@ -66,22 +76,25 @@ fn types() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let returns = vm
-        .function(
-            "f1",
-            &[
-                BorshToken::Uint {
-                    width: 256,
-                    value: BigInt::one(),
-                },
-                BorshToken::Uint {
-                    width: 256,
-                    value: BigInt::from(2u8),
-                },
-            ],
-        )
+        .function("f1")
+        .arguments(&[
+            BorshToken::Uint {
+                width: 256,
+                value: BigInt::one(),
+            },
+            BorshToken::Uint {
+                width: 256,
+                value: BigInt::from(2u8),
+            },
+        ])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
 
     assert_eq!(
@@ -104,16 +117,19 @@ fn types() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let returns = vm
-        .function(
-            "f1",
-            &[BorshToken::Int {
-                width: 64,
-                value: BigInt::from(4000u16),
-            }],
-        )
+        .function("f1")
+        .arguments(&[BorshToken::Int {
+            width: 64,
+            value: BigInt::from(4000u16),
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
 
     assert_eq!(
@@ -139,9 +155,16 @@ fn interfaces() {
         "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("f1", &[]).unwrap();
+    let returns = vm
+        .function("f1")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(returns, BorshToken::uint8_fixed_array(b"ab".to_vec()));
 }
@@ -155,9 +178,16 @@ fn constant() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("z", &[]).unwrap();
+    let returns = vm
+        .function("z")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -174,9 +204,16 @@ fn constant() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("z", &[]).unwrap();
+    let returns = vm
+        .function("z")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -193,9 +230,16 @@ fn constant() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("z", &[]).unwrap();
+    let returns = vm
+        .function("z")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -242,7 +286,15 @@ fn struct_accessor() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function("f", &[]);
+    vm.function("f")
+        .accounts(vec![
+            ("dataAccount", data_account),
+            ("systemProgram", [0; 32]),
+        ])
+        .call();
 }

--- a/tests/solana_tests/arrays.rs
+++ b/tests/solana_tests/arrays.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{build_solidity, BorshToken};
+use crate::{build_solidity, BorshToken, Pubkey};
 use num_bigint::BigInt;
 use num_traits::{One, Zero};
 
@@ -20,9 +20,17 @@ fn fixed_array() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("get", &[]).unwrap().unwrap_tuple();
+    let returns = vm
+        .function("get")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap()
+        .unwrap_tuple();
 
     assert_eq!(
         returns,
@@ -66,9 +74,16 @@ fn fixed_array() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("get", &[]).unwrap();
+    let returns = vm
+        .function("get")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -135,9 +150,16 @@ fn fixed_array() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("get", &[]).unwrap();
+    let returns = vm
+        .function("get")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -166,31 +188,31 @@ fn fixed_array() {
     );
 
     let returns = vm
-        .function(
-            "set",
-            &[BorshToken::Tuple(vec![
-                BorshToken::Bool(true),
-                BorshToken::FixedArray(vec![
-                    BorshToken::Uint {
-                        width: 32,
-                        value: BigInt::from(3u8),
-                    },
-                    BorshToken::Uint {
-                        width: 32,
-                        value: BigInt::from(5u8),
-                    },
-                    BorshToken::Uint {
-                        width: 32,
-                        value: BigInt::from(7u8),
-                    },
-                    BorshToken::Uint {
-                        width: 32,
-                        value: BigInt::from(11u8),
-                    },
-                ]),
-                BorshToken::Bool(true),
-            ])],
-        )
+        .function("set")
+        .arguments(&[BorshToken::Tuple(vec![
+            BorshToken::Bool(true),
+            BorshToken::FixedArray(vec![
+                BorshToken::Uint {
+                    width: 32,
+                    value: BigInt::from(3u8),
+                },
+                BorshToken::Uint {
+                    width: 32,
+                    value: BigInt::from(5u8),
+                },
+                BorshToken::Uint {
+                    width: 32,
+                    value: BigInt::from(7u8),
+                },
+                BorshToken::Uint {
+                    width: 32,
+                    value: BigInt::from(11u8),
+                },
+            ]),
+            BorshToken::Bool(true),
+        ])])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
 
     assert_eq!(
@@ -230,40 +252,43 @@ fn dynamic_array_fixed_elements() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let returns = vm
-        .function(
-            "get",
-            &[
+        .function("get")
+        .arguments(&[
+            BorshToken::Uint {
+                width: 256,
+                value: BigInt::from(12123123u32),
+            },
+            BorshToken::Array(vec![
                 BorshToken::Uint {
-                    width: 256,
-                    value: BigInt::from(12123123u32),
+                    width: 32,
+                    value: BigInt::from(3u8),
                 },
-                BorshToken::Array(vec![
-                    BorshToken::Uint {
-                        width: 32,
-                        value: BigInt::from(3u8),
-                    },
-                    BorshToken::Uint {
-                        width: 32,
-                        value: BigInt::from(5u8),
-                    },
-                    BorshToken::Uint {
-                        width: 32,
-                        value: BigInt::from(7u8),
-                    },
-                    BorshToken::Uint {
-                        width: 32,
-                        value: BigInt::from(11u8),
-                    },
-                ]),
                 BorshToken::Uint {
-                    width: 256,
-                    value: BigInt::from(102u8),
+                    width: 32,
+                    value: BigInt::from(5u8),
                 },
-            ],
-        )
+                BorshToken::Uint {
+                    width: 32,
+                    value: BigInt::from(7u8),
+                },
+                BorshToken::Uint {
+                    width: 32,
+                    value: BigInt::from(11u8),
+                },
+            ]),
+            BorshToken::Uint {
+                width: 256,
+                value: BigInt::from(102u8),
+            },
+        ])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
 
     assert_eq!(
@@ -275,7 +300,12 @@ fn dynamic_array_fixed_elements() {
     );
 
     // test that the abi encoder can handle fixed arrays
-    let returns = vm.function("set", &[]).unwrap().unwrap_tuple();
+    let returns = vm
+        .function("set")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap()
+        .unwrap_tuple();
 
     assert_eq!(
         returns,
@@ -338,28 +368,31 @@ fn fixed_array_dynamic_elements() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let returns = vm
-        .function(
-            "get",
-            &[
-                BorshToken::Uint {
-                    width: 256,
-                    value: BigInt::from(12123123u32),
-                },
-                BorshToken::FixedArray(vec![
-                    BorshToken::Bytes(vec![3, 5, 7]),
-                    BorshToken::Bytes(vec![11, 13, 17]),
-                    BorshToken::Bytes(vec![19, 23]),
-                    BorshToken::Bytes(vec![29]),
-                ]),
-                BorshToken::Uint {
-                    width: 256,
-                    value: BigInt::from(102u8),
-                },
-            ],
-        )
+        .function("get")
+        .arguments(&[
+            BorshToken::Uint {
+                width: 256,
+                value: BigInt::from(12123123u32),
+            },
+            BorshToken::FixedArray(vec![
+                BorshToken::Bytes(vec![3, 5, 7]),
+                BorshToken::Bytes(vec![11, 13, 17]),
+                BorshToken::Bytes(vec![19, 23]),
+                BorshToken::Bytes(vec![29]),
+            ]),
+            BorshToken::Uint {
+                width: 256,
+                value: BigInt::from(102u8),
+            },
+        ])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
 
     assert_eq!(
@@ -370,7 +403,12 @@ fn fixed_array_dynamic_elements() {
         }
     );
 
-    let returns = vm.function("set", &[]).unwrap().unwrap_tuple();
+    let returns = vm
+        .function("set")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap()
+        .unwrap_tuple();
 
     assert_eq!(
         returns,
@@ -425,28 +463,31 @@ fn dynamic_array_dynamic_elements() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let returns = vm
-        .function(
-            "get",
-            &[
-                BorshToken::Uint {
-                    width: 256,
-                    value: BigInt::from(12123123u32),
-                },
-                BorshToken::Array(vec![
-                    BorshToken::Bytes(vec![3, 5, 7]),
-                    BorshToken::Bytes(vec![11, 13, 17]),
-                    BorshToken::Bytes(vec![19, 23]),
-                    BorshToken::Bytes(vec![29]),
-                ]),
-                BorshToken::Uint {
-                    width: 256,
-                    value: BigInt::from(102u8),
-                },
-            ],
-        )
+        .function("get")
+        .arguments(&[
+            BorshToken::Uint {
+                width: 256,
+                value: BigInt::from(12123123u32),
+            },
+            BorshToken::Array(vec![
+                BorshToken::Bytes(vec![3, 5, 7]),
+                BorshToken::Bytes(vec![11, 13, 17]),
+                BorshToken::Bytes(vec![19, 23]),
+                BorshToken::Bytes(vec![29]),
+            ]),
+            BorshToken::Uint {
+                width: 256,
+                value: BigInt::from(102u8),
+            },
+        ])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
 
     assert_eq!(
@@ -457,7 +498,12 @@ fn dynamic_array_dynamic_elements() {
         }
     );
 
-    let returns = vm.function("set", &[]).unwrap().unwrap_tuple();
+    let returns = vm
+        .function("set")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap()
+        .unwrap_tuple();
 
     assert_eq!(
         returns,
@@ -506,11 +552,13 @@ fn fixed_array_fixed_elements_storage() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function(
-        "set_elem",
-        &[
+    vm.function("set_elem")
+        .arguments(&[
             BorshToken::Uint {
                 width: 256,
                 value: BigInt::from(2u8),
@@ -519,12 +567,12 @@ fn fixed_array_fixed_elements_storage() {
                 width: 64,
                 value: BigInt::from(12123123u64),
             },
-        ],
-    );
+        ])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function(
-        "set_elem",
-        &[
+    vm.function("set_elem")
+        .arguments(&[
             BorshToken::Uint {
                 width: 256,
                 value: BigInt::from(3u8),
@@ -533,17 +581,18 @@ fn fixed_array_fixed_elements_storage() {
                 width: 64,
                 value: BigInt::from(123456789u64),
             },
-        ],
-    );
+        ])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let returns = vm
-        .function(
-            "get_elem",
-            &[BorshToken::Uint {
-                width: 256,
-                value: BigInt::from(2u8),
-            }],
-        )
+        .function("get_elem")
+        .arguments(&[BorshToken::Uint {
+            width: 256,
+            value: BigInt::from(2u8),
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
 
     assert_eq!(
@@ -554,7 +603,11 @@ fn fixed_array_fixed_elements_storage() {
         },
     );
 
-    let returns = vm.function("get", &[]).unwrap();
+    let returns = vm
+        .function("get")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -578,9 +631,8 @@ fn fixed_array_fixed_elements_storage() {
         ]),
     );
 
-    vm.function(
-        "set",
-        &[BorshToken::FixedArray(vec![
+    vm.function("set")
+        .arguments(&[BorshToken::FixedArray(vec![
             BorshToken::Int {
                 width: 64,
                 value: BigInt::one(),
@@ -597,10 +649,15 @@ fn fixed_array_fixed_elements_storage() {
                 width: 64,
                 value: BigInt::from(4u8),
             },
-        ])],
-    );
+        ])])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("get", &[]).unwrap();
+    let returns = vm
+        .function("get")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -624,9 +681,15 @@ fn fixed_array_fixed_elements_storage() {
         ]),
     );
 
-    vm.function("del", &[]);
+    vm.function("del")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("get", &[]).unwrap();
+    let returns = vm
+        .function("get")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -680,22 +743,24 @@ fn fixed_array_dynamic_elements_storage() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function(
-        "set_elem",
-        &[
+    vm.function("set_elem")
+        .arguments(&[
             BorshToken::Uint {
                 width: 256,
                 value: BigInt::from(2u8),
             },
             BorshToken::String(String::from("abcd")),
-        ],
-    );
+        ])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function(
-        "set_elem",
-        &[
+    vm.function("set_elem")
+        .arguments(&[
             BorshToken::Uint {
                 width: 256,
                 value: BigInt::from(3u8),
@@ -703,22 +768,27 @@ fn fixed_array_dynamic_elements_storage() {
             BorshToken::String(String::from(
                 "you can lead a horse to water but you can’t make him drink",
             )),
-        ],
-    );
+        ])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let returns = vm
-        .function(
-            "get_elem",
-            &[BorshToken::Uint {
-                width: 256,
-                value: BigInt::from(2u8),
-            }],
-        )
+        .function("get_elem")
+        .arguments(&[BorshToken::Uint {
+            width: 256,
+            value: BigInt::from(2u8),
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
 
     assert_eq!(returns, BorshToken::String(String::from("abcd")));
 
-    let returns = vm.function("get", &[]).unwrap();
+    let returns = vm
+        .function("get")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -732,17 +802,21 @@ fn fixed_array_dynamic_elements_storage() {
         ]),
     );
 
-    vm.function(
-        "set",
-        &[BorshToken::FixedArray(vec![
+    vm.function("set")
+        .arguments(&[BorshToken::FixedArray(vec![
             BorshToken::String(String::from("a")),
             BorshToken::String(String::from("b")),
             BorshToken::String(String::from("c")),
             BorshToken::String(String::from("d")),
-        ])],
-    );
+        ])])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("get", &[]).unwrap();
+    let returns = vm
+        .function("get")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -754,9 +828,15 @@ fn fixed_array_dynamic_elements_storage() {
         ]),
     );
 
-    vm.function("del", &[]);
+    vm.function("del")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("get", &[]).unwrap();
+    let returns = vm
+        .function("get")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -810,9 +890,16 @@ fn storage_simple_dynamic_array() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("len", &[]).unwrap();
+    let returns = vm
+        .function("len")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -822,32 +909,34 @@ fn storage_simple_dynamic_array() {
         }
     );
 
-    vm.function(
-        "push",
-        &[BorshToken::Int {
+    vm.function("push")
+        .arguments(&[BorshToken::Int {
             width: 64,
             value: BigInt::from(102u8),
-        }],
-    );
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function("push_zero", &[]);
+    vm.function("push_zero")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function(
-        "push",
-        &[BorshToken::Int {
+    vm.function("push")
+        .arguments(&[BorshToken::Int {
             width: 64,
             value: BigInt::from(12345678901u64),
-        }],
-    );
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let returns = vm
-        .function(
-            "subscript",
-            &[BorshToken::Uint {
-                width: 32,
-                value: BigInt::zero(),
-            }],
-        )
+        .function("subscript")
+        .arguments(&[BorshToken::Uint {
+            width: 32,
+            value: BigInt::zero(),
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
 
     assert_eq!(
@@ -859,13 +948,13 @@ fn storage_simple_dynamic_array() {
     );
 
     let returns = vm
-        .function(
-            "subscript",
-            &[BorshToken::Uint {
-                width: 32,
-                value: BigInt::one(),
-            }],
-        )
+        .function("subscript")
+        .arguments(&[BorshToken::Uint {
+            width: 32,
+            value: BigInt::one(),
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
 
     assert_eq!(
@@ -877,13 +966,13 @@ fn storage_simple_dynamic_array() {
     );
 
     let returns = vm
-        .function(
-            "subscript",
-            &[BorshToken::Uint {
-                width: 32,
-                value: BigInt::from(2u8),
-            }],
-        )
+        .function("subscript")
+        .arguments(&[BorshToken::Uint {
+            width: 32,
+            value: BigInt::from(2u8),
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
 
     assert_eq!(
@@ -894,7 +983,11 @@ fn storage_simple_dynamic_array() {
         },
     );
 
-    let returns = vm.function("copy", &[]).unwrap();
+    let returns = vm
+        .function("copy")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -914,7 +1007,11 @@ fn storage_simple_dynamic_array() {
         ]),
     );
 
-    let returns = vm.function("pop", &[]).unwrap();
+    let returns = vm
+        .function("pop")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -924,7 +1021,11 @@ fn storage_simple_dynamic_array() {
         },
     );
 
-    let returns = vm.function("len", &[]).unwrap();
+    let returns = vm
+        .function("len")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -934,9 +1035,8 @@ fn storage_simple_dynamic_array() {
         }
     );
 
-    vm.function(
-        "set",
-        &[BorshToken::Array(vec![
+    vm.function("set")
+        .arguments(&[BorshToken::Array(vec![
             BorshToken::Uint {
                 width: 64,
                 value: BigInt::from(1u8),
@@ -965,10 +1065,15 @@ fn storage_simple_dynamic_array() {
                 width: 64,
                 value: BigInt::from(7u8),
             },
-        ])],
-    );
+        ])])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("copy", &[]).unwrap();
+    let returns = vm
+        .function("copy")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -1004,9 +1109,15 @@ fn storage_simple_dynamic_array() {
         ]),
     );
 
-    vm.function("rm", &[]);
+    vm.function("rm")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("len", &[]).unwrap();
+    let returns = vm
+        .function("len")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -1031,9 +1142,14 @@ fn storage_pop_running_on_empty() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function("pop", &[]);
+    vm.function("pop")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 }
 
 #[test]
@@ -1088,9 +1204,16 @@ fn storage_dynamic_array_of_structs() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("len", &[]).unwrap();
+    let returns = vm
+        .function("len")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -1100,38 +1223,40 @@ fn storage_dynamic_array_of_structs() {
         }
     );
 
-    vm.function(
-        "push1",
-        &[BorshToken::Tuple(vec![
+    vm.function("push1")
+        .arguments(&[BorshToken::Tuple(vec![
             BorshToken::Uint {
                 width: 64,
                 value: BigInt::from(13819038012u64),
             },
             BorshToken::Bool(true),
-        ])],
-    );
+        ])])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function("push_empty", &[]);
+    vm.function("push_empty")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function(
-        "push2",
-        &[BorshToken::Tuple(vec![
+    vm.function("push2")
+        .arguments(&[BorshToken::Tuple(vec![
             BorshToken::Uint {
                 width: 64,
                 value: BigInt::from(12313123141123213u64),
             },
             BorshToken::Bool(true),
-        ])],
-    );
+        ])])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let returns = vm
-        .function(
-            "subscript",
-            &[BorshToken::Uint {
-                width: 32,
-                value: BigInt::zero(),
-            }],
-        )
+        .function("subscript")
+        .arguments(&[BorshToken::Uint {
+            width: 32,
+            value: BigInt::zero(),
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
 
     assert_eq!(
@@ -1146,13 +1271,13 @@ fn storage_dynamic_array_of_structs() {
     );
 
     let returns = vm
-        .function(
-            "subscript",
-            &[BorshToken::Uint {
-                width: 32,
-                value: BigInt::one(),
-            }],
-        )
+        .function("subscript")
+        .arguments(&[BorshToken::Uint {
+            width: 32,
+            value: BigInt::one(),
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
 
     assert_eq!(
@@ -1167,13 +1292,13 @@ fn storage_dynamic_array_of_structs() {
     );
 
     let returns = vm
-        .function(
-            "subscript",
-            &[BorshToken::Uint {
-                width: 32,
-                value: BigInt::from(2u8),
-            }],
-        )
+        .function("subscript")
+        .arguments(&[BorshToken::Uint {
+            width: 32,
+            value: BigInt::from(2u8),
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
 
     assert_eq!(
@@ -1187,7 +1312,11 @@ fn storage_dynamic_array_of_structs() {
         ]),
     );
 
-    let returns = vm.function("copy", &[]).unwrap();
+    let returns = vm
+        .function("copy")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -1216,7 +1345,11 @@ fn storage_dynamic_array_of_structs() {
         ])
     );
 
-    let returns = vm.function("pop", &[]).unwrap();
+    let returns = vm
+        .function("pop")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -1229,7 +1362,11 @@ fn storage_dynamic_array_of_structs() {
         ])
     );
 
-    let returns = vm.function("len", &[]).unwrap();
+    let returns = vm
+        .function("len")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -1239,9 +1376,8 @@ fn storage_dynamic_array_of_structs() {
         }
     );
 
-    vm.function(
-        "set",
-        &[BorshToken::Array(vec![
+    vm.function("set")
+        .arguments(&[BorshToken::Array(vec![
             BorshToken::Tuple(vec![
                 BorshToken::Uint {
                     width: 64,
@@ -1284,10 +1420,15 @@ fn storage_dynamic_array_of_structs() {
                 },
                 BorshToken::Bool(true),
             ]),
-        ])],
-    );
+        ])])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("copy", &[]).unwrap();
+    let returns = vm
+        .function("copy")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -1337,9 +1478,15 @@ fn storage_dynamic_array_of_structs() {
         ]),
     );
 
-    vm.function("rm", &[]);
+    vm.function("rm")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("len", &[]).unwrap();
+    let returns = vm
+        .function("len")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -1364,9 +1511,16 @@ fn array_literal() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("list", &[]).unwrap();
+    let returns = vm
+        .function("list")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -1440,19 +1594,40 @@ fn storage_pop_push() {
     }"#,
     );
 
-    vm.constructor(&[]);
-    vm.function("fn1", &[]);
-    vm.function("fn2", &[]);
-    vm.function("fn3", &[]);
-    vm.function("fn4", &[]);
-    vm.function("fn5", &[]);
-    vm.function("fn6", &[]);
-    vm.function("fn7", &[]);
-    vm.function("fn8", &[]);
-    vm.function("clear", &[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    vm.function("fn1")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    vm.function("fn2")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    vm.function("fn3")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    vm.function("fn4")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    vm.function("fn5")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    vm.function("fn6")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    vm.function("fn7")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    vm.function("fn8")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    vm.function("clear")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     // make sure every thing has been freed
-    assert_eq!(vm.validate_account_data_heap(), 0);
+    assert_eq!(vm.validate_account_data_heap(&Pubkey(data_account)), 0);
 }
 
 #[test]
@@ -1479,7 +1654,10 @@ fn initialization_with_literal() {
         "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let mut addr1: Vec<u8> = Vec::new();
     addr1.resize(32, 0);
@@ -1487,51 +1665,52 @@ fn initialization_with_literal() {
     let mut addr2: Vec<u8> = Vec::new();
     addr2.resize(32, 0);
     addr2[0] = 2;
-    let _ = vm.function(
-        "split",
-        &[
+    let _ = vm
+        .function("split")
+        .arguments(&[
             BorshToken::FixedBytes(addr1[..].to_vec()),
             BorshToken::FixedBytes(addr2[..].to_vec()),
-        ],
-    );
+        ])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+
     let returns = vm
-        .function(
-            "getIdx",
-            &[BorshToken::Uint {
-                width: 32,
-                value: BigInt::zero(),
-            }],
-        )
+        .function("getIdx")
+        .arguments(&[BorshToken::Uint {
+            width: 32,
+            value: BigInt::zero(),
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
     let returned_addr1 = returns.into_fixed_bytes().unwrap();
     assert_eq!(addr1, returned_addr1);
 
     let returns = vm
-        .function(
-            "getIdx",
-            &[BorshToken::Uint {
-                width: 32,
-                value: BigInt::one(),
-            }],
-        )
+        .function("getIdx")
+        .arguments(&[BorshToken::Uint {
+            width: 32,
+            value: BigInt::one(),
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
     let returned_addr2 = returns.into_fixed_bytes().unwrap();
     assert_eq!(addr2, returned_addr2);
 
     let returns = vm
-        .function(
-            "getVec",
-            &[
-                BorshToken::Uint {
-                    width: 32,
-                    value: BigInt::from(563u16),
-                },
-                BorshToken::Uint {
-                    width: 32,
-                    value: BigInt::from(895u16),
-                },
-            ],
-        )
+        .function("getVec")
+        .arguments(&[
+            BorshToken::Uint {
+                width: 32,
+                value: BigInt::from(563u16),
+            },
+            BorshToken::Uint {
+                width: 32,
+                value: BigInt::from(895u16),
+            },
+        ])
+        .call()
         .unwrap();
     let array = returns.into_array().unwrap();
     assert_eq!(
@@ -1569,8 +1748,16 @@ fn dynamic_array_push() {
         "#,
     );
 
-    runtime.constructor(&[]);
-    runtime.function("test", &[]);
+    let data_account = runtime.initialize_data_account();
+    runtime
+        .function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+
+    runtime
+        .function("test")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let mut runtime = build_solidity(
         r#"
@@ -1590,8 +1777,16 @@ fn dynamic_array_push() {
         "#,
     );
 
-    runtime.constructor(&[]);
-    runtime.function("test", &[]);
+    let data_account = runtime.initialize_data_account();
+    runtime
+        .function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+
+    runtime
+        .function("test")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let mut runtime = build_solidity(
         r#"
@@ -1616,8 +1811,16 @@ fn dynamic_array_push() {
         "#,
     );
 
-    runtime.constructor(&[]);
-    runtime.function("test", &[]);
+    let data_account = runtime.initialize_data_account();
+    runtime
+        .function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+
+    runtime
+        .function("test")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let mut runtime = build_solidity(
         r#"
@@ -1638,8 +1841,16 @@ fn dynamic_array_push() {
         "#,
     );
 
-    runtime.constructor(&[]);
-    runtime.function("test", &[]);
+    let data_account = runtime.initialize_data_account();
+    runtime
+        .function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+
+    runtime
+        .function("test")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     // push() returns a reference to the thing
     let mut runtime = build_solidity(
@@ -1664,8 +1875,16 @@ fn dynamic_array_push() {
         }"#,
     );
 
-    runtime.constructor(&[]);
-    runtime.function("test", &[]);
+    let data_account = runtime.initialize_data_account();
+    runtime
+        .function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+
+    runtime
+        .function("test")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 }
 
 #[test]
@@ -1688,8 +1907,16 @@ fn dynamic_array_pop() {
         "#,
     );
 
-    runtime.constructor(&[]);
-    runtime.function("test", &[]);
+    let data_account = runtime.initialize_data_account();
+    runtime
+        .function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+
+    runtime
+        .function("test")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let mut runtime = build_solidity(
         r#"
@@ -1709,8 +1936,16 @@ fn dynamic_array_pop() {
         "#,
     );
 
-    runtime.constructor(&[]);
-    runtime.function("test", &[]);
+    let data_account = runtime.initialize_data_account();
+    runtime
+        .function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+
+    runtime
+        .function("test")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let mut runtime = build_solidity(
         r#"
@@ -1737,8 +1972,16 @@ fn dynamic_array_pop() {
         "#,
     );
 
-    runtime.constructor(&[]);
-    runtime.function("test", &[]);
+    let data_account = runtime.initialize_data_account();
+    runtime
+        .function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+
+    runtime
+        .function("test")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let mut runtime = build_solidity(
         r#"
@@ -1759,8 +2002,16 @@ fn dynamic_array_pop() {
         "#,
     );
 
-    runtime.constructor(&[]);
-    runtime.function("test", &[]);
+    let data_account = runtime.initialize_data_account();
+    runtime
+        .function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+
+    runtime
+        .function("test")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 }
 
 #[test]
@@ -1778,8 +2029,16 @@ fn dynamic_array_pop_empty_array() {
         }"#,
     );
 
-    runtime.constructor(&[]);
-    runtime.function("test", &[]);
+    let data_account = runtime.initialize_data_account();
+    runtime
+        .function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+
+    runtime
+        .function("test")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 }
 
 #[test]
@@ -1800,8 +2059,16 @@ fn dynamic_array_pop_bounds() {
         }"#,
     );
 
-    runtime.constructor(&[]);
-    runtime.function("test", &[]);
+    let data_account = runtime.initialize_data_account();
+    runtime
+        .function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+
+    runtime
+        .function("test")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 }
 
 #[test]
@@ -1840,8 +2107,16 @@ fn dynamic_array_push_pop_loop() {
         }"#,
     );
 
-    runtime.constructor(&[]);
-    runtime.function("test", &[]);
+    let data_account = runtime.initialize_data_account();
+    runtime
+        .function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+
+    runtime
+        .function("test")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let mut runtime = build_solidity(
         r#"
@@ -1879,8 +2154,16 @@ fn dynamic_array_push_pop_loop() {
         }"#,
     );
 
-    runtime.constructor(&[]);
-    runtime.function("test", &[]);
+    let data_account = runtime.initialize_data_account();
+    runtime
+        .function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+
+    runtime
+        .function("test")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 }
 
 #[test]
@@ -1899,7 +2182,10 @@ contract RH {
     "#;
 
     let mut vm = build_solidity(src);
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let separators = BorshToken::Array(vec![
         BorshToken::Int {
@@ -1943,7 +2229,11 @@ contract RH {
         },
     ]);
 
-    let returns = vm.function("calc", &[separators, params]).unwrap();
+    let returns = vm
+        .function("calc")
+        .arguments(&[separators, params])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -1990,12 +2280,15 @@ contract MyTest {
     "#;
 
     let mut vm = build_solidity(src);
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let ret = vm.function("foo", &[]).unwrap();
+    let ret = vm.function("foo").call().unwrap();
     assert_eq!(ret, BorshToken::Bytes(vec![65]));
 
-    let ret = vm.function("foo2", &[]).unwrap();
+    let ret = vm.function("foo2").call().unwrap();
     assert_eq!(
         ret,
         BorshToken::Uint {

--- a/tests/solana_tests/base58_encoding.rs
+++ b/tests/solana_tests/base58_encoding.rs
@@ -20,11 +20,17 @@ contract Base58 {
         "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     for _ in 0..10 {
         let account = account_new();
-        let _ = vm.function("print_this", &[BorshToken::Address(account)]);
+        let _ = vm
+            .function("print_this")
+            .arguments(&[BorshToken::Address(account)])
+            .call();
         let mut base_58 = account.to_base58();
         while base_58.len() < 44 {
             // Rust's to_base58() ignores leading zeros in the byte array,
@@ -35,7 +41,10 @@ contract Base58 {
         }
         assert_eq!(vm.logs, base_58);
         vm.logs.clear();
-        let _ = vm.function("print_as_hex", &[BorshToken::Address(account)]);
+        let _ = vm
+            .function("print_as_hex")
+            .arguments(&[BorshToken::Address(account)])
+            .call();
         let decoded = hex::decode(vm.logs.as_str()).unwrap();
         assert_eq!(account, decoded.as_ref());
         vm.logs.clear();

--- a/tests/solana_tests/constant.rs
+++ b/tests/solana_tests/constant.rs
@@ -20,9 +20,16 @@ fn constant() {
         "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("f", &[]).unwrap();
+    let returns = vm
+        .function("f")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
     assert_eq!(
         returns,
         BorshToken::Uint {
@@ -46,9 +53,16 @@ fn constant() {
         "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("f", &[]).unwrap();
+    let returns = vm
+        .function("f")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
     assert_eq!(
         returns,
         BorshToken::Uint {

--- a/tests/solana_tests/destructure.rs
+++ b/tests/solana_tests/destructure.rs
@@ -18,10 +18,16 @@ fn conditional_destructure() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let returns = vm
-        .function("f", &[BorshToken::Bool(true), BorshToken::Bool(true)])
+        .function("f")
+        .arguments(&[BorshToken::Bool(true), BorshToken::Bool(true)])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap()
         .unwrap_tuple();
 
@@ -40,7 +46,10 @@ fn conditional_destructure() {
     );
 
     let returns = vm
-        .function("f", &[BorshToken::Bool(true), BorshToken::Bool(false)])
+        .function("f")
+        .arguments(&[BorshToken::Bool(true), BorshToken::Bool(false)])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap()
         .unwrap_tuple();
 
@@ -59,7 +68,10 @@ fn conditional_destructure() {
     );
 
     let returns = vm
-        .function("f", &[BorshToken::Bool(false), BorshToken::Bool(false)])
+        .function("f")
+        .arguments(&[BorshToken::Bool(false), BorshToken::Bool(false)])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap()
         .unwrap_tuple();
 
@@ -78,7 +90,10 @@ fn conditional_destructure() {
     );
 
     let returns = vm
-        .function("f", &[BorshToken::Bool(false), BorshToken::Bool(true)])
+        .function("f")
+        .arguments(&[BorshToken::Bool(false), BorshToken::Bool(true)])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap()
         .unwrap_tuple();
 
@@ -113,9 +128,17 @@ fn casting_destructure() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("f", &[]).unwrap().unwrap_tuple();
+    let returns = vm
+        .function("f")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap()
+        .unwrap_tuple();
 
     assert_eq!(
         returns,
@@ -141,9 +164,16 @@ fn casting_destructure() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("f", &[]).unwrap();
+    let returns = vm
+        .function("f")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(returns, BorshToken::String(String::from("Hello")));
 }
@@ -177,7 +207,12 @@ fn casting_storage_destructure() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function("bar", &[]);
+    vm.function("bar")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 }

--- a/tests/solana_tests/events.rs
+++ b/tests/solana_tests/events.rs
@@ -23,9 +23,14 @@ fn simple_event() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function("go", &[]);
+    vm.function("go")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     assert_eq!(vm.events.len(), 1);
     assert_eq!(vm.events[0].len(), 1);
@@ -77,9 +82,14 @@ fn less_simple_event() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function("go", &[]);
+    vm.function("go")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     assert_eq!(vm.events.len(), 1);
     assert_eq!(vm.events[0].len(), 1);

--- a/tests/solana_tests/hash.rs
+++ b/tests/solana_tests/hash.rs
@@ -15,8 +15,16 @@ fn constants_hash_tests() {
         }"#,
     );
 
-    runtime.constructor(&[]);
-    runtime.function("test", &[]);
+    let data_account = runtime.initialize_data_account();
+    runtime
+        .function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+
+    runtime
+        .function("test")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let mut runtime = build_solidity(
         r#"
@@ -29,8 +37,15 @@ fn constants_hash_tests() {
         }"#,
     );
 
-    runtime.constructor(&[]);
-    runtime.function("test", &[]);
+    let data_account = runtime.initialize_data_account();
+    runtime
+        .function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    runtime
+        .function("test")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let mut runtime = build_solidity(
         r#"
@@ -43,8 +58,15 @@ fn constants_hash_tests() {
         }"#,
     );
 
-    runtime.constructor(&[]);
-    runtime.function("test", &[]);
+    let data_account = runtime.initialize_data_account();
+    runtime
+        .function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    runtime
+        .function("test")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 }
 
 #[test]
@@ -60,9 +82,19 @@ fn hash_tests() {
         }"##,
     );
 
-    runtime.constructor(&[]);
+    let data_account = runtime.initialize_data_account();
+    runtime
+        .function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
     let hash = runtime
-        .function("test", &[BorshToken::Bytes(b"Hello, World!".to_vec())])
+        .function("test")
+        .arguments(&[BorshToken::Bytes(b"Hello, World!".to_vec())])
+        .accounts(vec![
+            ("dataAccount", data_account),
+            ("systemProgram", [0; 32]),
+        ])
+        .call()
         .unwrap();
 
     assert_eq!(
@@ -83,9 +115,19 @@ fn hash_tests() {
         }"##,
     );
 
-    runtime.constructor(&[]);
+    let data_account = runtime.initialize_data_account();
+    runtime
+        .function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
     let hash = runtime
-        .function("test", &[BorshToken::Bytes(b"Hello, World!".to_vec())])
+        .function("test")
+        .arguments(&[BorshToken::Bytes(b"Hello, World!".to_vec())])
+        .accounts(vec![
+            ("dataAccount", data_account),
+            ("systemProgram", [0; 32]),
+        ])
+        .call()
         .unwrap();
 
     assert_eq!(
@@ -107,9 +149,19 @@ fn hash_tests() {
         }"##,
     );
 
-    runtime.constructor(&[]);
+    let data_account = runtime.initialize_data_account();
+    runtime
+        .function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
     let hash = runtime
-        .function("test", &[BorshToken::Bytes(b"Hello, World!".to_vec())])
+        .function("test")
+        .arguments(&[BorshToken::Bytes(b"Hello, World!".to_vec())])
+        .accounts(vec![
+            ("dataAccount", data_account),
+            ("systemProgram", [0; 32]),
+        ])
+        .call()
         .unwrap();
 
     assert_eq!(

--- a/tests/solana_tests/mappings.rs
+++ b/tests/solana_tests/mappings.rs
@@ -25,12 +25,14 @@ fn simple_mapping() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     for i in 0..10 {
-        vm.function(
-            "set",
-            &[
+        vm.function("set")
+            .arguments(&[
                 BorshToken::Uint {
                     width: 64,
                     value: BigInt::from(102 + i),
@@ -39,19 +41,20 @@ fn simple_mapping() {
                     width: 64,
                     value: BigInt::from(300331 + i),
                 },
-            ],
-        );
+            ])
+            .accounts(vec![("dataAccount", data_account)])
+            .call();
     }
 
     for i in 0..10 {
         let returns = vm
-            .function(
-                "get",
-                &[BorshToken::Uint {
-                    width: 64,
-                    value: BigInt::from(102 + i),
-                }],
-            )
+            .function("get")
+            .arguments(&[BorshToken::Uint {
+                width: 64,
+                value: BigInt::from(102 + i),
+            }])
+            .accounts(vec![("dataAccount", data_account)])
+            .call()
             .unwrap();
 
         assert_eq!(
@@ -64,13 +67,13 @@ fn simple_mapping() {
     }
 
     let returns = vm
-        .function(
-            "get",
-            &[BorshToken::Uint {
-                width: 64,
-                value: BigInt::from(101u8),
-            }],
-        )
+        .function("get")
+        .arguments(&[BorshToken::Uint {
+            width: 64,
+            value: BigInt::from(101u8),
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
 
     assert_eq!(
@@ -81,23 +84,23 @@ fn simple_mapping() {
         }
     );
 
-    vm.function(
-        "rm",
-        &[BorshToken::Uint {
+    vm.function("rm")
+        .arguments(&[BorshToken::Uint {
             width: 64,
             value: BigInt::from(104u8),
-        }],
-    );
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     for i in 0..10 {
         let returns = vm
-            .function(
-                "get",
-                &[BorshToken::Uint {
-                    width: 64,
-                    value: BigInt::from(102 + i),
-                }],
-            )
+            .function("get")
+            .arguments(&[BorshToken::Uint {
+                width: 64,
+                value: BigInt::from(102 + i),
+            }])
+            .accounts(vec![("dataAccount", data_account)])
+            .call()
             .unwrap();
 
         if 102 + i != 104 {
@@ -150,10 +153,14 @@ fn less_simple_mapping() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     vm.function(
-        "set_string",
+        "set_string")
+        .arguments(
         &[
             BorshToken::Uint {
                 width: 256,
@@ -161,11 +168,12 @@ fn less_simple_mapping() {
             },
             BorshToken::String(String::from("This is a string which should be a little longer than 32 bytes so we the the abi encoder")),
         ],
-    );
+    )
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function(
-        "add_int",
-        &[
+    vm.function("add_int")
+        .arguments(&[
             BorshToken::Uint {
                 width: 256,
                 value: BigInt::from(12313132131321312311213131u128),
@@ -174,17 +182,18 @@ fn less_simple_mapping() {
                 width: 64,
                 value: BigInt::from(102u8),
             },
-        ],
-    );
+        ])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let returns = vm
-        .function(
-            "get",
-            &[BorshToken::Uint {
-                width: 256,
-                value: BigInt::from(12313132131321312311213131u128),
-            }],
-        )
+        .function("get")
+        .arguments(&[BorshToken::Uint {
+            width: 256,
+            value: BigInt::from(12313132131321312311213131u128),
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
 
     assert_eq!(
@@ -231,29 +240,38 @@ fn string_mapping() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     vm.function(
-        "set_string",
+        "set_string")
+        .arguments(
         &[
             BorshToken::String(String::from("a")),
             BorshToken::String(String::from("This is a string which should be a little longer than 32 bytes so we the the abi encoder")),
         ],
-    );
+    )
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function(
-        "add_int",
-        &[
+    vm.function("add_int")
+        .arguments(&[
             BorshToken::String(String::from("a")),
             BorshToken::Int {
                 width: 64,
                 value: BigInt::from(102u8),
             },
-        ],
-    );
+        ])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let returns = vm
-        .function("get", &[BorshToken::String(String::from("a"))])
+        .function("get")
+        .arguments(&[BorshToken::String(String::from("a"))])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
 
     assert_eq!(
@@ -293,27 +311,46 @@ fn contract_mapping() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let index = BorshToken::Address(account_new());
 
     vm.function(
-        "set",
+        "set")
+        .arguments(
         &[
             index.clone(),
             BorshToken::String(String::from("This is a string which should be a little longer than 32 bytes so we the the abi encoder")),
-        ], );
+        ], )
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("get", &[index.clone()]).unwrap();
+    let returns = vm
+        .function("get")
+        .arguments(&[index.clone()])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
         BorshToken::String(String::from("This is a string which should be a little longer than 32 bytes so we the the abi encoder"))
     );
 
-    vm.function("rm", &[index.clone()]);
+    vm.function("rm")
+        .arguments(&[index.clone()])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("get", &[index]).unwrap();
+    let returns = vm
+        .function("get")
+        .arguments(&[index])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(returns, BorshToken::String(String::from("")));
 }
@@ -331,61 +368,64 @@ fn mapping_in_mapping() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function(
-        "set",
-        &[
+    vm.function("set")
+        .arguments(&[
             BorshToken::String(String::from("a")),
             BorshToken::Int {
                 width: 64,
                 value: BigInt::from(102u8),
             },
             BorshToken::FixedBytes(vec![0x98]),
-        ],
-    );
+        ])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let returns = vm
-        .function(
-            "map",
-            &[
-                BorshToken::String(String::from("a")),
-                BorshToken::Int {
-                    width: 64,
-                    value: BigInt::from(102u8),
-                },
-            ],
-        )
+        .function("map")
+        .arguments(&[
+            BorshToken::String(String::from("a")),
+            BorshToken::Int {
+                width: 64,
+                value: BigInt::from(102u8),
+            },
+        ])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
 
     assert_eq!(returns, BorshToken::uint8_fixed_array(vec![0x98]));
 
     let returns = vm
-        .function(
-            "map",
-            &[
-                BorshToken::String(String::from("a")),
-                BorshToken::Int {
-                    width: 64,
-                    value: BigInt::from(103u8),
-                },
-            ],
-        )
+        .function("map")
+        .arguments(&[
+            BorshToken::String(String::from("a")),
+            BorshToken::Int {
+                width: 64,
+                value: BigInt::from(103u8),
+            },
+        ])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
 
     assert_eq!(returns, BorshToken::uint8_fixed_array(vec![0]));
 
     let returns = vm
-        .function(
-            "map",
-            &[
-                BorshToken::String(String::from("b")),
-                BorshToken::Int {
-                    width: 64,
-                    value: BigInt::from(102u8),
-                },
-            ],
-        )
+        .function("map")
+        .arguments(&[
+            BorshToken::String(String::from("b")),
+            BorshToken::Int {
+                width: 64,
+                value: BigInt::from(102u8),
+            },
+        ])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
 
     assert_eq!(returns, BorshToken::uint8_fixed_array(vec![0]));
@@ -421,21 +461,26 @@ fn sparse_array() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     vm.function(
-        "set_string",
+        "set_string")
+        .arguments(
         &[
             BorshToken::Uint{
                 width: 256,
                 value: BigInt::from(909090909u64)
             },
             BorshToken::String(String::from("This is a string which should be a little longer than 32 bytes so we the the abi encoder")),
-        ], );
+        ], )
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function(
-        "add_int",
-        &[
+    vm.function("add_int")
+        .arguments(&[
             BorshToken::Uint {
                 width: 256,
                 value: BigInt::from(909090909u64),
@@ -444,17 +489,18 @@ fn sparse_array() {
                 width: 64,
                 value: BigInt::from(102u8),
             },
-        ],
-    );
+        ])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let returns = vm
-        .function(
-            "get",
-            &[BorshToken::Uint {
-                width: 256,
-                value: BigInt::from(909090909u64),
-            }],
-        )
+        .function("get")
+        .arguments(&[BorshToken::Uint {
+            width: 256,
+            value: BigInt::from(909090909u64),
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
 
     assert_eq!(
@@ -501,21 +547,26 @@ fn massive_sparse_array() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     vm.function(
-        "set_string",
+        "set_string")
+        .arguments(
         &[
             BorshToken::Uint {
                 width: 256,
                 value: BigInt::from(786868768768678687686877u128)
             },
             BorshToken::String(String::from("This is a string which should be a little longer than 32 bytes so we the the abi encoder")),
-        ], );
+        ], )
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function(
-        "add_int",
-        &[
+    vm.function("add_int")
+        .arguments(&[
             BorshToken::Uint {
                 width: 256,
                 value: BigInt::from(786868768768678687686877u128),
@@ -524,17 +575,18 @@ fn massive_sparse_array() {
                 width: 64,
                 value: BigInt::from(102u8),
             },
-        ],
-    );
+        ])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let returns = vm
-        .function(
-            "get",
-            &[BorshToken::Uint {
-                width: 256,
-                value: BigInt::from(786868768768678687686877u128),
-            }],
-        )
+        .function("get")
+        .arguments(&[BorshToken::Uint {
+            width: 256,
+            value: BigInt::from(786868768768678687686877u128),
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
 
     assert_eq!(
@@ -585,24 +637,30 @@ fn mapping_in_dynamic_array() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function(
-        "setNumber",
-        &[BorshToken::Int {
+    vm.function("setNumber")
+        .arguments(&[BorshToken::Int {
             width: 64,
             value: BigInt::from(2147483647),
-        }],
-    );
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function("push", &[]);
-    vm.function("push", &[]);
+    vm.function("push")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    vm.function("push")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     for array_no in 0..2 {
         for i in 0..10 {
-            vm.function(
-                "set",
-                &[
+            vm.function("set")
+                .arguments(&[
                     BorshToken::Uint {
                         width: 64,
                         value: BigInt::from(array_no),
@@ -615,27 +673,28 @@ fn mapping_in_dynamic_array() {
                         width: 64,
                         value: BigInt::from(300331 + i),
                     },
-                ],
-            );
+                ])
+                .accounts(vec![("dataAccount", data_account)])
+                .call();
         }
     }
 
     for array_no in 0..2 {
         for i in 0..10 {
             let returns = vm
-                .function(
-                    "map",
-                    &[
-                        BorshToken::Uint {
-                            width: 256,
-                            value: BigInt::from(array_no),
-                        },
-                        BorshToken::Uint {
-                            width: 64,
-                            value: BigInt::from(102 + i + array_no * 500),
-                        },
-                    ],
-                )
+                .function("map")
+                .arguments(&[
+                    BorshToken::Uint {
+                        width: 256,
+                        value: BigInt::from(array_no),
+                    },
+                    BorshToken::Uint {
+                        width: 64,
+                        value: BigInt::from(102 + i + array_no * 500),
+                    },
+                ])
+                .accounts(vec![("dataAccount", data_account)])
+                .call()
                 .unwrap();
 
             assert_eq!(
@@ -649,19 +708,19 @@ fn mapping_in_dynamic_array() {
     }
 
     let returns = vm
-        .function(
-            "map",
-            &[
-                BorshToken::Uint {
-                    width: 256,
-                    value: BigInt::zero(),
-                },
-                BorshToken::Uint {
-                    width: 64,
-                    value: BigInt::from(101u8),
-                },
-            ],
-        )
+        .function("map")
+        .arguments(&[
+            BorshToken::Uint {
+                width: 256,
+                value: BigInt::zero(),
+            },
+            BorshToken::Uint {
+                width: 64,
+                value: BigInt::from(101u8),
+            },
+        ])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
 
     assert_eq!(
@@ -672,9 +731,8 @@ fn mapping_in_dynamic_array() {
         }
     );
 
-    vm.function(
-        "rm",
-        &[
+    vm.function("rm")
+        .arguments(&[
             BorshToken::Uint {
                 width: 64,
                 value: BigInt::zero(),
@@ -683,24 +741,25 @@ fn mapping_in_dynamic_array() {
                 width: 64,
                 value: BigInt::from(104u8),
             },
-        ],
-    );
+        ])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     for i in 0..10 {
         let returns = vm
-            .function(
-                "map",
-                &[
-                    BorshToken::Uint {
-                        width: 256,
-                        value: BigInt::zero(),
-                    },
-                    BorshToken::Uint {
-                        width: 64,
-                        value: BigInt::from(102 + i),
-                    },
-                ],
-            )
+            .function("map")
+            .arguments(&[
+                BorshToken::Uint {
+                    width: 256,
+                    value: BigInt::zero(),
+                },
+                BorshToken::Uint {
+                    width: 64,
+                    value: BigInt::from(102 + i),
+                },
+            ])
+            .accounts(vec![("dataAccount", data_account)])
+            .call()
             .unwrap();
 
         if 102 + i != 104 {
@@ -722,7 +781,11 @@ fn mapping_in_dynamic_array() {
         }
     }
 
-    let returns = vm.function("length", &[]).unwrap();
+    let returns = vm
+        .function("length")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
     assert_eq!(
         returns,
         BorshToken::Uint {
@@ -731,9 +794,15 @@ fn mapping_in_dynamic_array() {
         }
     );
 
-    vm.function("pop", &[]);
+    vm.function("pop")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("length", &[]).unwrap();
+    let returns = vm
+        .function("length")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
     assert_eq!(
         returns,
         BorshToken::Uint {
@@ -742,9 +811,15 @@ fn mapping_in_dynamic_array() {
         }
     );
 
-    vm.function("pop", &[]);
+    vm.function("pop")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("length", &[]).unwrap();
+    let returns = vm
+        .function("length")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
     assert_eq!(
         returns,
         BorshToken::Uint {
@@ -753,7 +828,11 @@ fn mapping_in_dynamic_array() {
         }
     );
 
-    let returns = vm.function("number", &[]).unwrap();
+    let returns = vm
+        .function("number")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -802,24 +881,30 @@ fn mapping_in_struct_in_dynamic_array() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function(
-        "setNumber",
-        &[BorshToken::Int {
+    vm.function("setNumber")
+        .arguments(&[BorshToken::Int {
             width: 64,
             value: BigInt::from(2147483647),
-        }],
-    );
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function("push", &[]);
-    vm.function("push", &[]);
+    vm.function("push")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    vm.function("push")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     for array_no in 0..2 {
         for i in 0..10 {
-            vm.function(
-                "set",
-                &[
+            vm.function("set")
+                .arguments(&[
                     BorshToken::Uint {
                         width: 64,
                         value: BigInt::from(array_no),
@@ -832,27 +917,28 @@ fn mapping_in_struct_in_dynamic_array() {
                         width: 64,
                         value: BigInt::from(300331 + i),
                     },
-                ],
-            );
+                ])
+                .accounts(vec![("dataAccount", data_account)])
+                .call();
         }
     }
 
     for array_no in 0..2 {
         for i in 0..10 {
             let returns = vm
-                .function(
-                    "get",
-                    &[
-                        BorshToken::Uint {
-                            width: 64,
-                            value: BigInt::from(array_no),
-                        },
-                        BorshToken::Uint {
-                            width: 64,
-                            value: BigInt::from(102 + i + array_no * 500),
-                        },
-                    ],
-                )
+                .function("get")
+                .arguments(&[
+                    BorshToken::Uint {
+                        width: 64,
+                        value: BigInt::from(array_no),
+                    },
+                    BorshToken::Uint {
+                        width: 64,
+                        value: BigInt::from(102 + i + array_no * 500),
+                    },
+                ])
+                .accounts(vec![("dataAccount", data_account)])
+                .call()
                 .unwrap();
 
             assert_eq!(
@@ -866,19 +952,19 @@ fn mapping_in_struct_in_dynamic_array() {
     }
 
     let returns = vm
-        .function(
-            "get",
-            &[
-                BorshToken::Uint {
-                    width: 64,
-                    value: BigInt::zero(),
-                },
-                BorshToken::Uint {
-                    width: 64,
-                    value: BigInt::from(101u8),
-                },
-            ],
-        )
+        .function("get")
+        .arguments(&[
+            BorshToken::Uint {
+                width: 64,
+                value: BigInt::zero(),
+            },
+            BorshToken::Uint {
+                width: 64,
+                value: BigInt::from(101u8),
+            },
+        ])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
 
     assert_eq!(
@@ -889,9 +975,8 @@ fn mapping_in_struct_in_dynamic_array() {
         },
     );
 
-    vm.function(
-        "rm",
-        &[
+    vm.function("rm")
+        .arguments(&[
             BorshToken::Uint {
                 width: 64,
                 value: BigInt::zero(),
@@ -900,24 +985,25 @@ fn mapping_in_struct_in_dynamic_array() {
                 width: 64,
                 value: BigInt::from(104u8),
             },
-        ],
-    );
+        ])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     for i in 0..10 {
         let returns = vm
-            .function(
-                "get",
-                &[
-                    BorshToken::Uint {
-                        width: 64,
-                        value: BigInt::zero(),
-                    },
-                    BorshToken::Uint {
-                        width: 64,
-                        value: BigInt::from(102 + i),
-                    },
-                ],
-            )
+            .function("get")
+            .arguments(&[
+                BorshToken::Uint {
+                    width: 64,
+                    value: BigInt::zero(),
+                },
+                BorshToken::Uint {
+                    width: 64,
+                    value: BigInt::from(102 + i),
+                },
+            ])
+            .accounts(vec![("dataAccount", data_account)])
+            .call()
             .unwrap();
 
         if 102 + i != 104 {
@@ -939,10 +1025,18 @@ fn mapping_in_struct_in_dynamic_array() {
         }
     }
 
-    vm.function("pop", &[]);
-    vm.function("pop", &[]);
+    vm.function("pop")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    vm.function("pop")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("number", &[]).unwrap();
+    let returns = vm
+        .function("number")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -987,10 +1081,24 @@ contract DeleteTest {
 
     let sender = account_new();
 
-    vm.constructor(&[]);
-    let _ = vm.function("addData", &[BorshToken::Address(sender)]);
-    let _ = vm.function("deltest", &[]);
-    let returns = vm.function("get", &[]).unwrap();
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    let _ = vm
+        .function("addData")
+        .arguments(&[BorshToken::Address(sender)])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    let _ = vm
+        .function("deltest")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    let returns = vm
+        .function("get")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
     assert_eq!(
         returns,
         BorshToken::Tuple(vec![
@@ -1048,10 +1156,16 @@ function getArrAmt() public view returns (uint) {
 
     let sender = account_new();
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let ret = vm
-        .function("newCampaign", &[BorshToken::Address(sender)])
+        .function("newCampaign")
+        .arguments(&[BorshToken::Address(sender)])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
 
     assert_eq!(
@@ -1062,7 +1176,11 @@ function getArrAmt() public view returns (uint) {
         }
     );
 
-    let ret = vm.function("getAmt", &[]).unwrap();
+    let ret = vm
+        .function("getAmt")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
     assert_eq!(
         ret,
         BorshToken::Uint {
@@ -1071,7 +1189,11 @@ function getArrAmt() public view returns (uint) {
         }
     );
 
-    let ret = vm.function("getArrAmt", &[]).unwrap();
+    let ret = vm
+        .function("getArrAmt")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
     assert_eq!(
         ret,
         BorshToken::Uint {

--- a/tests/solana_tests/math.rs
+++ b/tests/solana_tests/math.rs
@@ -39,22 +39,25 @@ fn safe_math() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let returns = vm
-        .function(
-            "mul_test",
-            &[
-                BorshToken::Uint {
-                    width: 256,
-                    value: BigInt::from_str("1000000000000000000").unwrap(),
-                },
-                BorshToken::Uint {
-                    width: 256,
-                    value: BigInt::from_str("4000000000000000000").unwrap(),
-                },
-            ],
-        )
+        .function("mul_test")
+        .arguments(&[
+            BorshToken::Uint {
+                width: 256,
+                value: BigInt::from_str("1000000000000000000").unwrap(),
+            },
+            BorshToken::Uint {
+                width: 256,
+                value: BigInt::from_str("4000000000000000000").unwrap(),
+            },
+        ])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
 
     assert_eq!(
@@ -66,19 +69,19 @@ fn safe_math() {
     );
 
     let returns = vm
-        .function(
-            "add_test",
-            &[
-                BorshToken::Uint {
-                    width: 256,
-                    value: BigInt::from_str("1000000000000000000").unwrap(),
-                },
-                BorshToken::Uint {
-                    width: 256,
-                    value: BigInt::from_str("4000000000000000000").unwrap(),
-                },
-            ],
-        )
+        .function("add_test")
+        .arguments(&[
+            BorshToken::Uint {
+                width: 256,
+                value: BigInt::from_str("1000000000000000000").unwrap(),
+            },
+            BorshToken::Uint {
+                width: 256,
+                value: BigInt::from_str("4000000000000000000").unwrap(),
+            },
+        ])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
 
     assert_eq!(
@@ -90,19 +93,19 @@ fn safe_math() {
     );
 
     let returns = vm
-        .function(
-            "sub_test",
-            &[
-                BorshToken::Uint {
-                    width: 256,
-                    value: BigInt::from_str("4000000000000000000").unwrap(),
-                },
-                BorshToken::Uint {
-                    width: 256,
-                    value: BigInt::from_str("1000000000000000000").unwrap(),
-                },
-            ],
-        )
+        .function("sub_test")
+        .arguments(&[
+            BorshToken::Uint {
+                width: 256,
+                value: BigInt::from_str("4000000000000000000").unwrap(),
+            },
+            BorshToken::Uint {
+                width: 256,
+                value: BigInt::from_str("1000000000000000000").unwrap(),
+            },
+        ])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
 
     assert_eq!(
@@ -113,9 +116,9 @@ fn safe_math() {
         },
     );
 
-    let res = vm.function_must_fail(
-        "mul_test",
-        &[
+    let res = vm
+        .function("mul_test")
+        .arguments(&[
             BorshToken::Uint {
                 width: 256,
                 value: BigInt::from_str("400000000000000000000000000000000000000").unwrap(),
@@ -124,13 +127,15 @@ fn safe_math() {
                 width: 256,
                 value: BigInt::from_str("400000000000000000000000000000000000000").unwrap(),
             },
-        ],
-    );
+        ])
+        .accounts(vec![("dataAccount", data_account)])
+        .must_fail();
 
     assert_ne!(res.unwrap(), 0);
 
-    let res = vm.function_must_fail(
-        "add_test",
+    let res = vm.function(
+        "add_test")
+        .arguments(
         &[
             BorshToken::Uint {
                 width: 256,
@@ -141,13 +146,15 @@ fn safe_math() {
                 value: BigInt::from_str("100000000000000000000000000000000000000000000000000000000000000000000000000000").unwrap(),
             },
         ],
-    );
+    )
+        .accounts(vec![("dataAccount", data_account)])
+        .must_fail();
 
     assert_ne!(res.unwrap(), 0);
 
-    let res = vm.function_must_fail(
-        "sub_test",
-        &[
+    let res = vm
+        .function("sub_test")
+        .arguments(&[
             BorshToken::Uint {
                 width: 256,
                 value: BigInt::from_str("1000000000000000000").unwrap(),
@@ -156,8 +163,9 @@ fn safe_math() {
                 width: 256,
                 value: BigInt::from_str("4000000000000000000").unwrap(),
             },
-        ],
-    );
+        ])
+        .accounts(vec![("dataAccount", data_account)])
+        .must_fail();
 
     assert_ne!(res.unwrap(), 0);
 }

--- a/tests/solana_tests/modifiers.rs
+++ b/tests/solana_tests/modifiers.rs
@@ -28,10 +28,16 @@ fn returns_and_phis_needed() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let returns = vm
-        .function("func", &[BorshToken::Bool(false)])
+        .function("func")
+        .arguments(&[BorshToken::Bool(false)])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap()
         .unwrap_tuple();
 
@@ -47,7 +53,10 @@ fn returns_and_phis_needed() {
     );
 
     let returns = vm
-        .function("func", &[BorshToken::Bool(true)])
+        .function("func")
+        .arguments(&[BorshToken::Bool(true)])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap()
         .unwrap_tuple();
 

--- a/tests/solana_tests/primitives.rs
+++ b/tests/solana_tests/primitives.rs
@@ -27,9 +27,14 @@ fn assert_false() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function("assert_fails", &[]);
+    vm.function("assert_fails")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 }
 
 #[test]
@@ -44,9 +49,14 @@ fn assert_true() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function("assert_fails", &[]);
+    vm.function("assert_fails")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 }
 
 #[test]
@@ -76,18 +86,35 @@ fn boolean() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("return_true", &[]).unwrap();
+    let returns = vm
+        .function("return_true")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(returns, BorshToken::Bool(true));
 
-    let returns = vm.function("return_false", &[]).unwrap();
+    let returns = vm
+        .function("return_false")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(returns, BorshToken::Bool(false));
 
-    vm.function("true_arg", &[BorshToken::Bool(true)]);
-    vm.function("false_arg", &[BorshToken::Bool(false)]);
+    vm.function("true_arg")
+        .arguments(&[BorshToken::Bool(true)])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    vm.function("false_arg")
+        .arguments(&[BorshToken::Bool(false)])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 }
 
 #[test]
@@ -110,9 +137,16 @@ fn address() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("return_address", &[]).unwrap();
+    let returns = vm
+        .function("return_address")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -122,13 +156,13 @@ fn address() {
         ]),
     );
 
-    vm.function(
-        "address_arg",
-        &[BorshToken::Address([
+    vm.function("address_arg")
+        .arguments(&[BorshToken::Address([
             75, 161, 209, 89, 47, 84, 50, 13, 23, 127, 94, 21, 50, 249, 250, 185, 117, 49, 186,
             134, 82, 130, 112, 97, 218, 24, 157, 198, 40, 105, 118, 27,
-        ])],
-    );
+        ])])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 }
 
 #[test]
@@ -152,9 +186,16 @@ fn test_enum() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("return_enum", &[]).unwrap();
+    let returns = vm
+        .function("return_enum")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -164,13 +205,13 @@ fn test_enum() {
         }
     );
 
-    vm.function(
-        "enum_arg",
-        &[BorshToken::Uint {
+    vm.function("enum_arg")
+        .arguments(&[BorshToken::Uint {
             width: 8,
             value: BigInt::from(6u8),
-        }],
-    );
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 }
 
 #[test]
@@ -212,9 +253,17 @@ fn bytes() {
 
         let mut vm = build_solidity(&src);
 
-        vm.constructor(&[]);
+        let data_account = vm.initialize_data_account();
 
-        let returns = vm.function("return_literal", &[]).unwrap();
+        vm.function("new")
+            .accounts(vec![("dataAccount", data_account)])
+            .call();
+
+        let returns = vm
+            .function("return_literal")
+            .accounts(vec![("dataAccount", data_account)])
+            .call()
+            .unwrap();
 
         assert_eq!(
             returns,
@@ -222,10 +271,10 @@ fn bytes() {
         );
 
         let returns = vm
-            .function(
-                "return_arg",
-                &[BorshToken::FixedBytes(vec![1, 2, 3, 4, 5, 6, 7])],
-            )
+            .function("return_arg")
+            .arguments(&[BorshToken::FixedBytes(vec![1, 2, 3, 4, 5, 6, 7])])
+            .accounts(vec![("dataAccount", data_account)])
+            .call()
             .unwrap();
 
         assert_eq!(
@@ -244,13 +293,13 @@ fn bytes() {
             rng.fill(&mut b[..]);
 
             let or = vm
-                .function(
-                    "or",
-                    &[
-                        BorshToken::FixedBytes(a.to_vec()),
-                        BorshToken::FixedBytes(b.to_vec()),
-                    ],
-                )
+                .function("or")
+                .arguments(&[
+                    BorshToken::FixedBytes(a.to_vec()),
+                    BorshToken::FixedBytes(b.to_vec()),
+                ])
+                .accounts(vec![("dataAccount", data_account)])
+                .call()
                 .unwrap();
 
             let res: Vec<u8> = a.iter().zip(b.iter()).map(|(a, b)| a | b).collect();
@@ -265,13 +314,13 @@ fn bytes() {
             assert_eq!(or, BorshToken::uint8_fixed_array(res));
 
             let and = vm
-                .function(
-                    "and",
-                    &[
-                        BorshToken::FixedBytes(a.to_vec()),
-                        BorshToken::FixedBytes(b.to_vec()),
-                    ],
-                )
+                .function("and")
+                .arguments(&[
+                    BorshToken::FixedBytes(a.to_vec()),
+                    BorshToken::FixedBytes(b.to_vec()),
+                ])
+                .accounts(vec![("dataAccount", data_account)])
+                .call()
                 .unwrap();
 
             let res: Vec<u8> = a.iter().zip(b.iter()).map(|(a, b)| a & b).collect();
@@ -279,13 +328,13 @@ fn bytes() {
             assert_eq!(and, BorshToken::uint8_fixed_array(res));
 
             let xor = vm
-                .function(
-                    "xor",
-                    &[
-                        BorshToken::FixedBytes(a.to_vec()),
-                        BorshToken::FixedBytes(b.to_vec()),
-                    ],
-                )
+                .function("xor")
+                .arguments(&[
+                    BorshToken::FixedBytes(a.to_vec()),
+                    BorshToken::FixedBytes(b.to_vec()),
+                ])
+                .accounts(vec![("dataAccount", data_account)])
+                .call()
                 .unwrap();
 
             let res: Vec<u8> = a.iter().zip(b.iter()).map(|(a, b)| a ^ b).collect();
@@ -297,16 +346,16 @@ fn bytes() {
             println!("w = {width} r = {r}");
 
             let shl = vm
-                .function(
-                    "shift_left",
-                    &[
-                        BorshToken::FixedBytes(a.to_vec()),
-                        BorshToken::Uint {
-                            width: 32,
-                            value: BigInt::from(r),
-                        },
-                    ],
-                )
+                .function("shift_left")
+                .arguments(&[
+                    BorshToken::FixedBytes(a.to_vec()),
+                    BorshToken::Uint {
+                        width: 32,
+                        value: BigInt::from(r),
+                    },
+                ])
+                .accounts(vec![("dataAccount", data_account)])
+                .call()
                 .unwrap();
 
             let mut res = (BigUint::from_bytes_be(&a) << r).to_bytes_be();
@@ -322,16 +371,16 @@ fn bytes() {
             assert_eq!(shl, BorshToken::uint8_fixed_array(res));
 
             let shr = vm
-                .function(
-                    "shift_right",
-                    &[
-                        BorshToken::FixedBytes(a.to_vec()),
-                        BorshToken::Uint {
-                            width: 32,
-                            value: BigInt::from(r),
-                        },
-                    ],
-                )
+                .function("shift_right")
+                .arguments(&[
+                    BorshToken::FixedBytes(a.to_vec()),
+                    BorshToken::Uint {
+                        width: 32,
+                        value: BigInt::from(r),
+                    },
+                ])
+                .accounts(vec![("dataAccount", data_account)])
+                .call()
                 .unwrap();
 
             let mut res = (BigUint::from_bytes_be(&a) >> r).to_bytes_be();
@@ -417,7 +466,10 @@ fn uint() {
 
         let mut vm = build_solidity(&src);
 
-        vm.constructor(&[]);
+        let data_account = vm.initialize_data_account();
+        vm.function("new")
+            .accounts(vec![("dataAccount", data_account)])
+            .call();
 
         println!("width:{width}");
         let returned_width = width.next_power_of_two();
@@ -429,30 +481,31 @@ fn uint() {
                 std::mem::swap(&mut a, &mut b);
             }
 
-            let res = vm.function(
-                "pass",
-                &[BorshToken::Uint {
+            let res = vm
+                .function("pass")
+                .arguments(&[BorshToken::Uint {
                     width,
                     value: a.to_bigint().unwrap(),
-                }],
-            );
+                }])
+                .accounts(vec![("dataAccount", data_account)])
+                .call();
 
             println!("{a:x} = {res:?} o");
 
             let add = vm
-                .function(
-                    "add",
-                    &[
-                        BorshToken::Uint {
-                            width,
-                            value: a.to_bigint().unwrap(),
-                        },
-                        BorshToken::Uint {
-                            width,
-                            value: b.to_bigint().unwrap(),
-                        },
-                    ],
-                )
+                .function("add")
+                .arguments(&[
+                    BorshToken::Uint {
+                        width,
+                        value: a.to_bigint().unwrap(),
+                    },
+                    BorshToken::Uint {
+                        width,
+                        value: b.to_bigint().unwrap(),
+                    },
+                ])
+                .accounts(vec![("dataAccount", data_account)])
+                .call()
                 .unwrap();
 
             let mut res = a.clone().add(&b);
@@ -469,19 +522,19 @@ fn uint() {
             );
 
             let sub = vm
-                .function(
-                    "sub",
-                    &[
-                        BorshToken::Uint {
-                            width,
-                            value: a.to_bigint().unwrap(),
-                        },
-                        BorshToken::Uint {
-                            width,
-                            value: b.to_bigint().unwrap(),
-                        },
-                    ],
-                )
+                .function("sub")
+                .arguments(&[
+                    BorshToken::Uint {
+                        width,
+                        value: a.to_bigint().unwrap(),
+                    },
+                    BorshToken::Uint {
+                        width,
+                        value: b.to_bigint().unwrap(),
+                    },
+                ])
+                .accounts(vec![("dataAccount", data_account)])
+                .call()
                 .unwrap();
 
             let mut res = a.clone().sub(&b);
@@ -496,19 +549,19 @@ fn uint() {
             );
 
             let mul = vm
-                .function(
-                    "mul",
-                    &[
-                        BorshToken::Uint {
-                            width,
-                            value: a.to_bigint().unwrap(),
-                        },
-                        BorshToken::Uint {
-                            width,
-                            value: b.to_bigint().unwrap(),
-                        },
-                    ],
-                )
+                .function("mul")
+                .arguments(&[
+                    BorshToken::Uint {
+                        width,
+                        value: a.to_bigint().unwrap(),
+                    },
+                    BorshToken::Uint {
+                        width,
+                        value: b.to_bigint().unwrap(),
+                    },
+                ])
+                .accounts(vec![("dataAccount", data_account)])
+                .call()
                 .unwrap();
 
             let mut res = a.clone().mul(&b);
@@ -525,19 +578,19 @@ fn uint() {
             if let Some(mut n) = b.to_u32() {
                 n %= 65536;
                 let pow = vm
-                    .function(
-                        "pow",
-                        &[
-                            BorshToken::Uint {
-                                width,
-                                value: a.to_bigint().unwrap(),
-                            },
-                            BorshToken::Uint {
-                                width,
-                                value: BigInt::from(n),
-                            },
-                        ],
-                    )
+                    .function("pow")
+                    .arguments(&[
+                        BorshToken::Uint {
+                            width,
+                            value: a.to_bigint().unwrap(),
+                        },
+                        BorshToken::Uint {
+                            width,
+                            value: BigInt::from(n),
+                        },
+                    ])
+                    .accounts(vec![("dataAccount", data_account)])
+                    .call()
                     .unwrap();
 
                 let mut res = a.clone().pow(n);
@@ -554,19 +607,19 @@ fn uint() {
 
             if b != BigUint::zero() {
                 let div = vm
-                    .function(
-                        "div",
-                        &[
-                            BorshToken::Uint {
-                                width,
-                                value: a.to_bigint().unwrap(),
-                            },
-                            BorshToken::Uint {
-                                width,
-                                value: b.to_bigint().unwrap(),
-                            },
-                        ],
-                    )
+                    .function("div")
+                    .arguments(&[
+                        BorshToken::Uint {
+                            width,
+                            value: a.to_bigint().unwrap(),
+                        },
+                        BorshToken::Uint {
+                            width,
+                            value: b.to_bigint().unwrap(),
+                        },
+                    ])
+                    .accounts(vec![("dataAccount", data_account)])
+                    .call()
                     .unwrap();
 
                 let mut res = a.clone().div(&b);
@@ -582,19 +635,19 @@ fn uint() {
                 );
 
                 let add = vm
-                    .function(
-                        "mod",
-                        &[
-                            BorshToken::Uint {
-                                width,
-                                value: a.to_bigint().unwrap(),
-                            },
-                            BorshToken::Uint {
-                                width,
-                                value: b.to_bigint().unwrap(),
-                            },
-                        ],
-                    )
+                    .function("mod")
+                    .arguments(&[
+                        BorshToken::Uint {
+                            width,
+                            value: a.to_bigint().unwrap(),
+                        },
+                        BorshToken::Uint {
+                            width,
+                            value: b.to_bigint().unwrap(),
+                        },
+                    ])
+                    .accounts(vec![("dataAccount", data_account)])
+                    .call()
                     .unwrap();
 
                 let mut res = a.clone().rem(&b);
@@ -611,19 +664,19 @@ fn uint() {
             }
 
             let or = vm
-                .function(
-                    "or",
-                    &[
-                        BorshToken::Uint {
-                            width,
-                            value: a.to_bigint().unwrap(),
-                        },
-                        BorshToken::Uint {
-                            width,
-                            value: b.to_bigint().unwrap(),
-                        },
-                    ],
-                )
+                .function("or")
+                .arguments(&[
+                    BorshToken::Uint {
+                        width,
+                        value: a.to_bigint().unwrap(),
+                    },
+                    BorshToken::Uint {
+                        width,
+                        value: b.to_bigint().unwrap(),
+                    },
+                ])
+                .accounts(vec![("dataAccount", data_account)])
+                .call()
                 .unwrap();
 
             let mut res = a.clone().bitor(&b);
@@ -638,19 +691,19 @@ fn uint() {
             );
 
             let and = vm
-                .function(
-                    "and",
-                    &[
-                        BorshToken::Uint {
-                            width,
-                            value: a.to_bigint().unwrap(),
-                        },
-                        BorshToken::Uint {
-                            width,
-                            value: b.to_bigint().unwrap(),
-                        },
-                    ],
-                )
+                .function("and")
+                .arguments(&[
+                    BorshToken::Uint {
+                        width,
+                        value: a.to_bigint().unwrap(),
+                    },
+                    BorshToken::Uint {
+                        width,
+                        value: b.to_bigint().unwrap(),
+                    },
+                ])
+                .accounts(vec![("dataAccount", data_account)])
+                .call()
                 .unwrap();
 
             let mut res = a.clone().bitand(&b);
@@ -665,19 +718,19 @@ fn uint() {
             );
 
             let xor = vm
-                .function(
-                    "xor",
-                    &[
-                        BorshToken::Uint {
-                            width,
-                            value: a.to_bigint().unwrap(),
-                        },
-                        BorshToken::Uint {
-                            width,
-                            value: b.to_bigint().unwrap(),
-                        },
-                    ],
-                )
+                .function("xor")
+                .arguments(&[
+                    BorshToken::Uint {
+                        width,
+                        value: a.to_bigint().unwrap(),
+                    },
+                    BorshToken::Uint {
+                        width,
+                        value: b.to_bigint().unwrap(),
+                    },
+                ])
+                .accounts(vec![("dataAccount", data_account)])
+                .call()
                 .unwrap();
 
             let mut res = a.clone().bitxor(&b);
@@ -694,19 +747,19 @@ fn uint() {
             let r = rng.gen::<u32>() % (width as u32);
 
             let shl = vm
-                .function(
-                    "shift_left",
-                    &[
-                        BorshToken::Uint {
-                            width,
-                            value: a.to_bigint().unwrap(),
-                        },
-                        BorshToken::Uint {
-                            width: 32,
-                            value: BigInt::from(r),
-                        },
-                    ],
-                )
+                .function("shift_left")
+                .arguments(&[
+                    BorshToken::Uint {
+                        width,
+                        value: a.to_bigint().unwrap(),
+                    },
+                    BorshToken::Uint {
+                        width: 32,
+                        value: BigInt::from(r),
+                    },
+                ])
+                .accounts(vec![("dataAccount", data_account)])
+                .call()
                 .unwrap();
 
             let mut res = a.clone();
@@ -722,19 +775,19 @@ fn uint() {
             );
 
             let shr = vm
-                .function(
-                    "shift_right",
-                    &[
-                        BorshToken::Uint {
-                            width,
-                            value: a.to_bigint().unwrap(),
-                        },
-                        BorshToken::Uint {
-                            width: 32,
-                            value: BigInt::from(r),
-                        },
-                    ],
-                )
+                .function("shift_right")
+                .arguments(&[
+                    BorshToken::Uint {
+                        width,
+                        value: a.to_bigint().unwrap(),
+                    },
+                    BorshToken::Uint {
+                        width: 32,
+                        value: BigInt::from(r),
+                    },
+                ])
+                .accounts(vec![("dataAccount", data_account)])
+                .call()
                 .unwrap();
 
             let mut res = a.clone();
@@ -778,22 +831,26 @@ fn test_power_overflow_boundaries() {
         .replace("intN", &format!("int{width}"));
 
         let mut contract = build_solidity(&src);
-        contract.constructor(&[]);
+        let data_account = contract.initialize_data_account();
+        contract
+            .function("new")
+            .accounts(vec![("dataAccount", data_account)])
+            .call();
 
         let return_value = contract
-            .function(
-                "pow",
-                &[
-                    BorshToken::Uint {
-                        width,
-                        value: BigInt::from(2u8),
-                    },
-                    BorshToken::Uint {
-                        width,
-                        value: BigInt::from(width - 1),
-                    },
-                ],
-            )
+            .function("pow")
+            .arguments(&[
+                BorshToken::Uint {
+                    width,
+                    value: BigInt::from(2u8),
+                },
+                BorshToken::Uint {
+                    width,
+                    value: BigInt::from(width - 1),
+                },
+            ])
+            .accounts(vec![("dataAccount", data_account)])
+            .call()
             .unwrap();
 
         let res = BigUint::from(2_u32).pow((width - 1) as u32);
@@ -806,9 +863,9 @@ fn test_power_overflow_boundaries() {
             }
         );
 
-        let sesa = contract.function_must_fail(
-            "pow",
-            &[
+        let sesa = contract
+            .function("pow")
+            .arguments(&[
                 BorshToken::Uint {
                     width,
                     value: BigInt::from(2u8),
@@ -817,8 +874,9 @@ fn test_power_overflow_boundaries() {
                     width,
                     value: BigInt::from(width + 1),
                 },
-            ],
-        );
+            ])
+            .accounts(vec![("dataAccount", data_account)])
+            .must_fail();
 
         assert_ne!(sesa.unwrap(), 0);
     }
@@ -845,22 +903,27 @@ fn test_overflow_boundaries() {
 
         let returned_width = (width as u16).next_power_of_two();
 
+        let data_account = contract.initialize_data_account();
+        contract
+            .function("new")
+            .accounts(vec![("dataAccount", data_account)])
+            .call();
+
         // Multiply the boundaries by 1.
-        contract.constructor(&[]);
         let return_value = contract
-            .function(
-                "mul",
-                &[
-                    BorshToken::Int {
-                        width: width as u16,
-                        value: upper_boundary.clone(),
-                    },
-                    BorshToken::Int {
-                        width: width as u16,
-                        value: second_op.clone(),
-                    },
-                ],
-            )
+            .function("mul")
+            .arguments(&[
+                BorshToken::Int {
+                    width: width as u16,
+                    value: upper_boundary.clone(),
+                },
+                BorshToken::Int {
+                    width: width as u16,
+                    value: second_op.clone(),
+                },
+            ])
+            .accounts(vec![("dataAccount", data_account)])
+            .call()
             .unwrap();
         assert_eq!(
             return_value,
@@ -871,19 +934,19 @@ fn test_overflow_boundaries() {
         );
 
         let return_value = contract
-            .function(
-                "mul",
-                &[
-                    BorshToken::Int {
-                        width: width as u16,
-                        value: lower_boundary.clone(),
-                    },
-                    BorshToken::Int {
-                        width: width as u16,
-                        value: second_op.clone(),
-                    },
-                ],
-            )
+            .function("mul")
+            .arguments(&[
+                BorshToken::Int {
+                    width: width as u16,
+                    value: lower_boundary.clone(),
+                },
+                BorshToken::Int {
+                    width: width as u16,
+                    value: second_op.clone(),
+                },
+            ])
+            .accounts(vec![("dataAccount", data_account)])
+            .call()
             .unwrap();
         assert_eq!(
             return_value,
@@ -904,9 +967,9 @@ fn test_overflow_boundaries() {
 
         let lower_second_op = lower_boundary_minus_two.div(2);
 
-        let res = contract.function_must_fail(
-            "mul",
-            &[
+        let res = contract
+            .function("mul")
+            .arguments(&[
                 BorshToken::Int {
                     width: width as u16,
                     value: upper_second_op,
@@ -915,14 +978,15 @@ fn test_overflow_boundaries() {
                     width: width as u16,
                     value: BigInt::from(2u8),
                 },
-            ],
-        );
+            ])
+            .accounts(vec![("dataAccount", data_account)])
+            .must_fail();
 
         assert_ne!(res.unwrap(), 0);
 
-        let res = contract.function_must_fail(
-            "mul",
-            &[
+        let res = contract
+            .function("mul")
+            .arguments(&[
                 BorshToken::Int {
                     width: width as u16,
                     value: lower_second_op,
@@ -931,14 +995,15 @@ fn test_overflow_boundaries() {
                     width: width as u16,
                     value: BigInt::from(2),
                 },
-            ],
-        );
+            ])
+            .accounts(vec![("dataAccount", data_account)])
+            .must_fail();
 
         assert_ne!(res.unwrap(), 0);
 
-        let res = contract.function_must_fail(
-            "mul",
-            &[
+        let res = contract
+            .function("mul")
+            .arguments(&[
                 BorshToken::Int {
                     width: width as u16,
                     value: upper_boundary.clone(),
@@ -947,14 +1012,15 @@ fn test_overflow_boundaries() {
                     width: width as u16,
                     value: upper_boundary.clone(),
                 },
-            ],
-        );
+            ])
+            .accounts(vec![("dataAccount", data_account)])
+            .must_fail();
 
         assert_ne!(res.unwrap(), 0);
 
-        let res = contract.function_must_fail(
-            "mul",
-            &[
+        let res = contract
+            .function("mul")
+            .arguments(&[
                 BorshToken::Int {
                     width: width as u16,
                     value: lower_boundary.clone(),
@@ -963,14 +1029,15 @@ fn test_overflow_boundaries() {
                     width: width as u16,
                     value: lower_boundary.clone(),
                 },
-            ],
-        );
+            ])
+            .accounts(vec![("dataAccount", data_account)])
+            .must_fail();
 
         assert_ne!(res.unwrap(), 0);
 
-        let res = contract.function_must_fail(
-            "mul",
-            &[
+        let res = contract
+            .function("mul")
+            .arguments(&[
                 BorshToken::Int {
                     width: width as u16,
                     value: upper_boundary.clone(),
@@ -979,8 +1046,9 @@ fn test_overflow_boundaries() {
                     width: width as u16,
                     value: lower_boundary.clone(),
                 },
-            ],
-        );
+            ])
+            .accounts(vec![("dataAccount", data_account)])
+            .must_fail();
 
         assert_ne!(res.unwrap(), 0);
     }
@@ -1010,21 +1078,26 @@ fn test_mul_within_range_signed() {
         let second_op = BigInt::from(*side.choose(&mut rng).unwrap());
         println!("second op : {second_op:?}");
 
-        contract.constructor(&[]);
+        let data_account = contract.initialize_data_account();
+        contract
+            .function("new")
+            .accounts(vec![("dataAccount", data_account)])
+            .call();
+
         let return_value = contract
-            .function(
-                "mul",
-                &[
-                    BorshToken::Int {
-                        width: width as u16,
-                        value: first_operand_rand.clone(),
-                    },
-                    BorshToken::Int {
-                        width: width as u16,
-                        value: second_op.clone(),
-                    },
-                ],
-            )
+            .function("mul")
+            .arguments(&[
+                BorshToken::Int {
+                    width: width as u16,
+                    value: first_operand_rand.clone(),
+                },
+                BorshToken::Int {
+                    width: width as u16,
+                    value: second_op.clone(),
+                },
+            ])
+            .accounts(vec![("dataAccount", data_account)])
+            .call()
             .unwrap();
 
         let res = first_operand_rand.mul(second_op);
@@ -1051,7 +1124,12 @@ fn test_mul_within_range() {
         .replace("intN", &format!("int{width}"));
 
         let mut contract = build_solidity(&src);
-        contract.constructor(&[]);
+        let data_account = contract.initialize_data_account();
+        contract
+            .function("new")
+            .accounts(vec![("dataAccount", data_account)])
+            .call();
+
         for _ in 0..10 {
             // Max number to fit unsigned N bits is (2^N)-1
             let mut limit: BigUint = BigUint::from(2_u32).pow(width as u32);
@@ -1064,19 +1142,19 @@ fn test_mul_within_range() {
             let second_operand_rand = limit.div(&first_operand_rand);
 
             let return_value = contract
-                .function(
-                    "mul",
-                    &[
-                        BorshToken::Uint {
-                            width: width as u16,
-                            value: first_operand_rand.to_bigint().unwrap(),
-                        },
-                        BorshToken::Uint {
-                            width: width as u16,
-                            value: second_operand_rand.to_bigint().unwrap(),
-                        },
-                    ],
-                )
+                .function("mul")
+                .arguments(&[
+                    BorshToken::Uint {
+                        width: width as u16,
+                        value: first_operand_rand.to_bigint().unwrap(),
+                    },
+                    BorshToken::Uint {
+                        width: width as u16,
+                        value: second_operand_rand.to_bigint().unwrap(),
+                    },
+                ])
+                .accounts(vec![("dataAccount", data_account)])
+                .call()
                 .unwrap();
             let res = first_operand_rand * second_operand_rand;
 
@@ -1104,7 +1182,11 @@ fn test_overflow_detect_signed() {
         .replace("intN", &format!("int{width}"));
         let mut contract = build_solidity(&src);
 
-        contract.constructor(&[]);
+        let data_account = contract.initialize_data_account();
+        contract
+            .function("new")
+            .accounts(vec![("dataAccount", data_account)])
+            .call();
 
         // The range of values that can be held in signed N bits is [-2^(N-1), 2^(N-1)-1] .
         let mut limit: BigInt = BigInt::from(2_u32).pow((width - 1) as u32);
@@ -1117,9 +1199,9 @@ fn test_overflow_detect_signed() {
         // Calculate a number that when multiplied by first_operand_rand, the result will overflow N bits
         let second_operand_rand = rng.gen_bigint_range(&BigInt::from(2usize), &limit);
 
-        let res = contract.function_must_fail(
-            "mul",
-            &[
+        let res = contract
+            .function("mul")
+            .arguments(&[
                 BorshToken::Int {
                     width: width as u16,
                     value: first_operand_rand.clone(),
@@ -1128,8 +1210,9 @@ fn test_overflow_detect_signed() {
                     width: width as u16,
                     value: second_operand_rand.clone(),
                 },
-            ],
-        );
+            ])
+            .accounts(vec![("dataAccount", data_account)])
+            .must_fail();
 
         assert_ne!(res.unwrap(), 0);
 
@@ -1142,9 +1225,9 @@ fn test_overflow_detect_signed() {
         let first_operand_rand =
             rng.gen_bigint_range(&lower_limit, &(lower_limit.clone().div(2usize)).add(1usize));
 
-        let res = contract.function_must_fail(
-            "mul",
-            &[
+        let res = contract
+            .function("mul")
+            .arguments(&[
                 BorshToken::Int {
                     width: width as u16,
                     value: first_operand_rand.clone(),
@@ -1153,8 +1236,9 @@ fn test_overflow_detect_signed() {
                     width: width as u16,
                     value: second_operand_rand.clone(),
                 },
-            ],
-        );
+            ])
+            .accounts(vec![("dataAccount", data_account)])
+            .must_fail();
 
         assert_ne!(res.unwrap(), 0);
     }
@@ -1173,7 +1257,11 @@ fn test_overflow_detect_unsigned() {
         .replace("intN", &format!("int{width}"));
         let mut contract = build_solidity(&src);
 
-        contract.constructor(&[]);
+        let data_account = contract.initialize_data_account();
+        contract
+            .function("new")
+            .accounts(vec![("dataAccount", data_account)])
+            .call();
 
         for _ in 0..10 {
             // N bits can hold the range [0, (2^N)-1]. Generate a value that overflows N bits
@@ -1187,9 +1275,9 @@ fn test_overflow_detect_unsigned() {
             // Calculate a number that when multiplied by first_operand_rand, the result will overflow N bits
             let second_operand_rand = rng.gen_biguint_range(&BigUint::from(2usize), &limit);
 
-            let res = contract.function_must_fail(
-                "mul",
-                &[
+            let res = contract
+                .function("mul")
+                .arguments(&[
                     BorshToken::Uint {
                         width: width as u16,
                         value: first_operand_rand.to_bigint().unwrap(),
@@ -1198,8 +1286,9 @@ fn test_overflow_detect_unsigned() {
                         width: width as u16,
                         value: second_operand_rand.to_bigint().unwrap(),
                     },
-                ],
-            );
+                ])
+                .accounts(vec![("dataAccount", data_account)])
+                .must_fail();
             assert_ne!(res.unwrap(), 0);
         }
     }
@@ -1264,7 +1353,10 @@ fn int() {
 
         let mut vm = build_solidity(&src);
 
-        vm.constructor(&[]);
+        let data_account = vm.initialize_data_account();
+        vm.function("new")
+            .accounts(vec![("dataAccount", data_account)])
+            .call();
 
         let returned_width = (width as u16).next_power_of_two();
 
@@ -1273,19 +1365,19 @@ fn int() {
             let b = rng.gen_bigint(width - 1);
 
             let add = vm
-                .function(
-                    "add",
-                    &[
-                        BorshToken::Int {
-                            width: width as u16,
-                            value: a.clone(),
-                        },
-                        BorshToken::Int {
-                            width: width as u16,
-                            value: b.clone(),
-                        },
-                    ],
-                )
+                .function("add")
+                .arguments(&[
+                    BorshToken::Int {
+                        width: width as u16,
+                        value: a.clone(),
+                    },
+                    BorshToken::Int {
+                        width: width as u16,
+                        value: b.clone(),
+                    },
+                ])
+                .accounts(vec![("dataAccount", data_account)])
+                .call()
                 .unwrap();
 
             let mut res = a.clone().add(&b);
@@ -1300,19 +1392,19 @@ fn int() {
             );
 
             let sub = vm
-                .function(
-                    "sub",
-                    &[
-                        BorshToken::Int {
-                            width: width as u16,
-                            value: a.clone(),
-                        },
-                        BorshToken::Int {
-                            width: width as u16,
-                            value: b.clone(),
-                        },
-                    ],
-                )
+                .function("sub")
+                .arguments(&[
+                    BorshToken::Int {
+                        width: width as u16,
+                        value: a.clone(),
+                    },
+                    BorshToken::Int {
+                        width: width as u16,
+                        value: b.clone(),
+                    },
+                ])
+                .accounts(vec![("dataAccount", data_account)])
+                .call()
                 .unwrap();
 
             let mut res = a.clone().sub(&b);
@@ -1327,19 +1419,19 @@ fn int() {
             );
 
             let mul = vm
-                .function(
-                    "mul",
-                    &[
-                        BorshToken::Int {
-                            width: width as u16,
-                            value: a.clone(),
-                        },
-                        BorshToken::Int {
-                            width: width as u16,
-                            value: b.clone(),
-                        },
-                    ],
-                )
+                .function("mul")
+                .arguments(&[
+                    BorshToken::Int {
+                        width: width as u16,
+                        value: a.clone(),
+                    },
+                    BorshToken::Int {
+                        width: width as u16,
+                        value: b.clone(),
+                    },
+                ])
+                .accounts(vec![("dataAccount", data_account)])
+                .call()
                 .unwrap();
 
             let mut res = a.clone().mul(&b);
@@ -1355,19 +1447,19 @@ fn int() {
 
             if b != BigInt::zero() {
                 let div = vm
-                    .function(
-                        "div",
-                        &[
-                            BorshToken::Int {
-                                width: width as u16,
-                                value: a.clone(),
-                            },
-                            BorshToken::Int {
-                                width: width as u16,
-                                value: b.clone(),
-                            },
-                        ],
-                    )
+                    .function("div")
+                    .arguments(&[
+                        BorshToken::Int {
+                            width: width as u16,
+                            value: a.clone(),
+                        },
+                        BorshToken::Int {
+                            width: width as u16,
+                            value: b.clone(),
+                        },
+                    ])
+                    .accounts(vec![("dataAccount", data_account)])
+                    .call()
                     .unwrap();
 
                 let mut res = a.clone().div(&b);
@@ -1382,19 +1474,19 @@ fn int() {
                 );
 
                 let add = vm
-                    .function(
-                        "mod",
-                        &[
-                            BorshToken::Int {
-                                width: width as u16,
-                                value: a.clone(),
-                            },
-                            BorshToken::Int {
-                                width: width as u16,
-                                value: b.clone(),
-                            },
-                        ],
-                    )
+                    .function("mod")
+                    .arguments(&[
+                        BorshToken::Int {
+                            width: width as u16,
+                            value: a.clone(),
+                        },
+                        BorshToken::Int {
+                            width: width as u16,
+                            value: b.clone(),
+                        },
+                    ])
+                    .accounts(vec![("dataAccount", data_account)])
+                    .call()
                     .unwrap();
 
                 let mut res = a.clone().rem(&b);
@@ -1410,19 +1502,19 @@ fn int() {
             }
 
             let or = vm
-                .function(
-                    "or",
-                    &[
-                        BorshToken::Int {
-                            width: width as u16,
-                            value: a.clone(),
-                        },
-                        BorshToken::Int {
-                            width: width as u16,
-                            value: b.clone(),
-                        },
-                    ],
-                )
+                .function("or")
+                .arguments(&[
+                    BorshToken::Int {
+                        width: width as u16,
+                        value: a.clone(),
+                    },
+                    BorshToken::Int {
+                        width: width as u16,
+                        value: b.clone(),
+                    },
+                ])
+                .accounts(vec![("dataAccount", data_account)])
+                .call()
                 .unwrap();
 
             let mut res = a.clone().bitor(&b);
@@ -1437,19 +1529,19 @@ fn int() {
             );
 
             let and = vm
-                .function(
-                    "and",
-                    &[
-                        BorshToken::Int {
-                            width: width as u16,
-                            value: a.clone(),
-                        },
-                        BorshToken::Int {
-                            width: width as u16,
-                            value: b.clone(),
-                        },
-                    ],
-                )
+                .function("and")
+                .arguments(&[
+                    BorshToken::Int {
+                        width: width as u16,
+                        value: a.clone(),
+                    },
+                    BorshToken::Int {
+                        width: width as u16,
+                        value: b.clone(),
+                    },
+                ])
+                .accounts(vec![("dataAccount", data_account)])
+                .call()
                 .unwrap();
 
             let mut res = a.clone().bitand(&b);
@@ -1464,19 +1556,19 @@ fn int() {
             );
 
             let xor = vm
-                .function(
-                    "xor",
-                    &[
-                        BorshToken::Int {
-                            width: width as u16,
-                            value: a.clone(),
-                        },
-                        BorshToken::Int {
-                            width: width as u16,
-                            value: b.clone(),
-                        },
-                    ],
-                )
+                .function("xor")
+                .arguments(&[
+                    BorshToken::Int {
+                        width: width as u16,
+                        value: a.clone(),
+                    },
+                    BorshToken::Int {
+                        width: width as u16,
+                        value: b.clone(),
+                    },
+                ])
+                .accounts(vec![("dataAccount", data_account)])
+                .call()
                 .unwrap();
 
             let mut res = a.clone().bitxor(&b);
@@ -1493,19 +1585,19 @@ fn int() {
             let r = rng.gen::<u32>() % (width as u32);
 
             let shl = vm
-                .function(
-                    "shift_left",
-                    &[
-                        BorshToken::Int {
-                            width: width as u16,
-                            value: a.clone(),
-                        },
-                        BorshToken::Uint {
-                            width: 32,
-                            value: BigInt::from(r),
-                        },
-                    ],
-                )
+                .function("shift_left")
+                .arguments(&[
+                    BorshToken::Int {
+                        width: width as u16,
+                        value: a.clone(),
+                    },
+                    BorshToken::Uint {
+                        width: 32,
+                        value: BigInt::from(r),
+                    },
+                ])
+                .accounts(vec![("dataAccount", data_account)])
+                .call()
                 .unwrap();
 
             let mut res = a.clone().shl(r);
@@ -1521,19 +1613,19 @@ fn int() {
             );
 
             let shr = vm
-                .function(
-                    "shift_right",
-                    &[
-                        BorshToken::Int {
-                            width: width as u16,
-                            value: a.clone(),
-                        },
-                        BorshToken::Uint {
-                            width: 32,
-                            value: BigInt::from(r),
-                        },
-                    ],
-                )
+                .function("shift_right")
+                .arguments(&[
+                    BorshToken::Int {
+                        width: width as u16,
+                        value: a.clone(),
+                    },
+                    BorshToken::Uint {
+                        width: 32,
+                        value: BigInt::from(r),
+                    },
+                ])
+                .accounts(vec![("dataAccount", data_account)])
+                .call()
                 .unwrap();
 
             let mut res = a.shr(r);
@@ -1577,16 +1669,25 @@ fn bytes_cast() {
         "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let returns = vm
-        .function("to_bytes", &[BorshToken::FixedBytes(b"abcd".to_vec())])
+        .function("to_bytes")
+        .arguments(&[BorshToken::FixedBytes(b"abcd".to_vec())])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
 
     assert_eq!(returns, BorshToken::Bytes(b"abcd".to_vec()));
 
     let returns = vm
-        .function("to_bytes5", &[BorshToken::Bytes(b"abcde".to_vec())])
+        .function("to_bytes5")
+        .arguments(&[BorshToken::Bytes(b"abcde".to_vec())])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
 
     assert_eq!(returns, BorshToken::uint8_fixed_array(b"abcde".to_vec()));
@@ -1606,7 +1707,10 @@ fn shift_after_load() {
         "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
     let args = BorshToken::Array(vec![
         BorshToken::Uint {
             width: 256,
@@ -1617,7 +1721,12 @@ fn shift_after_load() {
             value: BigInt::from(4u8),
         },
     ]);
-    let returns = vm.function("testIt", &[args]).unwrap().unwrap_tuple();
+    let returns = vm
+        .function("testIt")
+        .arguments(&[args])
+        .call()
+        .unwrap()
+        .unwrap_tuple();
 
     assert_eq!(returns.len(), 2);
     assert_eq!(

--- a/tests/solana_tests/rational.rs
+++ b/tests/solana_tests/rational.rs
@@ -21,9 +21,16 @@ fn rational() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("test", &[]).unwrap();
+    let returns = vm
+        .function("test")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -33,7 +40,11 @@ fn rational() {
         }
     );
 
-    let returns = vm.function("test2", &[]).unwrap();
+    let returns = vm
+        .function("test2")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -53,9 +64,16 @@ fn rational() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("test", &[]).unwrap();
+    let returns = vm
+        .function("test")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -75,9 +93,16 @@ fn rational() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("test", &[]).unwrap();
+    let returns = vm
+        .function("test")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -97,9 +122,16 @@ fn rational() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("test", &[]).unwrap();
+    let returns = vm
+        .function("test")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -119,9 +151,16 @@ fn rational() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("test", &[]).unwrap();
+    let returns = vm
+        .function("test")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -140,9 +179,16 @@ fn rational() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("test", &[]).unwrap();
+    let returns = vm
+        .function("test")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -161,9 +207,16 @@ fn rational() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("test", &[]).unwrap();
+    let returns = vm
+        .function("test")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -182,16 +235,19 @@ fn rational() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let returns = vm
-        .function(
-            "test",
-            &[BorshToken::Uint {
-                width: 64,
-                value: BigInt::from(982451653u32),
-            }],
-        )
+        .function("test")
+        .arguments(&[BorshToken::Uint {
+            width: 64,
+            value: BigInt::from(982451653u32),
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap()
         .unwrap_tuple();
 

--- a/tests/solana_tests/returns.rs
+++ b/tests/solana_tests/returns.rs
@@ -31,9 +31,16 @@ fn return_single() {
             }
         }"#,
     );
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("f", &[]).unwrap();
+    let returns = vm
+        .function("f")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
     assert_eq!(
         returns,
         BorshToken::Uint {
@@ -42,7 +49,11 @@ fn return_single() {
         },
     );
 
-    let returns = vm.function("g", &[]).unwrap();
+    let returns = vm
+        .function("g")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
     assert_eq!(
         returns,
         BorshToken::Uint {
@@ -51,7 +62,11 @@ fn return_single() {
         },
     );
 
-    let returns = vm.function("h", &[]).unwrap();
+    let returns = vm
+        .function("h")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
     assert_eq!(
         returns,
         BorshToken::Uint {
@@ -60,7 +75,11 @@ fn return_single() {
         },
     );
 
-    let returns = vm.function("i", &[]).unwrap();
+    let returns = vm
+        .function("i")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
     assert_eq!(
         returns,
         BorshToken::Uint {
@@ -69,7 +88,11 @@ fn return_single() {
         },
     );
 
-    let returns = vm.function("j", &[]).unwrap();
+    let returns = vm
+        .function("j")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
     assert_eq!(
         returns,
         BorshToken::Uint {
@@ -90,8 +113,16 @@ fn return_ternary() {
         }"#,
     );
 
-    vm.constructor(&[]);
-    let returns = vm.function("f", &[]).unwrap().unwrap_tuple();
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    let returns = vm
+        .function("f")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap()
+        .unwrap_tuple();
 
     assert_eq!(
         returns,
@@ -116,8 +147,16 @@ fn return_ternary() {
         }"#,
     );
 
-    vm.constructor(&[]);
-    let returns = vm.function("f", &[]).unwrap().unwrap_tuple();
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    let returns = vm
+        .function("f")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap()
+        .unwrap_tuple();
 
     assert_eq!(
         returns,
@@ -156,10 +195,23 @@ fn return_nothing() {
         }"#,
     );
 
-    vm.constructor(&[]);
-    let _returns = vm.function("strange", &[]);
-    let _returns = vm.function("inc", &[]);
-    let returns = vm.function("get", &[]).unwrap();
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    let _returns = vm
+        .function("strange")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    let _returns = vm
+        .function("inc")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    let returns = vm
+        .function("get")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -192,9 +244,19 @@ fn return_nothing() {
         }"#,
     );
 
-    vm.constructor(&[]);
-    let _returns = vm.function("f", &[]);
-    let returns = vm.function("get", &[]).unwrap();
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    let _returns = vm
+        .function("f")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    let returns = vm
+        .function("get")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -220,8 +282,16 @@ fn return_function() {
         }"#,
     );
 
-    vm.constructor(&[]);
-    let returns = vm.function("f", &[]).unwrap().unwrap_tuple();
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    let returns = vm
+        .function("f")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap()
+        .unwrap_tuple();
 
     assert_eq!(
         returns,
@@ -250,8 +320,16 @@ fn return_function() {
         }"#,
     );
 
-    vm.constructor(&[]);
-    let returns = vm.function("f", &[]).unwrap().unwrap_tuple();
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    let returns = vm
+        .function("f")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap()
+        .unwrap_tuple();
 
     assert_eq!(
         returns,

--- a/tests/solana_tests/runtime_errors.rs
+++ b/tests/solana_tests/runtime_errors.rs
@@ -135,28 +135,33 @@ contract calle_contract {
     );
 
     vm.set_program(0);
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let mut _res = vm.function_must_fail(
-        "math_overflow",
-        &[BorshToken::Int {
+    let mut _res = vm
+        .function("math_overflow")
+        .arguments(&[BorshToken::Int {
             width: 8,
             value: BigInt::from(10u8),
-        }],
-    );
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .must_fail();
     assert_eq!(
         vm.logs,
         "runtime_error: math overflow in test.sol:22:20-29,\n"
     );
     vm.logs.clear();
 
-    _res = vm.function_must_fail(
-        "require_test",
-        &[BorshToken::Int {
+    _res = vm
+        .function("require_test")
+        .arguments(&[BorshToken::Int {
             width: 256,
             value: BigInt::from(9u8),
-        }],
-    );
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .must_fail();
 
     assert_eq!(
         vm.logs,
@@ -165,7 +170,10 @@ contract calle_contract {
 
     vm.logs.clear();
 
-    _res = vm.function_must_fail("get_storage_bytes", &[]);
+    _res = vm
+        .function("get_storage_bytes")
+        .accounts(vec![("dataAccount", data_account)])
+        .must_fail();
 
     assert_eq!(
         vm.logs,
@@ -174,7 +182,10 @@ contract calle_contract {
 
     vm.logs.clear();
 
-    _res = vm.function_must_fail("set_storage_bytes", &[]);
+    _res = vm
+        .function("set_storage_bytes")
+        .accounts(vec![("dataAccount", data_account)])
+        .must_fail();
 
     assert_eq!(
         vm.logs,
@@ -182,13 +193,14 @@ contract calle_contract {
     );
     vm.logs.clear();
 
-    _res = vm.function_must_fail(
-        "read_integer_failure",
-        &[BorshToken::Uint {
+    _res = vm
+        .function("read_integer_failure")
+        .arguments(&[BorshToken::Uint {
             width: 32,
             value: BigInt::from(2u8),
-        }],
-    );
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .must_fail();
 
     assert_eq!(
         vm.logs,
@@ -196,13 +208,14 @@ contract calle_contract {
     );
     vm.logs.clear();
 
-    _res = vm.function_must_fail(
-        "trunc_failure",
-        &[BorshToken::Uint {
+    _res = vm
+        .function("trunc_failure")
+        .arguments(&[BorshToken::Uint {
             width: 256,
             value: BigInt::from(u128::MAX),
-        }],
-    );
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .must_fail();
 
     assert_eq!(
         vm.logs,
@@ -210,7 +223,10 @@ contract calle_contract {
     );
     vm.logs.clear();
 
-    _res = vm.function_must_fail("invalid_instruction", &[]);
+    _res = vm
+        .function("invalid_instruction")
+        .accounts(vec![("dataAccount", data_account)])
+        .must_fail();
 
     assert_eq!(
         vm.logs,
@@ -219,7 +235,10 @@ contract calle_contract {
 
     vm.logs.clear();
 
-    _res = vm.function_must_fail("pop_empty_storage", &[]);
+    _res = vm
+        .function("pop_empty_storage")
+        .accounts(vec![("dataAccount", data_account)])
+        .must_fail();
 
     assert_eq!(
         vm.logs,
@@ -228,13 +247,14 @@ contract calle_contract {
 
     vm.logs.clear();
 
-    _res = vm.function_must_fail(
-        "write_bytes_failure",
-        &[BorshToken::Uint {
+    _res = vm
+        .function("write_bytes_failure")
+        .arguments(&[BorshToken::Uint {
             width: 256,
             value: BigInt::from(9u8),
-        }],
-    );
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .must_fail();
 
     assert_eq!(
         vm.logs,
@@ -243,13 +263,14 @@ contract calle_contract {
 
     vm.logs.clear();
 
-    _res = vm.function_must_fail(
-        "assert_test",
-        &[BorshToken::Uint {
+    _res = vm
+        .function("assert_test")
+        .arguments(&[BorshToken::Uint {
             width: 256,
             value: BigInt::from(9u8),
-        }],
-    );
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .must_fail();
     println!("{}", vm.logs);
     assert_eq!(
         vm.logs,
@@ -257,13 +278,14 @@ contract calle_contract {
     );
     vm.logs.clear();
 
-    _res = vm.function_must_fail(
-        "out_of_bounds",
-        &[BorshToken::Uint {
+    _res = vm
+        .function("out_of_bounds")
+        .arguments(&[BorshToken::Uint {
             width: 256,
             value: BigInt::from(19u8),
-        }],
-    );
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .must_fail();
 
     assert_eq!(
         vm.logs,
@@ -272,13 +294,14 @@ contract calle_contract {
 
     vm.logs.clear();
 
-    _res = vm.function_must_fail(
-        "write_integer_failure",
-        &[BorshToken::Uint {
+    _res = vm
+        .function("write_integer_failure")
+        .arguments(&[BorshToken::Uint {
             width: 256,
             value: BigInt::from(1u8),
-        }],
-    );
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .must_fail();
 
     assert_eq!(
         vm.logs,
@@ -287,13 +310,14 @@ contract calle_contract {
 
     vm.logs.clear();
 
-    _res = vm.function_must_fail(
-        "byte_cast_failure",
-        &[BorshToken::Uint {
+    _res = vm
+        .function("byte_cast_failure")
+        .arguments(&[BorshToken::Uint {
             width: 256,
             value: BigInt::from(33u8),
-        }],
-    );
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .must_fail();
 
     assert_eq!(
         vm.logs,
@@ -302,7 +326,10 @@ contract calle_contract {
 
     vm.logs.clear();
 
-    _res = vm.function_must_fail("i_will_revert", &[]);
+    _res = vm
+        .function("i_will_revert")
+        .accounts(vec![("dataAccount", data_account)])
+        .must_fail();
 
     assert_eq!(
         vm.logs,
@@ -311,7 +338,7 @@ contract calle_contract {
 
     vm.logs.clear();
 
-    _res = vm.function_must_fail("revert_with_message", &[]);
+    _res = vm.function("revert_with_message").must_fail();
     assert_eq!(
         vm.logs,
         "runtime_error: I reverted! revert encountered in test.sol:103:9-30,\n"

--- a/tests/solana_tests/storage.rs
+++ b/tests/solana_tests/storage.rs
@@ -18,8 +18,15 @@ fn simple() {
         }"#,
     );
 
-    vm.constructor(&[]);
-    let returns = vm.function("boom", &[]).unwrap();
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    let returns = vm
+        .function("boom")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
     assert_eq!(
         returns,
         BorshToken::Int {
@@ -48,8 +55,15 @@ fn simple() {
         }"#,
     );
 
-    vm.constructor(&[]);
-    let returns = vm.function("func", &[]).unwrap();
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    let returns = vm
+        .function("func")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
     assert_eq!(
         returns,
         BorshToken::Int {
@@ -76,53 +90,84 @@ fn string() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     assert_eq!(
-        vm.data()[0..20].to_vec(),
+        vm.account_data[&data_account].data[0..20].to_vec(),
         vec![65, 177, 160, 100, 0, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0]
     );
 
-    let returns = vm.function("get", &[]).unwrap();
+    let returns = vm
+        .function("get")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(returns, BorshToken::String(String::from("")));
 
-    vm.function("set", &[BorshToken::String(String::from("Hello, World!"))]);
+    vm.function("set")
+        .arguments(&[BorshToken::String(String::from("Hello, World!"))])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     assert_eq!(
-        vm.data()[0..20].to_vec(),
+        vm.account_data[&data_account].data[0..20].to_vec(),
         vec![65, 177, 160, 100, 0, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 40, 0, 0, 0]
     );
 
-    assert_eq!(vm.data()[40..53].to_vec(), b"Hello, World!");
+    assert_eq!(
+        vm.account_data[&data_account].data[40..53].to_vec(),
+        b"Hello, World!"
+    );
 
-    let returns = vm.function("get", &[]).unwrap();
+    let returns = vm
+        .function("get")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(returns, BorshToken::String(String::from("Hello, World!")));
 
     // try replacing it with a string of the same length. This is a special
     // fast-path handling
-    vm.function("set", &[BorshToken::String(String::from("Hallo, Werld!"))]);
+    vm.function("set")
+        .arguments(&[BorshToken::String(String::from("Hallo, Werld!"))])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("get", &[]).unwrap();
+    let returns = vm
+        .function("get")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(returns, BorshToken::String(String::from("Hallo, Werld!")));
 
     assert_eq!(
-        vm.data()[0..20].to_vec(),
+        vm.account_data[&data_account].data[0..20].to_vec(),
         vec![65, 177, 160, 100, 0, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 40, 0, 0, 0]
     );
 
     // Try setting this to an empty string. This is also a special case where
     // the result should be offset 0
-    vm.function("set", &[BorshToken::String(String::from(""))]);
+    vm.function("set")
+        .arguments(&[BorshToken::String(String::from(""))])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("get", &[]).unwrap();
+    let returns = vm
+        .function("get")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(returns, BorshToken::String(String::from("")));
 
     assert_eq!(
-        vm.data()[0..20].to_vec(),
+        vm.account_data[&data_account].data[0..20].to_vec(),
         vec![65, 177, 160, 100, 0, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0]
     );
 }
@@ -152,14 +197,21 @@ fn bytes() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     assert_eq!(
-        vm.data()[0..20].to_vec(),
+        vm.account_data[&data_account].data[0..20].to_vec(),
         vec![11, 66, 182, 57, 0, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0]
     );
 
-    let returns = vm.function("foo_length", &[]).unwrap();
+    let returns = vm
+        .function("foo_length")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -169,15 +221,15 @@ fn bytes() {
         }
     );
 
-    vm.function(
-        "set_foo",
-        &[BorshToken::Bytes(
+    vm.function("set_foo")
+        .arguments(&[BorshToken::Bytes(
             b"The shoemaker always wears the worst shoes".to_vec(),
-        )],
-    );
+        )])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     assert_eq!(
-        vm.data()[0..20].to_vec(),
+        vm.account_data[&data_account].data[0..20].to_vec(),
         vec![11, 66, 182, 57, 0, 0, 0, 0, 0, 0, 0, 0, 24, 0, 0, 0, 40, 0, 0, 0]
     );
 
@@ -186,52 +238,52 @@ fn bytes() {
         .enumerate()
     {
         let returns = vm
-            .function(
-                "get_foo_offset",
-                &[BorshToken::Uint {
-                    width: 32,
-                    value: BigInt::from(i),
-                }],
-            )
+            .function("get_foo_offset")
+            .arguments(&[BorshToken::Uint {
+                width: 32,
+                value: BigInt::from(i),
+            }])
+            .accounts(vec![("dataAccount", data_account)])
+            .call()
             .unwrap();
 
         assert_eq!(returns, BorshToken::uint8_fixed_array(vec![*b]));
     }
 
-    vm.function(
-        "set_foo_offset",
-        &[
+    vm.function("set_foo_offset")
+        .arguments(&[
             BorshToken::Uint {
                 width: 32,
                 value: BigInt::from(2u8),
             },
             BorshToken::FixedBytes(b"E".to_vec()),
-        ],
-    );
+        ])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function(
-        "set_foo_offset",
-        &[
+    vm.function("set_foo_offset")
+        .arguments(&[
             BorshToken::Uint {
                 width: 32,
                 value: BigInt::from(7u8),
             },
             BorshToken::FixedBytes(b"E".to_vec()),
-        ],
-    );
+        ])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     for (i, b) in b"ThE shoEmaker always wears the worst shoes"
         .iter()
         .enumerate()
     {
         let returns = vm
-            .function(
-                "get_foo_offset",
-                &[BorshToken::Uint {
-                    width: 32,
-                    value: BigInt::from(i),
-                }],
-            )
+            .function("get_foo_offset")
+            .arguments(&[BorshToken::Uint {
+                width: 32,
+                value: BigInt::from(i),
+            }])
+            .accounts(vec![("dataAccount", data_account)])
+            .call()
             .unwrap();
 
         assert_eq!(returns, BorshToken::uint8_fixed_array(vec![*b]));
@@ -264,18 +316,21 @@ fn bytes_set_subscript_range() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function(
-        "set_foo_offset",
-        &[
+    vm.function("set_foo_offset")
+        .arguments(&[
             BorshToken::Uint {
                 width: 32,
                 value: BigInt::zero(),
             },
             BorshToken::FixedBytes(b"E".to_vec()),
-        ],
-    );
+        ])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 }
 
 #[test]
@@ -304,22 +359,25 @@ fn bytes_get_subscript_range() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function(
-        "set_foo",
-        &[BorshToken::Bytes(
+    vm.function("set_foo")
+        .arguments(&[BorshToken::Bytes(
             b"The shoemaker always wears the worst shoes".to_vec(),
-        )],
-    );
+        )])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function(
-        "get_foo_offset",
-        &[BorshToken::Uint {
+    vm.function("get_foo_offset")
+        .arguments(&[BorshToken::Uint {
             width: 32,
             value: BigInt::from(0x80000000u64),
-        }],
-    );
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 }
 
 #[test]
@@ -335,10 +393,13 @@ fn storage_alignment() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     assert_eq!(
-        vm.data()[0..40].to_vec(),
+        vm.account_data[&data_account].data[0..40].to_vec(),
         vec![
             11, 66, 182, 57, 0, 0, 0, 0, 0, 0, 0, 0, 40, 0, 0, 0, 1, 0, 3, 2, 4, 0, 0, 0, 8, 7, 6,
             5, 0, 0, 0, 0, 16, 15, 14, 13, 12, 11, 10, 9
@@ -367,31 +428,60 @@ fn bytes_push_pop() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("get_bs", &[]).unwrap();
+    let returns = vm
+        .function("get_bs")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(returns, BorshToken::Bytes(vec!(0x0e, 0xda)));
 
-    let returns = vm.function("pop", &[]).unwrap();
+    let returns = vm
+        .function("pop")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(returns, BorshToken::uint8_fixed_array(vec!(0xda)));
 
-    let returns = vm.function("get_bs", &[]).unwrap();
+    let returns = vm
+        .function("get_bs")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(returns, BorshToken::Bytes(vec!(0x0e)));
 
-    vm.function("push", &[BorshToken::FixedBytes(vec![0x41])]);
+    vm.function("push")
+        .arguments(&[BorshToken::FixedBytes(vec![0x41])])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    println!("data:{}", hex::encode(vm.data()));
+    //println!("data:{}", hex::encode(vm.data()));
 
-    let returns = vm.function("get_bs", &[]).unwrap();
+    let returns = vm
+        .function("get_bs")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(returns, BorshToken::Bytes(vec!(0x0e, 0x41)));
 
-    vm.function("push", &[BorshToken::FixedBytes(vec![0x01])]);
+    vm.function("push")
+        .arguments(&[BorshToken::FixedBytes(vec![0x01])])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("get_bs", &[]).unwrap();
+    let returns = vm
+        .function("get_bs")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(returns, BorshToken::Bytes(vec!(0x0e, 0x41, 0x01)));
 }
@@ -410,9 +500,14 @@ fn bytes_empty_pop() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function("pop", &[]);
+    vm.function("pop")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 }
 
 #[test]
@@ -442,19 +537,28 @@ fn simple_struct() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function("set_s2", &[]);
+    vm.function("set_s2")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     assert_eq!(
-        vm.data()[0..32].to_vec(),
+        vm.account_data[&data_account].data[0..32].to_vec(),
         vec![
             11, 66, 182, 57, 0, 0, 0, 0, 0, 0, 0, 0, 32, 0, 0, 0, 173, 222, 0, 0, 254, 0, 0, 0,
             173, 222, 0, 0, 0, 0, 0, 0
         ]
     );
 
-    let returns = vm.function("get_s1", &[]).unwrap();
+    let returns = vm
+        .function("get_s1")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -470,9 +574,8 @@ fn simple_struct() {
         ])
     );
 
-    vm.function(
-        "set_s1",
-        &[BorshToken::Tuple(vec![
+    vm.function("set_s1")
+        .arguments(&[BorshToken::Tuple(vec![
             BorshToken::Uint {
                 width: 8,
                 value: BigInt::from(102u8),
@@ -481,10 +584,15 @@ fn simple_struct() {
                 width: 32,
                 value: BigInt::from(3240121u32),
             },
-        ])],
-    );
+        ])])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("get_s1", &[]).unwrap();
+    let returns = vm
+        .function("get_s1")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -534,12 +642,17 @@ fn struct_in_struct() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function("set_s2", &[]);
+    vm.function("set_s2")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     assert_eq!(
-        vm.data()[0..52].to_vec(),
+        vm.account_data[&data_account].data[0..52].to_vec(),
         vec![
             11, 66, 182, 57, 0, 0, 0, 0, 0, 0, 0, 0, 56, 0, 0, 0, 173, 222, 0, 0, 0, 0, 0, 0, 254,
             0, 0, 0, 0, 0, 102, 0, 0, 0, 0, 0, 114, 97, 98, 111, 111, 102, 0, 0, 0, 0, 0, 0, 210,
@@ -547,7 +660,11 @@ fn struct_in_struct() {
         ]
     );
 
-    let returns = vm.function("get_s1", &[]).unwrap();
+    let returns = vm
+        .function("get_s1")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -570,9 +687,8 @@ fn struct_in_struct() {
         ])
     );
 
-    vm.function(
-        "set_s1",
-        &[BorshToken::Tuple(vec![
+    vm.function("set_s1")
+        .arguments(&[BorshToken::Tuple(vec![
             BorshToken::Uint {
                 width: 8,
                 value: BigInt::from(127u8),
@@ -588,10 +704,15 @@ fn struct_in_struct() {
                 width: 64,
                 value: BigInt::from(12345678901234567890u64),
             },
-        ])],
-    );
+        ])])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("get_s1", &[]).unwrap();
+    let returns = vm
+        .function("get_s1")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -643,12 +764,17 @@ fn string_in_struct() {
             }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function("set_s2", &[]);
+    vm.function("set_s2")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     assert_eq!(
-        vm.data()[0..64].to_vec(),
+        vm.account_data[&data_account].data[0..64].to_vec(),
         vec![
             11, 66, 182, 57, 0, 0, 0, 0, 0, 0, 0, 0, 40, 0, 0, 0, 173, 222, 0, 0, 0, 0, 0, 0, 254,
             0, 0, 0, 56, 0, 0, 0, 210, 2, 150, 73, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0,
@@ -656,7 +782,11 @@ fn string_in_struct() {
         ]
     );
 
-    let returns = vm.function("get_s1", &[]).unwrap();
+    let returns = vm
+        .function("get_s1")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -673,9 +803,8 @@ fn string_in_struct() {
         ])
     );
 
-    vm.function(
-        "set_s1",
-        &[BorshToken::Tuple(vec![
+    vm.function("set_s1")
+        .arguments(&[BorshToken::Tuple(vec![
             BorshToken::Uint {
                 width: 8,
                 value: BigInt::from(127u8),
@@ -685,10 +814,15 @@ fn string_in_struct() {
                 width: 64,
                 value: BigInt::from(12345678901234567890u64),
             },
-        ])],
-    );
+        ])])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("get_s1", &[]).unwrap();
+    let returns = vm
+        .function("get_s1")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -758,11 +892,21 @@ fn complex_struct() {
         }"#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    vm.function("set_s2", &[]);
+    vm.function("set_s2")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("get_s1", &[]).unwrap().unwrap_tuple();
+    let returns = vm
+        .function("get_s1")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap()
+        .unwrap_tuple();
 
     assert_eq!(
         returns,
@@ -796,9 +940,8 @@ fn complex_struct() {
         ]
     );
 
-    vm.function(
-        "set_s1",
-        &[
+    vm.function("set_s1")
+        .arguments(&[
             BorshToken::Tuple(vec![
                 BorshToken::Uint {
                     width: 8,
@@ -823,10 +966,16 @@ fn complex_struct() {
                 BorshToken::String(String::from("be as honest as the day is long")),
             ]),
             BorshToken::String(String::from("yadayada")),
-        ],
-    );
+        ])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("get_s1", &[]).unwrap().unwrap_tuple();
+    let returns = vm
+        .function("get_s1")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap()
+        .unwrap_tuple();
 
     assert_eq!(
         returns,
@@ -858,9 +1007,16 @@ fn complex_struct() {
         ]
     );
 
-    vm.function("rm", &[]);
+    vm.function("rm")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("get_s1", &[]).unwrap().unwrap_tuple();
+    let returns = vm
+        .function("get_s1")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap()
+        .unwrap_tuple();
 
     assert_eq!(
         returns,

--- a/tests/solana_tests/strings.rs
+++ b/tests/solana_tests/strings.rs
@@ -20,13 +20,21 @@ fn storage_string_length() {
     }
     "#,
     );
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let _ = vm.function(
-        "setString",
-        &[BorshToken::String("coffee_tastes_good".to_string())],
-    );
-    let returns = vm.function("getLength", &[]).unwrap();
+    let _ = vm
+        .function("setString")
+        .arguments(&[BorshToken::String("coffee_tastes_good".to_string())])
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    let returns = vm
+        .function("getLength")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -59,8 +67,17 @@ fn load_string_vector() {
       "#,
     );
 
-    vm.constructor(&[]);
-    let returns = vm.function("testLength", &[]).unwrap().unwrap_tuple();
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    let returns = vm
+        .function("testLength")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap()
+        .unwrap_tuple();
+
     assert_eq!(
         returns[0],
         BorshToken::Uint {
@@ -84,35 +101,35 @@ fn load_string_vector() {
     );
 
     let returns = vm
-        .function(
-            "getString",
-            &[BorshToken::Uint {
-                width: 32,
-                value: BigInt::zero(),
-            }],
-        )
+        .function("getString")
+        .arguments(&[BorshToken::Uint {
+            width: 32,
+            value: BigInt::zero(),
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
     assert_eq!(returns, BorshToken::String("tea".to_string()));
 
     let returns = vm
-        .function(
-            "getString",
-            &[BorshToken::Uint {
-                width: 32,
-                value: BigInt::one(),
-            }],
-        )
+        .function("getString")
+        .arguments(&[BorshToken::Uint {
+            width: 32,
+            value: BigInt::one(),
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
     assert_eq!(returns, BorshToken::String("coffe".to_string()));
 
     let returns = vm
-        .function(
-            "getString",
-            &[BorshToken::Uint {
-                width: 32,
-                value: BigInt::from(2u8),
-            }],
-        )
+        .function("getString")
+        .arguments(&[BorshToken::Uint {
+            width: 32,
+            value: BigInt::from(2u8),
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap();
     assert_eq!(returns, BorshToken::String("sixsix".to_string()));
 }

--- a/tests/solana_tests/structs.rs
+++ b/tests/solana_tests/structs.rs
@@ -24,7 +24,10 @@ fn struct_as_reference() {
         "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
     let input = BorshToken::Array(vec![
         BorshToken::Tuple(vec![
             BorshToken::Uint {
@@ -48,7 +51,7 @@ fn struct_as_reference() {
         ]),
     ]);
 
-    let res = vm.function("try_ref", &[input]).unwrap();
+    let res = vm.function("try_ref").arguments(&[input]).call().unwrap();
     assert_eq!(
         res,
         BorshToken::Array(vec![

--- a/tests/solana_tests/unused_variable_elimination.rs
+++ b/tests/solana_tests/unused_variable_elimination.rs
@@ -37,9 +37,19 @@ fn test_returns() {
     "#;
 
     let mut vm = build_solidity(file);
-    vm.constructor(&[]);
-    let _ = vm.function("assign", &[]);
-    let returns = vm.function("pb1", &[]).unwrap();
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    let _ = vm
+        .function("assign")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    let returns = vm
+        .function("pb1")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(
         returns,
@@ -49,7 +59,11 @@ fn test_returns() {
         }
     );
 
-    let returns = vm.function("test1", &[]).unwrap();
+    let returns = vm
+        .function("test1")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
     assert_eq!(
         returns,
         BorshToken::Int {
@@ -57,7 +71,11 @@ fn test_returns() {
             value: BigInt::from(52u8)
         }
     );
-    let returns = vm.function("test2", &[]).unwrap();
+    let returns = vm
+        .function("test2")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
     assert_eq!(
         returns,
         BorshToken::Int {

--- a/tests/solana_tests/using.rs
+++ b/tests/solana_tests/using.rs
@@ -29,8 +29,15 @@ fn using_for_contracts() {
         }"#,
     );
 
-    runtime.constructor(&[]);
-    runtime.function("test", &[]);
+    let data_account = runtime.initialize_data_account();
+    runtime
+        .function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    runtime
+        .function("test")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     assert_eq!(runtime.logs, "Hello");
 
@@ -72,8 +79,18 @@ fn using_for_contracts() {
         }"#,
     );
 
-    runtime.constructor(&[]);
-    runtime.function("test", &[]);
+    let data_account = runtime.initialize_data_account();
+    runtime
+        .function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    runtime
+        .function("test")
+        .accounts(vec![
+            ("dataAccount", data_account),
+            ("systemProgram", [0; 32]),
+        ])
+        .call();
 
     assert_eq!(runtime.logs, "X libX contractx:2");
 }
@@ -202,9 +219,22 @@ fn user_defined_oper() {
         }"#,
     );
 
-    runtime.constructor(&[]);
+    let data_account = runtime.initialize_data_account();
+    runtime
+        .function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    runtime.function("test_cmp", &[]);
-    runtime.function("test_arith", &[]);
-    runtime.function("test_bit", &[]);
+    runtime
+        .function("test_cmp")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    runtime
+        .function("test_arith")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    runtime
+        .function("test_bit")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 }

--- a/tests/solana_tests/vector_to_slice.rs
+++ b/tests/solana_tests/vector_to_slice.rs
@@ -20,8 +20,15 @@ fn test_slice_in_phi() {
     "#;
 
     let mut vm = build_solidity(file);
-    vm.constructor(&[]);
-    let returns = vm.function("test", &[]).unwrap();
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+    let returns = vm
+        .function("test")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
 
     assert_eq!(returns, BorshToken::String(String::from("Hello!")));
 }

--- a/tests/solana_tests/yul.rs
+++ b/tests/solana_tests/yul.rs
@@ -60,9 +60,17 @@ contract testing  {
       "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("test_slot", &[]).unwrap();
+    let returns = vm
+        .function("test_slot")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
+
     assert_eq!(
         returns,
         BorshToken::Uint {
@@ -72,27 +80,26 @@ contract testing  {
     );
 
     let returns = vm
-        .function(
-            "call_data_array",
-            &[BorshToken::Array(vec![
-                BorshToken::Uint {
-                    width: 32,
-                    value: BigInt::from(3u8),
-                },
-                BorshToken::Uint {
-                    width: 32,
-                    value: BigInt::from(5u8),
-                },
-                BorshToken::Uint {
-                    width: 32,
-                    value: BigInt::from(7u8),
-                },
-                BorshToken::Uint {
-                    width: 32,
-                    value: BigInt::from(11u8),
-                },
-            ])],
-        )
+        .function("call_data_array")
+        .arguments(&[BorshToken::Array(vec![
+            BorshToken::Uint {
+                width: 32,
+                value: BigInt::from(3u8),
+            },
+            BorshToken::Uint {
+                width: 32,
+                value: BigInt::from(5u8),
+            },
+            BorshToken::Uint {
+                width: 32,
+                value: BigInt::from(7u8),
+            },
+            BorshToken::Uint {
+                width: 32,
+                value: BigInt::from(11u8),
+            },
+        ])])
+        .call()
         .unwrap()
         .unwrap_tuple();
 
@@ -111,13 +118,19 @@ contract testing  {
         ]
     );
 
-    let returns = vm.function("selector_address", &[]).unwrap().unwrap_tuple();
+    let returns = vm
+        .function("selector_address")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap()
+        .unwrap_tuple();
+
     assert_eq!(
         returns,
         vec![
             BorshToken::Uint {
                 width: 256,
-                value: BigInt::from_bytes_be(Sign::Plus, vm.stack[0].data.as_ref())
+                value: BigInt::from_bytes_be(Sign::Plus, data_account.as_ref())
             },
             BorshToken::Uint {
                 width: 256,
@@ -167,18 +180,22 @@ contract testing  {
       "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let returns = vm
-        .function(
-            "general_test",
-            &[BorshToken::Uint {
-                width: 64,
-                value: BigInt::from(5u8),
-            }],
-        )
+        .function("general_test")
+        .arguments(&[BorshToken::Uint {
+            width: 64,
+            value: BigInt::from(5u8),
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap()
         .unwrap_tuple();
+
     assert_eq!(
         returns,
         vec![
@@ -194,15 +211,16 @@ contract testing  {
     );
 
     let returns = vm
-        .function(
-            "general_test",
-            &[BorshToken::Uint {
-                width: 64,
-                value: BigInt::from(78u8),
-            }],
-        )
+        .function("general_test")
+        .arguments(&[BorshToken::Uint {
+            width: 64,
+            value: BigInt::from(78u8),
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap()
         .unwrap_tuple();
+
     assert_eq!(
         returns,
         vec![
@@ -218,15 +236,16 @@ contract testing  {
     );
 
     let returns = vm
-        .function(
-            "general_test",
-            &[BorshToken::Uint {
-                width: 64,
-                value: BigInt::from(259u16),
-            }],
-        )
+        .function("general_test")
+        .arguments(&[BorshToken::Uint {
+            width: 64,
+            value: BigInt::from(259u16),
+        }])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap()
         .unwrap_tuple();
+
     assert_eq!(
         returns,
         vec![
@@ -272,21 +291,26 @@ contract c {
         "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+
     let num: Vec<u8> = vec![
         0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
         0x11, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e,
         0x2f, 0x31,
     ];
+
     let returns = vm
-        .function(
-            "getByte",
-            &[BorshToken::Uint {
-                width: 256,
-                value: BigInt::from_bytes_be(Sign::Plus, &num),
-            }],
-        )
+        .function("getByte")
+        .arguments(&[BorshToken::Uint {
+            width: 256,
+            value: BigInt::from_bytes_be(Sign::Plus, &num),
+        }])
+        .call()
         .unwrap();
+
     assert_eq!(
         returns,
         BorshToken::Uint {
@@ -296,21 +320,21 @@ contract c {
     );
 
     let returns = vm
-        .function(
-            "divide",
-            &[
-                BorshToken::Uint {
-                    width: 256,
-                    value: BigInt::from(4u8),
-                },
-                BorshToken::Uint {
-                    width: 256,
-                    value: BigInt::from(3u8),
-                },
-            ],
-        )
+        .function("divide")
+        .arguments(&[
+            BorshToken::Uint {
+                width: 256,
+                value: BigInt::from(4u8),
+            },
+            BorshToken::Uint {
+                width: 256,
+                value: BigInt::from(3u8),
+            },
+        ])
+        .call()
         .unwrap()
         .unwrap_tuple();
+
     assert_eq!(
         returns,
         vec![
@@ -326,21 +350,21 @@ contract c {
     );
 
     let returns = vm
-        .function(
-            "divide",
-            &[
-                BorshToken::Uint {
-                    width: 256,
-                    value: BigInt::from(4u8),
-                },
-                BorshToken::Uint {
-                    width: 256,
-                    value: BigInt::zero(),
-                },
-            ],
-        )
+        .function("divide")
+        .arguments(&[
+            BorshToken::Uint {
+                width: 256,
+                value: BigInt::from(4u8),
+            },
+            BorshToken::Uint {
+                width: 256,
+                value: BigInt::zero(),
+            },
+        ])
+        .call()
         .unwrap()
         .unwrap_tuple();
+
     assert_eq!(
         returns,
         vec![
@@ -356,25 +380,25 @@ contract c {
     );
 
     let returns = vm
-        .function(
-            "mods",
-            &[
-                BorshToken::Uint {
-                    width: 256,
-                    value: BigInt::from(4u8),
-                },
-                BorshToken::Uint {
-                    width: 256,
-                    value: BigInt::from(2u8),
-                },
-                BorshToken::Uint {
-                    width: 256,
-                    value: BigInt::from(3u8),
-                },
-            ],
-        )
+        .function("mods")
+        .arguments(&[
+            BorshToken::Uint {
+                width: 256,
+                value: BigInt::from(4u8),
+            },
+            BorshToken::Uint {
+                width: 256,
+                value: BigInt::from(2u8),
+            },
+            BorshToken::Uint {
+                width: 256,
+                value: BigInt::from(3u8),
+            },
+        ])
+        .call()
         .unwrap()
         .unwrap_tuple();
+
     assert_eq!(
         returns,
         vec![
@@ -390,25 +414,25 @@ contract c {
     );
 
     let returns = vm
-        .function(
-            "mods",
-            &[
-                BorshToken::Uint {
-                    width: 256,
-                    value: BigInt::from(4u8),
-                },
-                BorshToken::Uint {
-                    width: 256,
-                    value: BigInt::from(2u8),
-                },
-                BorshToken::Uint {
-                    width: 256,
-                    value: BigInt::zero(),
-                },
-            ],
-        )
+        .function("mods")
+        .arguments(&[
+            BorshToken::Uint {
+                width: 256,
+                value: BigInt::from(4u8),
+            },
+            BorshToken::Uint {
+                width: 256,
+                value: BigInt::from(2u8),
+            },
+            BorshToken::Uint {
+                width: 256,
+                value: BigInt::zero(),
+            },
+        ])
+        .call()
         .unwrap()
         .unwrap_tuple();
+
     assert_eq!(
         returns,
         vec![
@@ -448,20 +472,24 @@ fn external_function() {
         "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+
     let mut addr: Vec<u8> = vec![0; 32];
     addr[5] = 90;
     let returns = vm
-        .function(
-            "test",
-            &[
-                BorshToken::Uint {
-                    width: 256,
-                    value: BigInt::from_bytes_le(Sign::Plus, addr.as_slice()),
-                },
-                BorshToken::FixedBytes(vec![1, 2, 3, 4, 5, 6, 7, 8]),
-            ],
-        )
+        .function("test")
+        .arguments(&[
+            BorshToken::Uint {
+                width: 256,
+                value: BigInt::from_bytes_le(Sign::Plus, addr.as_slice()),
+            },
+            BorshToken::FixedBytes(vec![1, 2, 3, 4, 5, 6, 7, 8]),
+        ])
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
         .unwrap()
         .unwrap_tuple();
 
@@ -499,8 +527,17 @@ contract testing  {
 }"#,
     );
 
-    runtime.constructor(&[]);
-    let returns = runtime.function("test_address", &[]).unwrap();
+    let data_account = runtime.initialize_data_account();
+    runtime
+        .function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+
+    let returns = runtime
+        .function("test_address")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
     let addr = returns.into_bigint().unwrap();
     let mut b_vec = addr.to_bytes_be().1;
     // test_address() returns address as uint256. If the highest bits are 0, then addr.to_bytes_be().1
@@ -508,14 +545,18 @@ contract testing  {
     while b_vec.len() < 32 {
         b_vec.insert(0, 0);
     }
-    assert_eq!(&b_vec, runtime.stack[0].data.as_ref());
+    assert_eq!(&b_vec, data_account.as_ref());
 
     runtime
         .account_data
-        .get_mut(&runtime.stack[0].data)
+        .get_mut(&data_account)
         .unwrap()
         .lamports = 102;
-    let returns = runtime.function("test_balance", &[]).unwrap();
+    let returns = runtime
+        .function("test_balance")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
     assert_eq!(
         returns,
         BorshToken::Uint {
@@ -524,7 +565,12 @@ contract testing  {
         }
     );
 
-    let returns = runtime.function("test_selfbalance", &[]).unwrap();
+    let returns = runtime
+        .function("test_selfbalance")
+        .accounts(vec![("dataAccount", data_account)])
+        .call()
+        .unwrap();
+
     assert_eq!(
         returns,
         BorshToken::Uint {
@@ -554,9 +600,13 @@ fn addmod_mulmod() {
         "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
-    let returns = vm.function("testMod", &[]).unwrap().unwrap_tuple();
+    let returns = vm.function("testMod").call().unwrap().unwrap_tuple();
+
     assert_eq!(
         returns,
         vec![
@@ -632,16 +682,18 @@ contract Testing {
         "#,
     );
 
-    vm.constructor(&[]);
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
 
     let returns = vm
-        .function(
-            "switch_default",
-            &[BorshToken::Uint {
-                width: 256,
-                value: BigInt::one(),
-            }],
-        )
+        .function("switch_default")
+        .arguments(&[BorshToken::Uint {
+            width: 256,
+            value: BigInt::one(),
+        }])
+        .call()
         .unwrap();
     assert_eq!(
         returns,
@@ -652,13 +704,12 @@ contract Testing {
     );
 
     let returns = vm
-        .function(
-            "switch_default",
-            &[BorshToken::Uint {
-                width: 256,
-                value: BigInt::from(2u8),
-            }],
-        )
+        .function("switch_default")
+        .arguments(&[BorshToken::Uint {
+            width: 256,
+            value: BigInt::from(2u8),
+        }])
+        .call()
         .unwrap();
     assert_eq!(
         returns,
@@ -669,13 +720,12 @@ contract Testing {
     );
 
     let returns = vm
-        .function(
-            "switch_default",
-            &[BorshToken::Uint {
-                width: 256,
-                value: BigInt::from(6u8),
-            }],
-        )
+        .function("switch_default")
+        .arguments(&[BorshToken::Uint {
+            width: 256,
+            value: BigInt::from(6u8),
+        }])
+        .call()
         .unwrap();
     assert_eq!(
         returns,
@@ -686,13 +736,12 @@ contract Testing {
     );
 
     let returns = vm
-        .function(
-            "switch_no_default",
-            &[BorshToken::Uint {
-                width: 256,
-                value: BigInt::one(),
-            }],
-        )
+        .function("switch_no_default")
+        .arguments(&[BorshToken::Uint {
+            width: 256,
+            value: BigInt::one(),
+        }])
+        .call()
         .unwrap();
     assert_eq!(
         returns,
@@ -703,13 +752,12 @@ contract Testing {
     );
 
     let returns = vm
-        .function(
-            "switch_no_default",
-            &[BorshToken::Uint {
-                width: 256,
-                value: BigInt::from(2u8),
-            }],
-        )
+        .function("switch_no_default")
+        .arguments(&[BorshToken::Uint {
+            width: 256,
+            value: BigInt::from(2u8),
+        }])
+        .call()
         .unwrap();
     assert_eq!(
         returns,
@@ -720,13 +768,12 @@ contract Testing {
     );
 
     let returns = vm
-        .function(
-            "switch_no_default",
-            &[BorshToken::Uint {
-                width: 256,
-                value: BigInt::from(6u8),
-            }],
-        )
+        .function("switch_no_default")
+        .arguments(&[BorshToken::Uint {
+            width: 256,
+            value: BigInt::from(6u8),
+        }])
+        .call()
         .unwrap();
     assert_eq!(
         returns,
@@ -737,13 +784,12 @@ contract Testing {
     );
 
     let returns = vm
-        .function(
-            "switch_no_case",
-            &[BorshToken::Uint {
-                width: 256,
-                value: BigInt::from(3u8),
-            }],
-        )
+        .function("switch_no_case")
+        .arguments(&[BorshToken::Uint {
+            width: 256,
+            value: BigInt::from(3u8),
+        }])
+        .call()
         .unwrap();
     assert_eq!(
         returns,


### PR DESCRIPTION
As we start representing contracts by their program id (#1430), we bump into an incompatibility in our VM. The program id and the contract's data account are tightly coupled!

In order for us to decouple them from Solang as whole, we need to refactor the VM so that it accepts contracts without a data account.