### PR TITLE
Use Ubuntu 20.04 rather than 22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   linux-x86-64:
     name: Linux x86-64
     runs-on: solang-ubuntu-latest
-    container: ghcr.io/hyperledger/solang-llvm:ci-4
+    container: ghcr.io/hyperledger/solang-llvm:ci-5
     steps:
     - name: Checkout sources
       uses: actions/checkout@v3.1.0
@@ -33,7 +33,7 @@ jobs:
     name: Linux arm64
     runs-on: linux-arm64
     if: ${{ github.repository_owner == 'hyperledger' }}
-    container: ghcr.io/hyperledger/solang-llvm:ci-4
+    container: ghcr.io/hyperledger/solang-llvm:ci-5
     steps:
     - name: Checkout sources
       uses: actions/checkout@v3.1.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
   lints:
     name: Lints
     runs-on: solang-ubuntu-latest
-    container: ghcr.io/hyperledger/solang-llvm:ci-4
+    container: ghcr.io/hyperledger/solang-llvm:ci-5
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -71,7 +71,7 @@ jobs:
   linux-x86-64:
     name: Linux x86-64
     runs-on: solang-ubuntu-latest
-    container: ghcr.io/hyperledger/solang-llvm:ci-4
+    container: ghcr.io/hyperledger/solang-llvm:ci-5
     steps:
     - name: Checkout sources
       uses: actions/checkout@v3
@@ -93,7 +93,7 @@ jobs:
     name: Linux Arm
     runs-on: linux-arm64
     if: ${{ github.repository_owner == 'hyperledger' }}
-    container: ghcr.io/hyperledger/solang-llvm:ci-4
+    container: ghcr.io/hyperledger/solang-llvm:ci-5
     steps:
     - name: Checkout sources
       uses: actions/checkout@v3
@@ -231,7 +231,7 @@ jobs:
   anchor:
     name: Anchor Integration test
     runs-on: solang-ubuntu-latest
-    container: ghcr.io/hyperledger/solang-llvm:ci-4
+    container: ghcr.io/hyperledger/solang-llvm:ci-5
     needs: linux-x86-64
     steps:
     - name: Checkout sources
@@ -278,7 +278,7 @@ jobs:
   solana:
     name: Solana Integration test
     runs-on: solang-ubuntu-latest
-    container: ghcr.io/hyperledger/solang-llvm:ci-4
+    container: ghcr.io/hyperledger/solang-llvm:ci-5
     needs: linux-x86-64
     steps:
     - name: Checkout sources

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/hyperledger/solang-llvm:ci-4 as builder
+FROM ghcr.io/hyperledger/solang-llvm:ci-5 as builder
 
 COPY . src
 WORKDIR /src/stdlib/
@@ -9,7 +9,7 @@ RUN rustup default 1.68.0
 WORKDIR /src
 RUN cargo build --release
 
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 COPY --from=builder /src/target/release/solang /usr/bin/solang
 
 LABEL org.opencontainers.image.title="Solang Solidity Compiler" \


### PR DESCRIPTION
We've had a few users reporting that solang does not work in their environment; usually this is ubuntu 20.04 WSL.