### PR TITLE
Updates for Solidity 0.8.21

### DIFF
--- a/solang-parser/README.md
+++ b/solang-parser/README.md
@@ -3,7 +3,7 @@
 This crate is part of [Hyperledger Solang](https://solang.readthedocs.io/). It contains the
 parser for Solidity, including the dialects used by Solang for Solana and Polkadot.
 
-This parser is compatible with Ethereum Solidity v0.8.20.
+This parser is compatible with Ethereum Solidity v0.8.21.
 
 `solang-parser` is still `0.*.*`, so breaking changes [may occur at any time](https://semver.org/#spec-item-4). If you must depend on `solang-parser`, we recommend pinning to a specific version, i.e., `=0.y.z`.
 

--- a/solang-parser/src/pt.rs
+++ b/solang-parser/src/pt.rs
@@ -377,27 +377,38 @@ pub enum SourceUnitPart {
 #[cfg_attr(feature = "pt-serde", derive(Serialize, Deserialize))]
 pub enum Import {
     /// `import <0>;`
-    Plain(StringLiteral, Loc),
+    Plain(ImportPath, Loc),
 
     /// `import * as <1> from <0>;`
     ///
     /// or
     ///
     /// `import <0> as <1>;`
-    GlobalSymbol(StringLiteral, Identifier, Loc),
+    GlobalSymbol(ImportPath, Identifier, Loc),
 
     /// `import { <<1.0> [as <1.1>]>,* } from <0>;`
-    Rename(StringLiteral, Vec<(Identifier, Option<Identifier>)>, Loc),
+    Rename(ImportPath, Vec<(Identifier, Option<Identifier>)>, Loc),
+}
+
+/// An import statement.
+#[derive(Debug, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "pt-serde", derive(Serialize, Deserialize))]
+pub enum ImportPath {
+    /// "foo.sol"
+    Filename(StringLiteral),
+    /// std.stub (experimental Solidity feature)
+    Path(IdentifierPath),
 }
 
 impl Import {
     /// Returns the import string.
     #[inline]
-    pub const fn literal(&self) -> &StringLiteral {
+    pub const fn literal(&self) -> Option<&StringLiteral> {
         match self {
-            Self::Plain(literal, _)
-            | Self::GlobalSymbol(literal, _, _)
-            | Self::Rename(literal, _, _) => literal,
+            Self::Plain(ImportPath::Filename(literal), _)
+            | Self::GlobalSymbol(ImportPath::Filename(literal), _, _)
+            | Self::Rename(ImportPath::Filename(literal), _, _) => Some(literal),
+            _ => None,
         }
     }
 }

--- a/solang-parser/src/solidity.lalrpop
+++ b/solang-parser/src/solidity.lalrpop
@@ -24,10 +24,15 @@ SourceUnitPart: SourceUnitPart = {
     <l:@L> ";" <r:@R> => SourceUnitPart::StraySemicolon(Loc::File(file_no, l, r)),
 }
 
+ImportPath: ImportPath = {
+    StringLiteral => ImportPath::Filename(<>),
+    SolIdentifierPath => ImportPath::Path(<>),
+}
+
 ImportDirective: SourceUnitPart = {
-    <l:@L> "import" <s:StringLiteral> <r:@R> ";" => SourceUnitPart::ImportDirective(Import::Plain(s, Loc::File(file_no, l, r))),
-    <l:@L> "import" <s:StringLiteral> "as" <id:SolIdentifier> <r:@R> ";" => SourceUnitPart::ImportDirective(Import::GlobalSymbol(s, id, Loc::File(file_no, l, r))),
-    <l:@L> "import" "*" "as" <id:SolIdentifier> <from:SolIdentifier> <s:StringLiteral> <r:@R> ";" => {
+    <l:@L> "import" <s:ImportPath> <r:@R> ";" => SourceUnitPart::ImportDirective(Import::Plain(s, Loc::File(file_no, l, r))),
+    <l:@L> "import" <s:ImportPath> "as" <id:SolIdentifier> <r:@R> ";" => SourceUnitPart::ImportDirective(Import::GlobalSymbol(s, id, Loc::File(file_no, l, r))),
+    <l:@L> "import" "*" "as" <id:SolIdentifier> <from:SolIdentifier> <s:ImportPath> <r:@R> ";" => {
         if from.name != "from" {
             let error = ErrorRecovery {
                 error: ParseError::User {
@@ -39,7 +44,7 @@ ImportDirective: SourceUnitPart = {
         }
         SourceUnitPart::ImportDirective(Import::GlobalSymbol(s, id, Loc::File(file_no, l, r)))
     },
-    <l:@L> "import" "{" <rename:CommaOne<ImportRename>> "}" <from:SolIdentifier> <s:StringLiteral> <r:@R> ";" =>? {
+    <l:@L> "import" "{" <rename:CommaOne<ImportRename>> "}" <from:SolIdentifier> <s:ImportPath> <r:@R> ";" =>? {
         if from.name != "from" {
             let error = ErrorRecovery {
                 error: ParseError::User {

--- a/src/sema/mod.rs
+++ b/src/sema/mod.rs
@@ -215,10 +215,22 @@ fn resolve_import(
     resolver: &mut FileResolver,
     ns: &mut ast::Namespace,
 ) {
-    let filename = match import {
+    let path = match import {
         pt::Import::Plain(f, _)
         | pt::Import::GlobalSymbol(f, _, _)
         | pt::Import::Rename(f, _, _) => f,
+    };
+
+    let filename = match path {
+        pt::ImportPath::Filename(f) => f,
+        pt::ImportPath::Path(path) => {
+            ns.diagnostics.push(ast::Diagnostic::error(
+                path.loc,
+                "experimental import paths not supported".into(),
+            ));
+
+            return;
+        }
     };
 
     let os_filename = OsStr::new(&filename.string);
@@ -396,6 +408,11 @@ fn resolve_pragma(
         ns.diagnostics.push(ast::Diagnostic::debug(
             *loc,
             "pragma 'experimental' with value 'ABIEncoderV2' is ignored".to_string(),
+        ));
+    } else if name.name == "experimental" && value.string == "solidity" {
+        ns.diagnostics.push(ast::Diagnostic::error(
+            *loc,
+            "experimental solidity features are not supported".to_string(),
         ));
     } else if name.name == "abicoder" && value.string == "v2" {
         ns.diagnostics.push(ast::Diagnostic::debug(

--- a/tests/contract.rs
+++ b/tests/contract.rs
@@ -126,14 +126,14 @@ fn add_file(cache: &mut FileResolver, path: &Path, target: Target) -> io::Result
 
     for line in source.lines() {
         if line.starts_with("import") {
-            let start = line.find('"').unwrap();
-            let end = line.rfind('"').unwrap();
-            let file = &line[start + 1..end];
-            if file != "solana" {
-                let mut import_path = path.parent().unwrap().to_path_buf();
-                import_path.push(file);
-                println!("adding import {}", import_path.display());
-                add_file(cache, &import_path, target)?;
+            if let (Some(start), Some(end)) = (line.find('"'), line.rfind('"')) {
+                let file = &line[start + 1..end];
+                if file != "solana" {
+                    let mut import_path = path.parent().unwrap().to_path_buf();
+                    import_path.push(file);
+                    println!("adding import {}", import_path.display());
+                    add_file(cache, &import_path, target)?;
+                }
             }
         }
     }

--- a/tests/contract_testcases/evm/experimental.sol
+++ b/tests/contract_testcases/evm/experimental.sol
@@ -1,0 +1,11 @@
+pragma experimental solidity;
+
+import std.stub;
+import * as foo from a.b;
+import {a as b} from x;
+
+// ---- Expect: diagnostics ----
+// error: 1:1-29: experimental solidity features are not supported
+// error: 3:8-16: experimental import paths not supported
+// error: 4:22-25: experimental import paths not supported
+// error: 5:22-23: experimental import paths not supported

--- a/tests/evm.rs
+++ b/tests/evm.rs
@@ -245,7 +245,7 @@ fn ethereum_solidity_tests() {
         })
         .sum();
 
-    assert_eq!(errors, 1029);
+    assert_eq!(errors, 1038);
 }
 
 fn set_file_contents(source: &str, path: &Path) -> (FileResolver, Vec<String>) {


### PR DESCRIPTION
Solidity introduces an experimental feature:

	pragma experimental solidity;

	import std.stub;

Note it is not supported yet, but we've added it to the Solidity parser and formatter, and Solang now gives nice error messages when it encounters these.

Note that the evm test failures have gone up, but this is not a regression. There are simply more tests.