### PR TITLE
Produce error diagnostics if overflow occurs in constant folding

### DIFF
--- a/src/codegen/cfg.rs
+++ b/src/codegen/cfg.rs
@@ -572,7 +572,7 @@ impl ControlFlowGraph {
                 Expression::Subtract {
                     loc,
                     ty: Type::Uint(32),
-                    overflowing: false,
+                    overflowing: true,
                     left: Box::new(Expression::Variable {
                         loc,
                         ty: Type::Uint(32),
@@ -588,7 +588,7 @@ impl ControlFlowGraph {
                 Expression::Add {
                     loc,
                     ty: Type::Uint(32),
-                    overflowing: false,
+                    overflowing: true,
                     left: Box::new(Expression::Variable {
                         loc,
                         ty: Type::Uint(32),

--- a/src/codegen/cfg.rs
+++ b/src/codegen/cfg.rs
@@ -1557,9 +1557,11 @@ pub fn optimize_and_check_cfg(
             return;
         }
     }
-    if opt.constant_folding {
-        constant_folding::constant_folding(cfg, ns);
-    }
+
+    // constant folding generates diagnostics, so always run it. This means that the diagnostics
+    // do not depend which passes are enabled. If the constant_folding is not enabled, run it
+    // dry mode.
+    constant_folding::constant_folding(cfg, !opt.constant_folding, ns);
     if opt.vector_to_slice {
         vector_to_slice::vector_to_slice(cfg, ns);
     }

--- a/src/codegen/constant_folding.rs
+++ b/src/codegen/constant_folding.rs
@@ -681,7 +681,7 @@ fn bigint_to_expression(
                 bs.resize(*bits as usize / 8, 0xff);
 
                 BigInt::from_bytes_le(Sign::Plus, &bs)
-            } else if value.bits() > *bits as u64 || value.sign() == Sign::Minus {
+            } else if value.bits() > *bits as u64 {
                 if !overflowing {
                     ns.diagnostics.push(Diagnostic::error(
                         *loc,
@@ -691,11 +691,6 @@ fn bigint_to_expression(
                         ),
                     ));
                 }
-                let (_, mut bs) = value.to_bytes_le();
-                bs.truncate(*bits as usize / 8);
-
-                BigInt::from_bytes_le(Sign::Plus, &bs)
-            } else if value.bits() > *bits as u64 {
                 let (_, mut bs) = value.to_bytes_le();
                 bs.truncate(*bits as usize / 8);
 

--- a/src/codegen/constant_folding.rs
+++ b/src/codegen/constant_folding.rs
@@ -867,7 +867,7 @@ fn bitwise_and(
     ) = (&left.0, &right.0)
     {
         (
-            bigint_to_expression(loc, ty, left.bitand(right), false, ns),
+            bigint_to_expression(loc, ty, left.bitand(right), true, ns),
             true,
         )
     } else {
@@ -901,7 +901,7 @@ fn bitwise_or(
     ) = (&left.0, &right.0)
     {
         (
-            bigint_to_expression(loc, ty, left.bitor(right), false, ns),
+            bigint_to_expression(loc, ty, left.bitor(right), true, ns),
             true,
         )
     } else {
@@ -935,7 +935,7 @@ fn bitwise_xor(
     ) = (&left.0, &right.0)
     {
         (
-            bigint_to_expression(loc, ty, left.bitxor(right), false, ns),
+            bigint_to_expression(loc, ty, left.bitxor(right), true, ns),
             true,
         )
     } else {
@@ -977,7 +977,7 @@ fn shift_left(
             let right: u64 = right.to_u64().unwrap();
 
             return (
-                bigint_to_expression(loc, ty, left.shl(&right), false, ns),
+                bigint_to_expression(loc, ty, left.shl(&right), true, ns),
                 true,
             );
         }
@@ -1020,7 +1020,7 @@ fn shift_right(
             let right: u64 = right.to_u64().unwrap();
 
             return (
-                bigint_to_expression(loc, ty, left.shr(&right), false, ns),
+                bigint_to_expression(loc, ty, left.shr(&right), true, ns),
                 true,
             );
         }
@@ -1242,7 +1242,7 @@ fn trunc(
 ) -> (Expression, bool) {
     let expr = expression(expr, vars, cfg, ns);
     if let Expression::NumberLiteral { value, .. } = expr.0 {
-        (bigint_to_expression(loc, ty, value, false, ns), true)
+        (bigint_to_expression(loc, ty, value, true, ns), true)
     } else {
         (
             Expression::Trunc {
@@ -1265,7 +1265,7 @@ fn bitwise_not(
 ) -> (Expression, bool) {
     let expr = expression(expr, vars, cfg, ns);
     if let Expression::NumberLiteral { value, .. } = expr.0 {
-        (bigint_to_expression(loc, ty, !value, false, ns), true)
+        (bigint_to_expression(loc, ty, !value, true, ns), true)
     } else {
         (
             Expression::BitwiseNot {

--- a/src/codegen/expression.rs
+++ b/src/codegen/expression.rs
@@ -331,9 +331,15 @@ pub fn expression(
             ty: ty.clone(),
             expr: Box::new(expression(expr, cfg, contract_no, func, ns, vartab, opt)),
         },
-        ast::Expression::Negate { loc, ty, expr } => Expression::Negate {
+        ast::Expression::Negate {
+            loc,
+            ty,
+            unchecked,
+            expr,
+        } => Expression::Negate {
             loc: *loc,
             ty: ty.clone(),
+            overflowing: *unchecked,
             expr: Box::new(expression(expr, cfg, contract_no, func, ns, vartab, opt)),
         },
         ast::Expression::StructLiteral { loc, ty, values } => Expression::StructLiteral {

--- a/src/codegen/expression.rs
+++ b/src/codegen/expression.rs
@@ -23,7 +23,7 @@ use crate::sema::{
         StructType, Type,
     },
     diagnostics::Diagnostics,
-    eval::{eval_const_number, eval_const_rational},
+    eval::{eval_const_number, eval_const_rational, eval_constants_in_expression},
     expression::integers::bigint_to_expression,
     expression::ResolveTo,
 };
@@ -43,7 +43,18 @@ pub fn expression(
     vartab: &mut Vartable,
     opt: &Options,
 ) -> Expression {
-    match expr {
+    let constant_expr;
+
+    let expr =
+        if let (Some(expr), _) = eval_constants_in_expression(expr, &mut Diagnostics::default()) {
+            constant_expr = expr;
+
+            &constant_expr
+        } else {
+            expr
+        };
+
+    match &expr {
         ast::Expression::StorageVariable {
             loc,
             contract_no: var_contract_no,

--- a/src/codegen/expression.rs
+++ b/src/codegen/expression.rs
@@ -43,16 +43,8 @@ pub fn expression(
     vartab: &mut Vartable,
     opt: &Options,
 ) -> Expression {
-    let constant_expr;
-
-    let expr =
-        if let (Some(expr), _) = eval_constants_in_expression(expr, &mut Diagnostics::default()) {
-            constant_expr = expr;
-
-            &constant_expr
-        } else {
-            expr
-        };
+    let evaluated = eval_constants_in_expression(expr, &mut Diagnostics::default());
+    let expr = evaluated.0.as_ref().unwrap_or(expr);
 
     match &expr {
         ast::Expression::StorageVariable {

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -620,6 +620,7 @@ pub enum Expression {
     Negate {
         loc: pt::Loc,
         ty: Type,
+        overflowing: bool,
         expr: Box<Expression>,
     },
     Undefined {
@@ -1561,9 +1562,15 @@ impl Expression {
                     ty: ty.clone(),
                     expr: Box::new(filter(expr, ctx)),
                 },
-                Expression::Negate { loc, ty, expr } => Expression::Negate {
+                Expression::Negate {
+                    loc,
+                    ty,
+                    overflowing,
+                    expr,
+                } => Expression::Negate {
                     loc: *loc,
                     ty: ty.clone(),
+                    overflowing: *overflowing,
                     expr: Box::new(filter(expr, ctx)),
                 },
                 Expression::Subscript {

--- a/src/codegen/subexpression_elimination/expression.rs
+++ b/src/codegen/subexpression_elimination/expression.rs
@@ -291,10 +291,14 @@ impl Expression {
             },
 
             Expression::Negate {
-                loc, ty: expr_type, ..
+                loc,
+                ty: expr_type,
+                overflowing,
+                ..
             } => Expression::Negate {
                 loc: *loc,
                 ty: expr_type.clone(),
+                overflowing: *overflowing,
                 expr: Box::new(operand.clone()),
             },
 

--- a/src/codegen/subexpression_elimination/operator.rs
+++ b/src/codegen/subexpression_elimination/operator.rs
@@ -46,6 +46,7 @@ pub enum Operator {
     Cast(Type),
     BytesCast,
     Negate,
+    OverflowingNegate,
     BitwiseNot,
 }
 
@@ -97,7 +98,13 @@ impl Expression {
             Expression::Trunc { ty, .. } => Operator::Trunc(ty.clone()),
             Expression::Cast { ty, .. } => Operator::Cast(ty.clone()),
             Expression::BytesCast { .. } => Operator::BytesCast,
-            Expression::Negate { .. } => Operator::Negate,
+            Expression::Negate { overflowing, .. } => {
+                if *overflowing {
+                    Operator::OverflowingNegate
+                } else {
+                    Operator::Negate
+                }
+            }
             Expression::More { signed: true, .. } => Operator::SignedMore,
             Expression::More { signed: false, .. } => Operator::UnsignedMore,
             Expression::Less { signed: true, .. } => Operator::SignedLess,

--- a/src/codegen/subexpression_elimination/tests.rs
+++ b/src/codegen/subexpression_elimination/tests.rs
@@ -231,6 +231,7 @@ fn not_tracked() {
     let minus = Expression::Negate {
         loc: Loc::Codegen,
         ty: Type::Int(32),
+        overflowing: true,
         expr: Box::new(load.clone()),
     };
     let exp = Expression::ShiftLeft {
@@ -326,6 +327,8 @@ fn complex_expression() {
     let unary = Expression::Negate {
         loc: Loc::Codegen,
         ty: Type::Int(44),
+        overflowing: true,
+
         expr: Box::new(modu.clone()),
     };
 
@@ -517,6 +520,8 @@ fn kill() {
     let unary = Expression::Negate {
         loc: Loc::Codegen,
         ty: Type::Int(44),
+        overflowing: true,
+
         expr: Box::new(modu.clone()),
     };
 
@@ -626,6 +631,8 @@ fn clone() {
     let unary = Expression::Negate {
         loc: Loc::Codegen,
         ty: Type::Int(44),
+        overflowing: true,
+
         expr: Box::new(modu.clone()),
     };
 
@@ -733,6 +740,7 @@ fn intersect() {
     let unary = Expression::Negate {
         loc: Loc::Codegen,
         ty: Type::Int(44),
+        overflowing: true,
         expr: Box::new(modu.clone()),
     };
 

--- a/src/codegen/subexpression_elimination/tests.rs
+++ b/src/codegen/subexpression_elimination/tests.rs
@@ -328,7 +328,6 @@ fn complex_expression() {
         loc: Loc::Codegen,
         ty: Type::Int(44),
         overflowing: true,
-
         expr: Box::new(modu.clone()),
     };
 
@@ -521,7 +520,6 @@ fn kill() {
         loc: Loc::Codegen,
         ty: Type::Int(44),
         overflowing: true,
-
         expr: Box::new(modu.clone()),
     };
 
@@ -632,7 +630,6 @@ fn clone() {
         loc: Loc::Codegen,
         ty: Type::Int(44),
         overflowing: true,
-
         expr: Box::new(modu.clone()),
     };
 

--- a/src/sema/ast.rs
+++ b/src/sema/ast.rs
@@ -1071,6 +1071,8 @@ pub enum Expression {
     Negate {
         loc: pt::Loc,
         ty: Type,
+        /// Do not check for overflow, i.e. in `unchecked {}` block
+        unchecked: bool,
         expr: Box<Expression>,
     },
 

--- a/src/sema/dotgraphviz.rs
+++ b/src/sema/dotgraphviz.rs
@@ -999,15 +999,22 @@ impl Dot {
 
                 self.add_expression(expr, func, ns, node, String::from("expr"));
             }
-            Expression::Negate { loc, ty, expr } => {
+            Expression::Negate {
+                loc,
+                ty,
+                unchecked,
+                expr,
+            } => {
+                let mut labels = vec![
+                    format!("unary minus {}", ty.to_string(ns)),
+                    ns.loc_to_string(PathDisplay::FullPath, loc),
+                ];
+                if *unchecked {
+                    labels.push(String::from("unchecked"));
+                }
+
                 let node = self.add_node(
-                    Node::new(
-                        "unary_minus",
-                        vec![
-                            format!("unary minus {}", ty.to_string(ns)),
-                            ns.loc_to_string(PathDisplay::FullPath, loc),
-                        ],
-                    ),
+                    Node::new("unary_minus", labels),
                     Some(parent),
                     Some(parent_rel),
                 );

--- a/src/sema/eval.rs
+++ b/src/sema/eval.rs
@@ -710,7 +710,7 @@ pub(crate) fn eval_constants_in_expression(
     }
 }
 
-/// Function that takes a BigInt and an expected type. If the number of bits in the type required to represent the BigInt is not suffiecient, it will return a diagnostic.
+/// Function that takes a BigInt and an expected type. If the number of bits in the type required to represent the BigInt is not sufficient, it will return a diagnostic.
 pub(crate) fn overflow_diagnostic(result: &BigInt, ty: &Type, loc: &Loc) -> Option<Diagnostic> {
     if result.bits() > 1024 {
         // Do not try to print large values. For example:

--- a/src/sema/expression/resolve_expression.rs
+++ b/src/sema/expression/resolve_expression.rs
@@ -550,6 +550,7 @@ fn negate(
                 Ok(Expression::Negate {
                     loc: *loc,
                     ty: expr_type,
+                    unchecked: context.unchecked,
                     expr: Box::new(expr),
                 })
             }

--- a/src/sema/function_annotation.rs
+++ b/src/sema/function_annotation.rs
@@ -3,7 +3,7 @@
 use super::{
     ast::{ConstructorAnnotation, Diagnostic, Expression, Function, Namespace, Type},
     diagnostics::Diagnostics,
-    eval::overflow_check,
+    eval::overflow_diagnostic,
     expression::literals::{hex_number_literal, unit_literal},
     expression::{ExprContext, ResolveTo},
     Symtable,
@@ -140,7 +140,7 @@ fn function_selector(
                 };
 
                 if let Ok(Expression::NumberLiteral { loc, value, .. }) = &expr {
-                    if let Some(diagnostic) = overflow_check(value, &uint8, loc) {
+                    if let Some(diagnostic) = overflow_diagnostic(value, &uint8, loc) {
                         diagnostics.push(diagnostic);
                     } else {
                         selector.push(value.to_u8().unwrap());

--- a/src/sema/tests/mod.rs
+++ b/src/sema/tests/mod.rs
@@ -320,19 +320,7 @@ fn constant_overflow_checks() {
 
     assert_eq!(errors.len(), 31);
 
-    assert_eq!(
-        warnings[0].message,
-        "left shift by 7 may overflow the final result"
-    );
-    assert_eq!(
-        warnings[1].message,
-        "left shift by 7 may overflow the final result"
-    );
-    assert_eq!(
-        warnings[2].message,
-        "left shift by 9 may overflow the final result"
-    );
-    assert_eq!(warnings.len(), 3);
+    assert_eq!(warnings.len(), 0);
 }
 
 #[test]

--- a/tests/codegen_testcases/solidity/array_boundary_opt.sol
+++ b/tests/codegen_testcases/solidity/array_boundary_opt.sol
@@ -17,16 +17,16 @@ contract Array_bound_Test {
         // CHECK: ty:uint32 %array_length.temp.34 = uint32 20
         uint256[] d = new uint256[](20);
 
-        // CHECK: ty:uint32 %array_length.temp.32 = (%1.cse_temp + uint32 1)
+        // CHECK: ty:uint32 %array_length.temp.32 = (overflowing %1.cse_temp + uint32 1)
         a.push();
 
-        // CHECK: ty:uint32 %array_length.temp.33 = ((arg #2) - uint32 1)
+        // CHECK: ty:uint32 %array_length.temp.33 = (overflowing (arg #2) - uint32 1)
         c.pop();
 
         // CHECK: ty:uint32 %array_length.temp.34 = uint32 21
         d.push();
 
-        // CHECK: return (zext uint256 (((%array_length.temp.32 + (builtin ArrayLength ((arg #0)))) + ((arg #2) - uint32 1)) + uint32 21))
+        // CHECK: return (zext uint256 (((%array_length.temp.32 + (builtin ArrayLength ((arg #0)))) + (overflowing (arg #2) - uint32 1)) + uint32 21))
         return a.length + b.length + c.length + d.length;
     }
 

--- a/tests/codegen_testcases/solidity/modifier_opt.sol
+++ b/tests/codegen_testcases/solidity/modifier_opt.sol
@@ -11,7 +11,7 @@ contract Test {
         // CHECK: branchcond (uint128((builtin Value ())) != uint128 0),
         // NOT-CHECK: uint128 1 - uint128 1
 
-        // CHECK: branchcond (uint128((builtin Value ())) != uint128 -1),
+        // CHECK: branchcond (uint128((builtin Value ())) != uint128 340282366920938463463374607431768211455),
         // NOT-CHECK: uint128 2 ** uint128 127
     }
 
@@ -22,7 +22,7 @@ contract Test {
         require(msg.value != 1 - 1);
 
         // CHECK: block0: # entry
-        // CHECK: branchcond (uint128((builtin Value ())) != uint128 -1),
+        // CHECK: branchcond (uint128((builtin Value ())) != uint128 340282366920938463463374607431768211455),
         // NOT-CHECK: uint128 2 ** uint128 127,
 
         // CHECK: branchcond (uint128((builtin Value ())) != uint128 0),
@@ -34,7 +34,7 @@ contract Test {
         return 2 ** 256 - 1;
 
         // CHECK: block0: # entry
-        // CHECK: return uint256 -1
+        // CHECK: return uint256 115792089237316195423570985008687907853269984665640564039457584007913129639935
         // NOT-CHECK: (uint256 2 ** uint256 256) - uint256 1
     }
 }

--- a/tests/codegen_testcases/yul/binary_arithmetic_builtins.sol
+++ b/tests/codegen_testcases/yul/binary_arithmetic_builtins.sol
@@ -52,7 +52,7 @@ contract testing {
             // CHECK: ty:uint256 %t = (overflowing uint256 22193982385802470 + uint256(false))
             let t := add(q, r)
 
-            // CHECK: ty:uint256 %u = uint256 -1
+            // CHECK: ty:uint256 %u = uint256 115792089237316195423570985008687907853269984665640564039457584007913129639935
             let u := sub(false, true)
 
             // CHECK: ty:uint256 %v = uint256((overflowing true + false))

--- a/tests/contract_testcases/solana/expressions/overflow_constant_propagation.sol
+++ b/tests/contract_testcases/solana/expressions/overflow_constant_propagation.sol
@@ -25,6 +25,34 @@ contract foo {
         int16 c4 = -a4;
         print("c4: {}".format(c4));
     }
+
+    function test_unchecked() public pure {
+        unchecked {
+            uint32 x = 2147483648;
+            uint32 y = 2147483648;
+            uint32 z = x + y;
+            print("z: {}".format(z));
+
+            uint16 a1 = 256;
+            uint16 b1 = 257;
+            uint16 c1 = a1 * b1;
+            print("c1: {}".format(c1));
+
+            uint16 a2 = 10;
+            uint16 b2 = 5;
+            uint16 c2 = a2 ** b2;
+            print("c2: {}".format(c2));
+
+            uint16 a3 = 256;
+            uint16 b3 = 257;
+            uint16 c3 = a3 - b3;
+            print("c3: {}".format(c3));
+
+            int16 a4 = -0x8000;
+            int16 c4 = -a4;
+            print("c4: {}".format(c4));
+        }
+    }
 }
 // ---- Expect: diagnostics ----
 // error: 6:20-25: arithmetic overflow, 4294967296 does not fit into uint32

--- a/tests/contract_testcases/solana/expressions/overflow_constant_propagation.sol
+++ b/tests/contract_testcases/solana/expressions/overflow_constant_propagation.sol
@@ -1,0 +1,33 @@
+// Note: none of these errors will occur without --no-constant-folding
+contract foo {
+    function test() public pure {
+        uint32 x = 2147483648;
+        uint32 y = 2147483648;
+        uint32 z = x + y;
+        print("z: {}".format(z));
+
+        uint16 a1 = 256;
+        uint16 b1 = 257;
+        uint16 c1 = a1 * b1;
+        print("c1: {}".format(c1));
+
+        uint16 a2 = 10;
+        uint16 b2 = 5;
+        uint16 c2 = a2 ** b2;
+        print("c2: {}".format(c2));
+
+        uint16 a3 = 256;
+        uint16 b3 = 257;
+        uint16 c3 = a3 - b3;
+        print("c3: {}".format(c3));
+
+        int16 a4 = -0x8000;
+        int16 c4 = -a4;
+        print("c4: {}".format(c4));
+    }
+}
+// ---- Expect: diagnostics ----
+// error: 6:20-25: arithmetic overflow, 4294967296 does not fit into uint32
+// error: 11:21-28: arithmetic overflow, 65792 does not fit into uint16
+// error: 16:21-29: arithmetic overflow, 100000 does not fit into uint16
+// error: 21:21-28: arithmetic overflow, -1 does not fit into uint16

--- a/tests/contract_testcases/solana/expressions/overflow_constant_propagation.sol
+++ b/tests/contract_testcases/solana/expressions/overflow_constant_propagation.sol
@@ -53,10 +53,24 @@ contract foo {
             print("c4: {}".format(c4));
         }
     }
+
+    function test_big() public pure returns (uint256) {
+            uint256 a1 = 1 << 255;
+            uint64 b1 = 1 << 31;
+            uint256 c1 = a1**b1;
+            print("c1: {}".format(c1));
+
+            uint256 a2 = 1 << 255;
+            uint64 b2 = 1 << 3;
+            uint256 c2 = a2**b2;
+            print("c2: {}".format(c2));
+    }
 }
 // ---- Expect: diagnostics ----
-// error: 6:20-25: arithmetic overflow: 4294967296 does not fit into uint32
-// error: 11:21-28: arithmetic overflow: 65792 does not fit into uint16
-// error: 16:21-29: arithmetic overflow: 100000 does not fit into uint16
-// error: 21:21-28: arithmetic overflow: -1 does not fit into uint16
-// error: 25:20-23: arithmetic overflow: 32768 does not fit into int16
+// error: 6:20-25: value 4294967296 does not fit into type uint32.
+// error: 11:21-28: value 65792 does not fit into type uint16.
+// error: 16:21-29: value 100000 does not fit into type uint16.
+// error: 21:21-28: negative value -1 does not fit into type uint16. Cannot implicitly convert signed literal to unsigned type.
+// error: 25:20-23: value 32768 does not fit into type int16.
+// error: 60:26-32: power 2147483648 not possible
+// error: 65:26-32: value is too large to fit into type uint256

--- a/tests/contract_testcases/solana/expressions/overflow_constant_propagation.sol
+++ b/tests/contract_testcases/solana/expressions/overflow_constant_propagation.sol
@@ -55,8 +55,8 @@ contract foo {
     }
 }
 // ---- Expect: diagnostics ----
-// error: 6:20-25: arithmetic overflow, 4294967296 does not fit into uint32
-// error: 11:21-28: arithmetic overflow, 65792 does not fit into uint16
-// error: 16:21-29: arithmetic overflow, 100000 does not fit into uint16
-// error: 21:21-28: arithmetic overflow, -1 does not fit into uint16
-// error: 25:20-23: arithmetic overflow, 32768 does not fit into int16
+// error: 6:20-25: arithmetic overflow: 4294967296 does not fit into uint32
+// error: 11:21-28: arithmetic overflow: 65792 does not fit into uint16
+// error: 16:21-29: arithmetic overflow: 100000 does not fit into uint16
+// error: 21:21-28: arithmetic overflow: -1 does not fit into uint16
+// error: 25:20-23: arithmetic overflow: 32768 does not fit into int16

--- a/tests/contract_testcases/solana/expressions/overflow_constant_propagation.sol
+++ b/tests/contract_testcases/solana/expressions/overflow_constant_propagation.sol
@@ -31,3 +31,4 @@ contract foo {
 // error: 11:21-28: arithmetic overflow, 65792 does not fit into uint16
 // error: 16:21-29: arithmetic overflow, 100000 does not fit into uint16
 // error: 21:21-28: arithmetic overflow, -1 does not fit into uint16
+// error: 25:20-23: arithmetic overflow, 32768 does not fit into int16

--- a/tests/contract_testcases/solana/large_ints.sol
+++ b/tests/contract_testcases/solana/large_ints.sol
@@ -8,7 +8,5 @@ contract c {
 
 // ---- Expect: diagnostics ----
 // error: 3:12-22: value is too large to fit into type uint256
-// warning: 4:11-23: left shift by 100000 may overflow the final result
 // error: 4:11-23: value is too large to fit into type int256
-// warning: 5:11-24: left shift by 100000 may overflow the final result
 // error: 5:11-24: value is too large to fit into type int256


### PR DESCRIPTION
The negate operator does not check for overflow, add this too.

Fixes https://github.com/hyperledger/solang/issues/1484