### PR TITLE
Polkadot: Do not emit the storage initializer twice 

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -54,7 +54,7 @@ use solang_parser::{pt, pt::CodeLocation};
 pub const SOLANA_FIRST_OFFSET: u64 = 16;
 
 /// Name of the storage initializer function
-pub const STORAGE_INITIALIZER: &'static str = "storage_initializer";
+pub const STORAGE_INITIALIZER: &str = "storage_initializer";
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum OptimizationLevel {

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -53,6 +53,9 @@ use solang_parser::{pt, pt::CodeLocation};
 // The sizeof(struct account_data_header)
 pub const SOLANA_FIRST_OFFSET: u64 = 16;
 
+/// Name of the storage initializer function
+pub const STORAGE_INITIALIZER: &'static str = "storage_initializer";
+
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum OptimizationLevel {
     None = 0,
@@ -252,10 +255,7 @@ fn contract(contract_no: usize, ns: &mut Namespace, opt: &Options) {
 /// This function will set all contract storage initializers and should be called from the constructor
 fn storage_initializer(contract_no: usize, ns: &mut Namespace, opt: &Options) -> ControlFlowGraph {
     // note the single `:` to prevent a name clash with user-declared functions
-    let mut cfg = ControlFlowGraph::new(
-        format!("{}:storage_initializer", ns.contracts[contract_no].name),
-        ASTFunction::None,
-    );
+    let mut cfg = ControlFlowGraph::new(STORAGE_INITIALIZER.to_string(), ASTFunction::None);
     let mut vartab = Vartable::new(ns.next_id);
 
     for layout in &ns.contracts[contract_no].layout {

--- a/src/emit/functions.rs
+++ b/src/emit/functions.rs
@@ -4,7 +4,7 @@ use crate::{
     emit::{binary::Binary, cfg::emit_cfg, TargetRuntime},
     sema::ast::{Contract, Namespace, Type},
 };
-use inkwell::{module::Linkage, values::FunctionValue};
+use inkwell::module::Linkage;
 
 /// Emit all functions, constructors, fallback and receiver
 pub(super) fn emit_functions<'a, T: TargetRuntime<'a>>(
@@ -48,26 +48,4 @@ pub(super) fn emit_functions<'a, T: TargetRuntime<'a>>(
     for (func_decl, cfg) in defines {
         emit_cfg(target, bin, contract, cfg, func_decl, ns);
     }
-}
-
-/// Emit the storage initializers
-pub(super) fn emit_initializer<'a, T: TargetRuntime<'a>>(
-    target: &mut T,
-    bin: &mut Binary<'a>,
-    contract: &Contract,
-    ns: &Namespace,
-) -> FunctionValue<'a> {
-    let function_ty = bin.function_type(&[], &[], ns);
-
-    let function = bin.module.add_function(
-        &format!("sol::{}::storage_initializers", contract.name),
-        function_ty,
-        Some(Linkage::Internal),
-    );
-
-    let cfg = &contract.cfg[contract.initializer.unwrap()];
-
-    emit_cfg(target, bin, contract, cfg, function, ns);
-
-    function
 }

--- a/src/emit/polkadot/mod.rs
+++ b/src/emit/polkadot/mod.rs
@@ -2,7 +2,7 @@
 
 use std::ffi::CString;
 
-use crate::codegen::Options;
+use crate::codegen::{Options, STORAGE_INITIALIZER};
 use crate::sema::ast::{Contract, Namespace};
 use inkwell::context::Context;
 use inkwell::module::{Linkage, Module};
@@ -146,7 +146,7 @@ impl PolkadotTarget {
 
         emit_functions(&mut target, &mut binary, contract, ns);
 
-        let function_name = CString::new(format!("{}:storage_initializer", contract.name)).unwrap();
+        let function_name = CString::new(STORAGE_INITIALIZER).unwrap();
         let mut storage_initializers = binary
             .functions
             .values()


### PR DESCRIPTION
There is no need to deliberately emit the storage initializer CFG a second time. It just ends up as dead code because it's  being emitted anyways.