### PR TITLE
Fix incorrect deserialization

### DIFF
--- a/integration/solana/account_data.sol
+++ b/integration/solana/account_data.sol
@@ -1,0 +1,11 @@
+import '../../solana-library/spl_token.sol';
+
+contract AccountData {
+    function token_account(address addr) view public returns (SplToken.TokenAccountData) {
+        return SplToken.get_token_account_data(addr);
+    }
+
+    function mint_account(address addr) view public returns (SplToken.MintAccountData) {
+        return SplToken.get_mint_account_data(addr);
+    }
+}

--- a/integration/solana/account_data.spec.ts
+++ b/integration/solana/account_data.spec.ts
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: Apache-2.0
+
+
+import {loadContractAndCallConstructor, newConnectionAndPayer} from "./setup";
+import {Connection, Keypair, PublicKey} from "@solana/web3.js";
+import {
+    approveChecked,
+    AuthorityType,
+    createMint,
+    getAccount,
+    getOrCreateAssociatedTokenAccount, mintTo,
+    setAuthority
+} from "@solana/spl-token";
+import { publicKey, u64, bool } from '@solana/buffer-layout-utils';
+import { u32, u8, struct } from '@solana/buffer-layout';
+import expect from "expect";
+import {Program} from "@coral-xyz/anchor";
+import assert from "assert";
+import exp from "constants";
+
+describe('Deserialize account data', function () {
+    this.timeout(500000);
+
+    interface RawMint {
+        mintAuthorityOption: 1 | 0;
+        mintAuthority: PublicKey;
+        supply: bigint;
+        decimals: number;
+        isInitialized: boolean;
+        freezeAuthorityOption: 1 | 0;
+        freezeAuthority: PublicKey;
+    }
+
+    const MintLayout = struct<RawMint>([
+        u32('mintAuthorityOption'),
+        publicKey('mintAuthority'),
+        u64('supply'),
+        u8('decimals'),
+        bool('isInitialized'),
+        u32('freezeAuthorityOption'),
+        publicKey('freezeAuthority'),
+    ]);
+
+    let program: Program;
+    let storage: Keypair;
+    let connection: Connection;
+    let payer: Keypair;
+
+    before(async function (){
+        ({ program, storage } = await loadContractAndCallConstructor('AccountData'));
+        ([connection, payer] = newConnectionAndPayer()) ;
+    });
+
+    it('token account', async function check_token_account() {
+        const mint_authority = Keypair.generate();
+        const freeze_authority = Keypair.generate();
+
+        const mint = await createMint(
+            connection,
+            payer,
+            mint_authority.publicKey,
+            freeze_authority.publicKey,
+            0
+        );
+
+        const owner = Keypair.generate();
+
+        let token_account = await getOrCreateAssociatedTokenAccount(
+            connection,
+            payer,
+            mint,
+            owner.publicKey
+        );
+
+        let res = await program.methods.tokenAccount(token_account.address)
+            .accounts({dataAccount: storage.publicKey})
+            .remainingAccounts(
+                [
+                    {pubkey: token_account.address, isSigner: false, isWritable: false}
+                ]
+            )
+            .view();
+
+        expect(res.mintAccount).toEqual(token_account.mint);
+        expect(res.owner).toEqual(token_account.owner);
+        expect(res.balance.toString()).toEqual(token_account.amount.toString());
+        expect(res.delegatePresent).toEqual(token_account.delegate != null);
+        expect(res.delegate).toEqual(new PublicKey("11111111111111111111111111111111")); // 0
+        expect(res.state).toEqual({"initialized": {}});
+        expect(res.isNativePresent).toEqual(token_account.rentExemptReserve != null);
+        expect(res.isNative.toString()).toEqual("0");
+        expect(res.delegatedAmount.toString()).toEqual(token_account.delegatedAmount.toString());
+        expect(res.closeAuthorityPresent).toEqual(token_account.closeAuthority != null);
+        expect(res.closeAuthority).toEqual(new PublicKey("11111111111111111111111111111111")); // 0
+
+        const delegate_account = Keypair.generate();
+        // delegate tokens
+        await approveChecked(
+            connection,
+            payer,
+            mint,
+            token_account.address,
+            delegate_account.publicKey,
+            owner,
+            1,
+            0
+        );
+        token_account = await getAccount(connection, token_account.address);
+
+        res = await program.methods.tokenAccount(token_account.address)
+            .accounts({dataAccount: storage.publicKey})
+            .remainingAccounts(
+                [
+                    {pubkey: token_account.address, isSigner: false, isWritable: false}
+                ]
+            )
+            .view();
+
+        // The delegate account should be present now
+        expect(res.delegatePresent).toEqual(token_account.delegate !=  null);
+        expect(res.delegate).toEqual(token_account.delegate);
+
+        const close_authority = Keypair.generate();
+        // close authority
+        await setAuthority(
+            connection,
+            payer,
+            token_account.address,
+            owner,
+            AuthorityType.CloseAccount,
+            close_authority.publicKey
+        );
+        token_account = await getAccount(connection, token_account.address);
+
+        res = await program.methods.tokenAccount(token_account.address)
+            .accounts({dataAccount: storage.publicKey})
+            .remainingAccounts(
+                [
+                    {pubkey: token_account.address, isSigner: false, isWritable: false}
+                ]
+            )
+            .view();
+
+        // The close authority should be present
+        expect(res.closeAuthorityPresent).toEqual(token_account.closeAuthority != null);
+        expect(res.closeAuthority).toEqual(close_authority.publicKey);
+
+        const sol_mint = new PublicKey("So11111111111111111111111111111111111111112");
+        token_account = await getOrCreateAssociatedTokenAccount(
+            connection,
+            payer,
+            sol_mint,
+            owner.publicKey
+        );
+
+        res = await program.methods.tokenAccount(token_account.address)
+            .accounts({dataAccount: storage.publicKey})
+            .remainingAccounts(
+                [
+                    {pubkey: token_account.address, isSigner: false, isWritable: false}
+                ]
+            )
+            .view();
+
+        // Is native must be present
+        expect(res.isNativePresent).toEqual(token_account.isNative);
+        expect(res.isNativePresent).toEqual(token_account.rentExemptReserve != null);
+        expect(res.isNative.toString()).toEqual(token_account.rentExemptReserve!.toString());
+    });
+
+    it('mint account', async function mint_account() {
+        const mint_authority = Keypair.generate();
+        const freeze_authority = Keypair.generate();
+
+        const mint = await createMint(
+            connection,
+            payer,
+            mint_authority.publicKey,
+            freeze_authority.publicKey,
+            2
+        );
+
+        const owner = Keypair.generate();
+
+        const token_account = await getOrCreateAssociatedTokenAccount(
+            connection,
+            payer,
+            mint,
+            owner.publicKey
+        );
+
+        await mintTo(
+            connection,
+            payer,
+            mint,
+            token_account.address,
+            mint_authority,
+            5
+        );
+
+        let data = await connection.getAccountInfo(mint);
+        assert(data != null);
+        let decoded = MintLayout.decode(data.data);
+
+        let res = await program.methods.mintAccount(mint)
+            .accounts({dataAccount: storage.publicKey})
+            .remainingAccounts(
+                [
+                    {pubkey: mint, isWritable: false, isSigner: false}
+                ]
+            )
+            .view();
+
+        // Authorities are present
+        expect(res.authorityPresent).toEqual(decoded.mintAuthorityOption > 0);
+        expect(res.mintAuthority).toEqual(decoded.mintAuthority);
+        expect(res.supply.toString()).toEqual(decoded.supply.toString())
+        expect(res.decimals).toEqual(decoded.decimals);
+        expect(res.isInitialized).toEqual(decoded.isInitialized);
+        expect(res.freezeAuthorityPresent).toEqual(decoded.freezeAuthorityOption > 0);
+        expect(res.freezeAuthority).toEqual(decoded.freezeAuthority);
+
+        await setAuthority(
+            connection,
+            payer,
+            mint,
+            mint_authority,
+            AuthorityType.MintTokens,
+            null
+        );
+
+        await setAuthority(
+            connection,
+            payer,
+            mint,
+            freeze_authority,
+            AuthorityType.FreezeAccount,
+            null
+        );
+
+        data = await connection.getAccountInfo(mint);
+        assert(data != null);
+        decoded = MintLayout.decode(data.data);
+
+        res = await program.methods.mintAccount(mint)
+            .accounts({dataAccount: storage.publicKey})
+            .remainingAccounts(
+                [
+                    {pubkey: mint, isWritable: false, isSigner: false}
+                ]
+            )
+            .view();
+
+        // Authorities are not present
+        expect(res.authorityPresent).toEqual(decoded.mintAuthorityOption > 0);
+        expect(res.supply.toString()).toEqual(decoded.supply.toString())
+        expect(res.decimals).toEqual(decoded.decimals);
+        expect(res.isInitialized).toEqual(decoded.isInitialized);
+        expect(res.freezeAuthorityPresent).toEqual(decoded.freezeAuthorityOption > 0);
+    });
+});

--- a/solana-library/spl_token.sol
+++ b/solana-library/spl_token.sol
@@ -217,7 +217,7 @@ library SplToken {
 				is_native_present: ai.data.readUint32LE(109) > 0,
 				is_native: ai.data.readUint64LE(113),
 				delegated_amount: ai.data.readUint64LE(121),
-				close_authority_present: ai.data.readUint32LE(129) > 10,
+				close_authority_present: ai.data.readUint32LE(129) > 0,
 				close_authority: ai.data.readAddress(133)
 			}
 		);

--- a/tests/solana.rs
+++ b/tests/solana.rs
@@ -141,7 +141,7 @@ fn build_solidity(src: &str) -> VirtualMachine {
 }
 
 fn build_solidity_with_cache(cache: FileResolver) -> VirtualMachine {
-    VirtualMachine::new_with_cache(cache).build()
+    VirtualMachineBuilder::new_with_cache(cache).build()
 }
 
 pub(crate) struct VirtualMachineBuilder {
@@ -153,17 +153,11 @@ impl VirtualMachineBuilder {
     pub(crate) fn new(src: &str) -> Self {
         let mut cache = FileResolver::default();
         cache.set_file_contents("test.sol", src.to_string());
-        Self {
-            cache,
-            opts: None
-        }
+        Self { cache, opts: None }
     }
 
     pub(crate) fn new_with_cache(cache: FileResolver) -> Self {
-        Self {
-            cache,
-            opts: None,
-        }
+        Self { cache, opts: None }
     }
 
     pub(crate) fn opts(mut self, opts: Options) -> Self {
@@ -172,7 +166,6 @@ impl VirtualMachineBuilder {
     }
 
     pub(crate) fn build(mut self) -> VirtualMachine {
-
         let (res, ns) = compile(
             OsStr::new("test.sol"),
             &mut self.cache,

--- a/tests/solana_tests/metas.rs
+++ b/tests/solana_tests/metas.rs
@@ -74,7 +74,7 @@ fn use_authority() {
 
 #[test]
 fn token_account() {
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
     cache.set_file_contents(
         "spl_token.sol",
         include_str!("../../solana-library/spl_token.sol").to_string(),
@@ -232,7 +232,7 @@ contract Foo {
 
 #[test]
 fn mint_account() {
-    let mut cache = FileResolver::new();
+    let mut cache = FileResolver::default();
     cache.set_file_contents(
         "spl_token.sol",
         include_str!("../../solana-library/spl_token.sol").to_string(),

--- a/tests/solana_tests/metas.rs
+++ b/tests/solana_tests/metas.rs
@@ -1,6 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{account_new, build_solidity, AccountMeta, AccountState, BorshToken, Pubkey};
+use crate::{
+    account_new, build_solidity, build_solidity_with_cache, AccountMeta, AccountState, BorshToken,
+    Pubkey,
+};
+use borsh::BorshSerialize;
+use num_bigint::BigInt;
+use solang::file_resolver::FileResolver;
 
 #[test]
 fn use_authority() {
@@ -63,5 +69,291 @@ fn use_authority() {
             width: 64,
             value: 1.into()
         }
+    );
+}
+
+#[test]
+fn token_account() {
+    let mut cache = FileResolver::new();
+    cache.set_file_contents(
+        "spl_token.sol",
+        include_str!("../../solana-library/spl_token.sol").to_string(),
+    );
+    let src = r#"
+    import './spl_token.sol';
+
+contract Foo {
+    function token_account(address add) public returns (SplToken.TokenAccountData) {
+        return SplToken.get_token_account_data(add);
+    }
+}
+    "#;
+    cache.set_file_contents("test.sol", src.to_string());
+
+    let mut vm = build_solidity_with_cache(cache);
+
+    #[derive(BorshSerialize)]
+    struct TokenAccount {
+        mint_account: [u8; 32],
+        owner: [u8; 32],
+        balance: u64,
+        delegate_present: u32,
+        delegate: [u8; 32],
+        state: u8,
+        is_native_present: u32,
+        is_native: u64,
+        delegated_amount: u64,
+        close_authority_present: u32,
+        close_authority: [u8; 32],
+    }
+
+    let mut data = TokenAccount {
+        mint_account: account_new(),
+        owner: account_new(),
+        balance: 234,
+        delegate_present: 0,
+        delegate: account_new(),
+        state: 1,
+        is_native_present: 0,
+        is_native: 234,
+        delegated_amount: 1346,
+        close_authority_present: 0,
+        close_authority: account_new(),
+    };
+
+    let encoded = data.try_to_vec().unwrap();
+
+    let account = account_new();
+    vm.account_data.insert(
+        account,
+        AccountState {
+            owner: None,
+            lamports: 0,
+            data: encoded,
+        },
+    );
+
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+
+    let res = vm
+        .function("token_account")
+        .arguments(&[BorshToken::Address(account)])
+        .accounts(vec![("dataAccount", data_account)])
+        .remaining_accounts(&[AccountMeta {
+            pubkey: Pubkey(account),
+            is_signer: false,
+            is_writable: false,
+        }])
+        .call()
+        .unwrap()
+        .unwrap_tuple();
+
+    assert_eq!(
+        res,
+        vec![
+            BorshToken::Address(data.mint_account),
+            BorshToken::Address(data.owner),
+            BorshToken::Uint {
+                width: 64,
+                value: BigInt::from(data.balance)
+            },
+            BorshToken::Bool(data.delegate_present > 0),
+            BorshToken::Address(data.delegate),
+            BorshToken::Uint {
+                width: 8,
+                value: BigInt::from(data.state)
+            },
+            BorshToken::Bool(data.is_native_present > 0),
+            BorshToken::Uint {
+                width: 64,
+                value: BigInt::from(data.is_native)
+            },
+            BorshToken::Uint {
+                width: 64,
+                value: BigInt::from(data.delegated_amount)
+            },
+            BorshToken::Bool(data.close_authority_present > 0),
+            BorshToken::Address(data.close_authority)
+        ]
+    );
+
+    data.delegate_present = 1;
+    data.is_native_present = 1;
+    data.close_authority_present = 1;
+
+    let encoded = data.try_to_vec().unwrap();
+    vm.account_data.get_mut(&account).unwrap().data = encoded;
+
+    let res = vm
+        .function("token_account")
+        .arguments(&[BorshToken::Address(account)])
+        .accounts(vec![("dataAccount", data_account)])
+        .remaining_accounts(&[AccountMeta {
+            pubkey: Pubkey(account),
+            is_signer: false,
+            is_writable: false,
+        }])
+        .call()
+        .unwrap()
+        .unwrap_tuple();
+
+    assert_eq!(
+        res,
+        vec![
+            BorshToken::Address(data.mint_account),
+            BorshToken::Address(data.owner),
+            BorshToken::Uint {
+                width: 64,
+                value: BigInt::from(data.balance)
+            },
+            BorshToken::Bool(data.delegate_present > 0),
+            BorshToken::Address(data.delegate),
+            BorshToken::Uint {
+                width: 8,
+                value: BigInt::from(data.state)
+            },
+            BorshToken::Bool(data.is_native_present > 0),
+            BorshToken::Uint {
+                width: 64,
+                value: BigInt::from(data.is_native)
+            },
+            BorshToken::Uint {
+                width: 64,
+                value: BigInt::from(data.delegated_amount)
+            },
+            BorshToken::Bool(data.close_authority_present > 0),
+            BorshToken::Address(data.close_authority)
+        ]
+    );
+}
+
+#[test]
+fn mint_account() {
+    let mut cache = FileResolver::new();
+    cache.set_file_contents(
+        "spl_token.sol",
+        include_str!("../../solana-library/spl_token.sol").to_string(),
+    );
+    let src = r#"
+    import './spl_token.sol';
+
+contract Foo {
+    function mint_account(address add) public returns (SplToken.MintAccountData) {
+        return SplToken.get_mint_account_data(add);
+    }
+}
+    "#;
+    cache.set_file_contents("test.sol", src.to_string());
+
+    let mut vm = build_solidity_with_cache(cache);
+
+    #[derive(BorshSerialize)]
+    struct MintAccountData {
+        authority_present: u32,
+        mint_authority: [u8; 32],
+        supply: u64,
+        decimals: u8,
+        is_initialized: bool,
+        freeze_authority_present: u32,
+        freeze_authority: [u8; 32],
+    }
+
+    let mut data = MintAccountData {
+        authority_present: 0,
+        mint_authority: account_new(),
+        supply: 450,
+        decimals: 4,
+        is_initialized: false,
+        freeze_authority_present: 0,
+        freeze_authority: account_new(),
+    };
+
+    let encoded = data.try_to_vec().unwrap();
+    let account = account_new();
+    vm.account_data.insert(
+        account,
+        AccountState {
+            owner: None,
+            lamports: 0,
+            data: encoded,
+        },
+    );
+
+    let data_account = vm.initialize_data_account();
+    vm.function("new")
+        .accounts(vec![("dataAccount", data_account)])
+        .call();
+
+    let res = vm
+        .function("mint_account")
+        .accounts(vec![("dataAccount", data_account)])
+        .arguments(&[BorshToken::Address(account)])
+        .remaining_accounts(&[AccountMeta {
+            pubkey: Pubkey(account),
+            is_writable: false,
+            is_signer: false,
+        }])
+        .call()
+        .unwrap()
+        .unwrap_tuple();
+
+    assert_eq!(
+        res,
+        vec![
+            BorshToken::Bool(data.authority_present > 0),
+            BorshToken::Address(data.mint_authority),
+            BorshToken::Uint {
+                width: 64,
+                value: BigInt::from(data.supply)
+            },
+            BorshToken::Uint {
+                width: 8,
+                value: BigInt::from(data.decimals)
+            },
+            BorshToken::Bool(data.is_initialized),
+            BorshToken::Bool(data.freeze_authority_present > 0),
+            BorshToken::Address(data.freeze_authority)
+        ]
+    );
+
+    data.authority_present = 1;
+    data.is_initialized = true;
+    data.freeze_authority_present = 1;
+    let encoded = data.try_to_vec().unwrap();
+    vm.account_data.get_mut(&account).unwrap().data = encoded;
+
+    let res = vm
+        .function("mint_account")
+        .accounts(vec![("dataAccount", data_account)])
+        .arguments(&[BorshToken::Address(account)])
+        .remaining_accounts(&[AccountMeta {
+            pubkey: Pubkey(account),
+            is_writable: false,
+            is_signer: false,
+        }])
+        .call()
+        .unwrap()
+        .unwrap_tuple();
+
+    assert_eq!(
+        res,
+        vec![
+            BorshToken::Bool(data.authority_present > 0),
+            BorshToken::Address(data.mint_authority),
+            BorshToken::Uint {
+                width: 64,
+                value: BigInt::from(data.supply)
+            },
+            BorshToken::Uint {
+                width: 8,
+                value: BigInt::from(data.decimals)
+            },
+            BorshToken::Bool(data.is_initialized),
+            BorshToken::Bool(data.freeze_authority_present > 0),
+            BorshToken::Address(data.freeze_authority)
+        ]
     );
 }


### PR DESCRIPTION
The deserialization of `struct TokenAccountData` in the Solana library is incorrect. This PR fixes the issue and tests the deserialization of both `struct TokenAccountData` and `struct MintAccountData`.