### PR TITLE
Use named constants instead of magic numbers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,6 @@ wasm-opt = { version = "0.112.0", optional = true }
 contract-build = { version = "3.0.1", optional = true }
 primitive-types = { version = "0.12", features = ["codec"] }
 normalize-path = "0.2.1"
-solana-program = "1.16.8"
 
 [dev-dependencies]
 num-derive = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ wasm-opt = { version = "0.112.0", optional = true }
 contract-build = { version = "3.0.1", optional = true }
 primitive-types = { version = "0.12", features = ["codec"] }
 normalize-path = "0.2.1"
+solana-program = "1.16.8"
 
 [dev-dependencies]
 num-derive = "0.4"


### PR DESCRIPTION
Using magic numbers degrades code readability.