### PR TITLE
Avoid overflow in transfer

### DIFF
--- a/docs/language/managing_values.rst
+++ b/docs/language/managing_values.rst
@@ -95,8 +95,7 @@ Here is an example:
     function to be called, use ``address.call{value: 100}("")`` instead.
 
 .. note::
-    On Solana, these functions manage native token assets from a contract's data account when
-    invoked from a contract variable. Normally, funds are not stored in a contract's account, as
-    one can set a separate payer account to pay for all the transactions. In this case, it is more
-    straightforward to use the :ref:`system instruction library <system_instruction_library>` to transfer
-    native tokens between accounts.
+    On Solana, ``send()`` and ``transfer()`` can only transfer native tokens between accounts owned
+    by the contract's program account, since only the account owner can modify its balance.
+    Use the :ref:`system instruction library <system_instruction_library>` to transfer
+    native tokens between accounts owned by Solana's system program.

--- a/stdlib/solana.c
+++ b/stdlib/solana.c
@@ -154,17 +154,23 @@ void sol_transfer(uint8_t *to_address, uint64_t lamports, SolParameters *params)
     uint64_t *from = params->ka[0].lamports;
     uint64_t *to = sol_account_lamport(to_address, params);
 
-    if (__builtin_sub_overflow(*from, lamports, from))
+    uint64_t from_balance;
+    uint64_t to_balance;
+
+    if (__builtin_sub_overflow(*from, lamports, &from_balance))
     {
         sol_log("sender does not have enough balance");
         sol_panic();
     }
 
-    if (__builtin_add_overflow(*to, lamports, to))
+    if (__builtin_add_overflow(*to, lamports, &to_balance))
     {
         sol_log("recipient lamports overflows");
         sol_panic();
     }
+
+    *from = from_balance;
+    *to = to_balance;
 }
 
 bool sol_try_transfer(uint8_t *to_address, uint64_t lamports, SolParameters *params)


### PR DESCRIPTION
`address.transfer` and `address.send` utilize `void sol_transfer` from `solana.c` under the hood, which was saving the overflowed valued to the account balance. This PR fixes such an issue.