### PR TITLE
Polkadot: Implemented Node Interactions in Solang's CLI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -336,6 +336,9 @@ jobs:
     - name: Deploy and test contracts
       run: npm run test
       working-directory: ./integration/polkadot
+    - name: Test Polkadot cli
+      run: ./cli_test.sh
+      working-directory: ./integration/polkadot
     - name: cleanup
       if: always()
       run: docker kill ${{steps.substrate.outputs.id}}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,8 +61,15 @@ petgraph = "0.6.3"
 wasmparser = "0.110.0"
 wasm-encoder = "0.31"
 toml = "0.7"
-wasm-opt = { version = "0.112.0", optional = true }
-contract-build = { version = "3.0.1", optional = true }
+wasm-opt = { version = "0.114.1", optional = true }
+contract-build = { git = "https://github.com/paritytech/cargo-contract", optional = true }
+contract-extrinsics = {git = "https://github.com/paritytech/cargo-contract"}
+anyhow = "1.0.75"
+colored = "2.0.4"
+url = { version = "2.4.1", features = ["serde"] }
+subxt = "0.31.0"
+pallet-contracts-primitives = "24.0.0"
+sp-core = "21.0.0"
 primitive-types = { version = "0.12", features = ["codec"] }
 normalize-path = "0.2.1"
 bitflags = "2.3.3"

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -207,11 +207,11 @@ Options:
   must be specified.
 
 \-\-address\-length *length-in-bytes*
-  Change the default address length on Polkadot. By default, Substate uses an address type of 32 bytes. This option
+  Change the default address length on Polkadot. By default, Substrate uses an address type of 32 bytes. This option
   is ignored for any other target.
 
 \-\-value\-length *length-in-bytes*
-  Change the default value length on Polkadot. By default, Substate uses an value type of 16 bytes. This option
+  Change the default value length on Polkadot. By default, Substrate uses an value type of 16 bytes. This option
   is ignored for any other target.
 
 \-\-importpath *directory*
@@ -243,6 +243,132 @@ for an example of how to use this.
 .. note::
 
   There is only supported on Solana.
+
+Submitting extrinsics to Polkadot on-chain
+__________________________________________
+
+  solang polkadot [SUBCOMMAND] [OPTIONS]... [FILE]...
+
+This means that the command line is ``solang polkadot`` followed by a subcommand followed by any options described below,
+followed by the filename. The filename could be ``.wasm file``, ``.contract`` bundle, or ``.json`` metadata file.
+
+General Options (for all subcommands):
+
+\-\-url *url*
+  The websockets URL for the substrate node. [default: ws://localhost:9944]
+
+\-\-network *network*
+  Specify the network name to use.
+  You can either specify a network name or a URL, but not both.
+
+  Network:
+
+  rococo
+    Contracts (Rococo) (Equivalent to ``--url wss://rococo-contracts-rpc.polkadot.io``)
+
+  phala-po-c5
+    Phala PoC-5 (Equivalent to ``--url wss://poc5.phala.network/ws``)
+
+  astar-shiden
+    Astar Shiden (Kusama) (Equivalent to ``--url wss://rpc.shiden.astar.network``)
+
+  astar-shibuya
+    Astar Shibuya (Tokio) (Equivalent to ``--url wss://rpc.shibuya.astar.network``)
+
+  astar
+    Astar (Equivalent to ``--url wss://rpc.astar.network``)
+
+  aleph-zero-testnet
+    Aleph Zero Testnet (Equivalent to ``--url wss://ws.test.azero.dev``)
+
+  aleph-zero
+    Aleph Zero (Equivalent to ``--url wss://ws.azero.dev``)
+  
+  t3rnt0rn
+    T3RN T0RN (Equivalent to ``--url wss://ws.t0rn.io``)
+  
+  pendulum-testnet
+    Pendulum Testnet (Equivalent to ``--url wss://rpc-foucoco.pendulumchain.tech``)
+
+-s, \-\-suri *suri*
+  Specifies the secret key URI used for deploying the contract (must be specified). For example:
+    For a development account: //Alice
+    
+    With a password: //Alice///SECRET_PASSWORD
+
+-x, \-\-execute
+  Specifies whether to submit the extrinsic for on-chain execution.
+
+\-\-storage-deposit-limit *storage-deposit-limit*
+  Specifies the maximum amount of balance that can be charged from the caller to pay for the storage consumed.
+
+\-\-output-json
+  Specifies whether to export the call output in JSON format.
+
+\-\-help, -h
+  This displays a short description of all the options
+
+Subcommands:
+
+  solang polkadot upload [OPTIONS]... [FILE]...
+
+  solang polkadot instantiate [OPTIONS]... [FILE]...
+
+Options specific to the ``instantiate`` subcommand:
+
+\-\-constructor *constructor*
+  Specifies the name of the contract constructor to call. [default: new]
+
+\-\-args *<ARGS>...*
+  Specifies the arguments of the contract constructor to call.
+
+\-\-value *value*
+  Specifies the value to be transferred as part of the call. [default: 0]
+
+\-\-gas *gas*
+  Specifies the maximum amount of gas to be used for this command.
+
+\-\-proof-size *proof-size*
+  Specifies the maximum proof size for this instantiation.
+
+\-\-salt *salt*
+  Specifies a salt used in the address derivation of the new contract.
+
+-y, \-\-skip-confirm
+  When set, skips the interactive confirmation prompt.
+
+  solang polkadot call [OPTIONS]... [FILE]...
+
+Options specific to the ``call`` subcommand:
+
+\-\-contract *contract*
+  Specifies the address of the contract to call.
+
+-m, \-\-message *message*
+  Specifies the name of the contract message to call.
+
+\-\-args *<ARGS>...*
+  Specifies the arguments of the contract message to call.
+
+\-\-value *value*
+  Specifies the value to be transferred as part of the call. [default: 0]
+
+\-\-gas *gas*
+  Specifies the maximum amount of gas to be used for this command.
+
+\-\-proof-size *proof-size*
+  Specifies the maximum proof size for this call.
+
+-y, \-\-skip-confirm
+  When set, skips the interactive confirmation prompt.
+
+  solang polkadot remove [OPTIONS]... [FILE]...
+
+Options specific to the ``remove`` subcommand:
+
+\-\-code-hash *code_hash*
+  Specifies the code hash to remove.
+
 
 Running Solang using a container
 ________________________________

--- a/integration/polkadot/cli_test.sh
+++ b/integration/polkadot/cli_test.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+set -e
+
+# Compile the Solidity contract
+solang compile -v --target polkadot flipper.sol
+
+# Upload the contract to a substrate node
+upload_result=$(solang polkadot upload --suri //Alice -x flipper.contract --output-json)
+
+# Instantiate the contract
+instantiate_result=$(solang polkadot instantiate --suri //Alice --args true -x flipper.contract --output-json --skip-confirm)
+
+# Extract the contract address from the instantiate result
+instantiate_contract_address=$(echo "$instantiate_result" | jq -r '.contract')
+
+# Call the contract
+call_result=$(solang polkadot call --contract "$instantiate_contract_address" --message get --suri //Alice flipper.contract --output-json --skip-confirm)
+
+# Extract the "value" field from the "data" object
+value=$(echo "$call_result" | jq -r '.data.Bool')
+
+# Step 5: Assert that "value" is true
+if [ "$value" == "true" ]; then
+    echo "Contract call succeeded."
+else
+    echo "Contract call reverted."
+    exit 1
+fi
+
+# Call the flip function on the contract
+call_flip_result=$(solang polkadot call --contract "$instantiate_contract_address" --message flip --suri //Alice -x flipper.contract --output-json --skip-confirm)
+
+# Check that "value" is now false
+call_result=$(solang polkadot call --contract "$instantiate_contract_address" --message get --suri //Alice flipper.contract --output-json --skip-confirm)
+
+# Extract the "value" field from the "data" object
+value=$(echo "$call_result" | jq -r '.data.Bool')
+
+# Assert that "value" is false
+if [ "$value" == "false" ]; then
+    echo "Contract call flipped as expected."
+else
+    echo "Contract call did not flip the value."
+    exit 1
+fi
+
+# Compile another Solidity contract
+solang compile -v --target polkadot asserts.sol
+
+# Upload the contract to a substrate node
+upload_result=$(solang polkadot upload --suri //Alice -x asserts.contract --output-json)
+
+# Extract the "code_hash" value directly from the second JSON object
+code_hash=$(echo "$upload_result" | tail -n 1 | jq -r '.code_hash')
+
+# Remove the contract using the code hash
+remove_result=$(solang polkadot remove --suri //Alice --output-json --code-hash "$code_hash" asserts.contract)
+
+# Get the "code_hash" value from the second JSON object
+removed_code_hash=$(echo "$remove_result" | tail -n 1)
+
+# In case of success, the last line of the output will be the code hash
+if [[ "$removed_code_hash" == 0x* ]]; then
+    echo "Contract removed successfully."
+    exit 0
+else
+    echo "Contract removal failed."
+    exit 1
+fi

--- a/src/bin/cli/polkadot/call.rs
+++ b/src/bin/cli/polkadot/call.rs
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::cli::check_target_match;
+use contract_extrinsics::ErrorVariant;
+
+use serde_json::json;
+use std::fmt::Debug;
+
+use super::{prompt_confirm_transaction, CLIExtrinsicOpts};
+use anyhow::{Context, Result};
+use contract_build::name_value_println;
+use contract_build::Verbosity;
+use contract_extrinsics::{
+    BalanceVariant, CallCommandBuilder, DefaultConfig, ExtrinsicOptsBuilder, StorageDeposit,
+    TokenMetadata,
+};
+use subxt::Config;
+
+#[derive(Debug, clap::Args)]
+#[clap(name = "call", about = "Call a contract on Polkadot")]
+pub struct PolkadotCallCommand {
+    #[clap(
+        name = "contract",
+        long,
+        help = "Specifies the address of the contract to call."
+    )]
+    contract: <DefaultConfig as Config>::AccountId,
+    #[clap(
+        long,
+        short,
+        help = "Specifies the name of the contract message to call."
+    )]
+    message: String,
+    #[clap(long, num_args = 0.., help = "Specifies the arguments of the contract message to call.")]
+    args: Vec<String>,
+    #[clap(flatten)]
+    extrinsic_cli_opts: CLIExtrinsicOpts,
+    #[clap(
+        name = "value",
+        long,
+        default_value = "0",
+        help = "Specifies the value to be transferred as part of the call."
+    )]
+    value: BalanceVariant,
+    #[clap(
+        name = "gas",
+        long,
+        help = "Specifies the maximum amount of gas to be used for this command."
+    )]
+    gas_limit: Option<u64>,
+    #[clap(long, help = "Specifies the maximum proof size for this call.")]
+    proof_size: Option<u64>,
+    #[clap(
+        short('y'),
+        long,
+        help = "Specifies whether to skip the confirmation prompt."
+    )]
+    skip_confirm: bool,
+}
+
+impl PolkadotCallCommand {
+    /// Returns whether to export the call output in JSON format.
+    pub fn output_json(&self) -> bool {
+        self.extrinsic_cli_opts.output_json
+    }
+
+    pub async fn handle(&self) -> Result<(), ErrorVariant> {
+        check_target_match("polkadot").unwrap();
+        let cli_options = ExtrinsicOptsBuilder::default()
+            .file(Some(self.extrinsic_cli_opts.file.clone()))
+            .url(self.extrinsic_cli_opts.url().clone())
+            .suri(self.extrinsic_cli_opts.suri.clone())
+            .storage_deposit_limit(self.extrinsic_cli_opts.storage_deposit_limit.clone())
+            .done();
+        let exec = CallCommandBuilder::default()
+            .contract(self.contract.clone())
+            .message(self.message.clone())
+            .args(self.args.clone())
+            .extrinsic_opts(cli_options)
+            .gas_limit(self.gas_limit)
+            .proof_size(self.proof_size)
+            .value(self.value.clone())
+            .done()
+            .await?;
+
+        if !self.extrinsic_cli_opts.execute {
+            let result = exec.call_dry_run().await?;
+            match result.result {
+                Ok(ref ret_val) => {
+                    let value = exec
+                        .transcoder()
+                        .decode_message_return(exec.message(), &mut &ret_val.data[..])
+                        .context(format!("Failed to decode return value {:?}", &ret_val))?;
+                    if self.output_json() {
+                        let json_object = json!({
+                            "reverted": ret_val.did_revert(),
+                            "data": value,
+                            "gas_consumed": result.gas_consumed,
+                            "gas_required": result.gas_required,
+                            "storage_deposit": StorageDeposit::from(&result.storage_deposit),
+                        })
+                        .to_string();
+                        println!("{}", json_object);
+                    } else {
+                        name_value_println!("Result", format!("{}", value));
+                        name_value_println!("Reverted", format!("{:?}", ret_val.did_revert()));
+                        println!("Execution of your call has NOT been completed.\n
+                        To submit the transaction and execute the call on chain, please include -x/--execute flag.");
+                    };
+                }
+                Err(ref err) => {
+                    let metadata = exec.client().metadata();
+                    let object = ErrorVariant::from_dispatch_error(err, &metadata)?;
+                    return Err(object);
+                }
+            }
+        } else {
+            let gas_limit = exec.estimate_gas().await?;
+            if !self.skip_confirm {
+                prompt_confirm_transaction(|| {
+                    println!("Call Summary:");
+                    name_value_println!("Message", exec.message());
+                    name_value_println!("Args", exec.args().join(" "));
+                    name_value_println!("Gas limit", gas_limit.to_string());
+                })?;
+            }
+            let token_metadata = TokenMetadata::query(exec.client()).await?;
+            let display_events = exec.call(Some(gas_limit)).await?;
+            let output = if self.output_json() {
+                display_events.to_json()?
+            } else {
+                display_events.display_events(Verbosity::Default, &token_metadata)?
+            };
+            println!("{output}");
+        }
+        Ok(())
+    }
+}

--- a/src/bin/cli/polkadot/instantiate.rs
+++ b/src/bin/cli/polkadot/instantiate.rs
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{prompt_confirm_transaction, CLIExtrinsicOpts};
+use crate::cli::check_target_match;
+use anyhow::Result;
+use contract_build::{name_value_println, util::decode_hex, Verbosity};
+use contract_extrinsics::ErrorVariant;
+use contract_extrinsics::{
+    BalanceVariant, DisplayEvents, ExtrinsicOptsBuilder, InstantiateCommandBuilder,
+};
+use sp_core::Bytes;
+use std::fmt::Debug;
+
+#[derive(Debug, clap::Args)]
+#[clap(name = "instantiate", about = "Instantiate a contract on Polkadot")]
+pub struct PolkadotInstantiateCommand {
+    #[clap(
+        name = "constructor",
+        long,
+        default_value = "new",
+        help = "Specifies the name of the contract constructor to call."
+    )]
+    constructor: String,
+    #[clap(long, num_args = 0.., help = "Specifies the arguments of the contract constructor to call.")]
+    args: Vec<String>,
+    #[clap(flatten)]
+    extrinsic_cli_opts: CLIExtrinsicOpts,
+    #[clap(
+        name = "value",
+        long,
+        default_value = "0",
+        help = "Specifies the value to be transferred as part of the call."
+    )]
+    value: BalanceVariant,
+    #[clap(
+        name = "gas",
+        long,
+        help = "Specifies the maximum amount of gas to be used for this command."
+    )]
+    gas_limit: Option<u64>,
+    #[clap(
+        long,
+        help = "Specifies the maximum proof size for this instantiation."
+    )]
+    proof_size: Option<u64>,
+    #[clap(long, value_parser = parse_hex_bytes, help = "Specifies a salt used in the address derivation of the new contract.")]
+    salt: Option<Bytes>,
+    #[clap(
+        short('y'),
+        long,
+        help = "Specifies whether to skip the confirmation prompt."
+    )]
+    skip_confirm: bool,
+}
+
+/// Parse hex encoded bytes.
+fn parse_hex_bytes(input: &str) -> Result<Bytes> {
+    let bytes = decode_hex(input)?;
+    Ok(bytes.into())
+}
+
+impl PolkadotInstantiateCommand {
+    /// Returns whether to export the call output in JSON format.
+    pub fn output_json(&self) -> bool {
+        self.extrinsic_cli_opts.output_json
+    }
+
+    pub async fn handle(&self) -> Result<(), ErrorVariant> {
+        check_target_match("polkadot").unwrap();
+        let cli_options = ExtrinsicOptsBuilder::default()
+            .file(Some(self.extrinsic_cli_opts.file.clone()))
+            .url(self.extrinsic_cli_opts.url().clone())
+            .suri(self.extrinsic_cli_opts.suri.clone())
+            .storage_deposit_limit(self.extrinsic_cli_opts.storage_deposit_limit.clone())
+            .done();
+        let exec = InstantiateCommandBuilder::default()
+            .constructor(self.constructor.clone())
+            .args(self.args.clone())
+            .extrinsic_opts(cli_options)
+            .value(self.value.clone())
+            .gas_limit(self.gas_limit)
+            .proof_size(self.proof_size)
+            .salt(self.salt.clone())
+            .done()
+            .await?;
+
+        if !self.extrinsic_cli_opts.execute {
+            let result = exec.instantiate_dry_run().await?;
+            match exec.decode_instantiate_dry_run(&result).await {
+                Ok(dry_run_result) => {
+                    if self.output_json() {
+                        println!("{}", dry_run_result.to_json()?);
+                    } else {
+                        name_value_println!("Result", format!("{}", &dry_run_result.result));
+                        name_value_println!("Reverted", format!("{:?}", &dry_run_result.reverted));
+                        name_value_println!("Contract", &dry_run_result.contract);
+                        name_value_println!(
+                            "Gas consumed",
+                            &dry_run_result.gas_consumed.to_string()
+                        );
+                        println!("Execution of your instantiate call has NOT been completed.\n
+                        To submit the transaction and execute the call on chain, please include -x/--execute flag.");
+                    }
+                    Ok(())
+                }
+                Err(object) => Err(object),
+            }
+        } else {
+            let gas_limit = exec.estimate_gas().await?;
+            if !self.skip_confirm {
+                prompt_confirm_transaction(|| {
+                    println!("Instantiation Summary:");
+                    name_value_println!("Constructor", exec.args().constructor());
+                    name_value_println!("Args", exec.args().raw_args().join(" "));
+                    name_value_println!("Gas limit", gas_limit.to_string());
+                })?;
+            }
+            let instantiate_result = exec.instantiate(Some(gas_limit)).await?;
+            let events = DisplayEvents::from_events(
+                &instantiate_result.result,
+                Some(exec.transcoder()),
+                &exec.client().metadata(),
+            )?;
+            let contract_address = instantiate_result.contract_address.to_string();
+            if self.output_json() {
+                let display_instantiate_result = InstantiateResult {
+                    code_hash: instantiate_result.code_hash.map(|ch| format!("{ch:?}")),
+                    contract: contract_address,
+                    events,
+                };
+                println!("{}", display_instantiate_result.to_json()?)
+            } else {
+                println!(
+                    "{}",
+                    events
+                        .display_events(Verbosity::Default, &instantiate_result.token_metadata)?
+                );
+                if let Some(code_hash) = instantiate_result.code_hash {
+                    name_value_println!("Code hash", format!("{code_hash:?}"));
+                }
+                name_value_println!("Contract", contract_address);
+            };
+            Ok(())
+        }
+    }
+}
+
+#[derive(serde::Serialize)]
+pub struct InstantiateResult {
+    pub contract: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code_hash: Option<String>,
+    pub events: DisplayEvents,
+}
+
+impl InstantiateResult {
+    pub fn to_json(&self) -> Result<String> {
+        Ok(serde_json::to_string_pretty(self)?)
+    }
+}

--- a/src/bin/cli/polkadot/mod.rs
+++ b/src/bin/cli/polkadot/mod.rs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod call;
+pub mod instantiate;
+pub mod remove;
+pub mod upload;
+
+pub(crate) use self::{
+    call::PolkadotCallCommand, instantiate::PolkadotInstantiateCommand,
+    remove::PolkadotRemoveCommand, upload::PolkadotUploadCommand,
+};
+use crate::PathBuf;
+use anyhow::anyhow;
+use anyhow::Result;
+use contract_extrinsics::BalanceVariant;
+use std::io::{self, Write};
+pub use subxt::PolkadotConfig as DefaultConfig;
+
+/// Common CLI options for any extrinsic execution.
+#[derive(Clone, Debug, clap::Args)]
+pub struct CLIExtrinsicOpts {
+    #[clap(
+        value_parser,
+        help = "Specifies the path to a contract wasm file, .contract bundle, or .json metadata file."
+    )]
+    file: PathBuf,
+    #[clap(
+        name = "url",
+        long,
+        value_parser,
+        default_value = "ws://localhost:9944",
+        help = "Specifies the websockets URL for the substrate node directly."
+    )]
+    url: url::Url,
+    #[clap(
+        value_enum,
+        name = "network",
+        long,
+        conflicts_with = "url",
+        help = "Specifies the network name."
+    )]
+    network: Option<Network>,
+    #[clap(
+        name = "suri",
+        long,
+        short,
+        help = "Specifies the secret key URI used for deploying the contract. For example:\n
+    For a development account: //Alice\n
+    With a password: //Alice///SECRET_PASSWORD"
+    )]
+    suri: String,
+    #[clap(
+        short('x'),
+        long,
+        help = "Specifies whether to submit the extrinsic for execution."
+    )]
+    execute: bool,
+    #[clap(
+        long,
+        help = "Specifies the maximum amount of balance that can be charged from the caller to pay for the storage consumed."
+    )]
+    storage_deposit_limit: Option<BalanceVariant>,
+    #[clap(long, help = "Specifies whether to export the call output in JSON.")]
+    output_json: bool,
+}
+
+/// Available networks.
+#[derive(clap::ValueEnum, Clone, Debug)]
+enum Network {
+    Rococo,
+    PhalaPoC5,
+    AstarShiden,
+    AstarShibuya,
+    Astar,
+    AlephZeroTestnet,
+    AlephZero,
+    T3RNT0RN,
+    PendulumTestnet,
+}
+
+impl CLIExtrinsicOpts {
+    /// Returns the URL for the substrate node.
+    /// If the network is specified, it returns the URL for the network.
+    /// Otherwise, it returns the URL specified by the user.
+    pub fn url(&self) -> url::Url {
+        if let Some(net) = &self.network {
+            match net {
+                Network::Rococo => {
+                    url::Url::parse("wss://rococo-contracts-rpc.polkadot.io").unwrap()
+                }
+                Network::PhalaPoC5 => url::Url::parse("wss://poc5.phala.network/ws").unwrap(),
+                Network::AstarShiden => url::Url::parse("wss://rpc.shiden.astar.network").unwrap(),
+                Network::AstarShibuya => {
+                    url::Url::parse("wss://rpc.shibuya.astar.network").unwrap()
+                }
+                Network::Astar => url::Url::parse("wss://rpc.astar.network").unwrap(),
+                Network::AlephZeroTestnet => url::Url::parse("wss://ws.test.azero.dev").unwrap(),
+                Network::AlephZero => url::Url::parse("wss://ws.azero.dev").unwrap(),
+                Network::T3RNT0RN => url::Url::parse("wss://ws.t0rn.io").unwrap(),
+                Network::PendulumTestnet => {
+                    url::Url::parse("wss://rpc-foucoco.pendulumchain.tech").unwrap()
+                }
+            }
+        } else {
+            self.url.clone()
+        }
+    }
+}
+
+/// Prompt the user to confirm transaction.
+pub fn prompt_confirm_transaction<F: FnOnce()>(summary: F) -> Result<()> {
+    summary();
+    println!("Are you sure you want to submit this transaction? (Y/n): ");
+
+    let mut choice = String::new();
+    io::stdout().flush()?;
+    io::stdin().read_line(&mut choice)?;
+    match choice.trim().to_lowercase().as_str() {
+        "y" | "" => Ok(()),
+        "n" => Err(anyhow!("Transaction not submitted")),
+        _ => Err(anyhow!("Invalid choice")),
+    }
+}

--- a/src/bin/cli/polkadot/remove.rs
+++ b/src/bin/cli/polkadot/remove.rs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use contract_extrinsics::ErrorVariant;
+use std::fmt::Debug;
+
+use super::CLIExtrinsicOpts;
+use crate::cli::check_target_match;
+use anyhow::Result;
+use contract_build::{name_value_println, Verbosity};
+use contract_extrinsics::{
+    parse_code_hash, DefaultConfig, ExtrinsicOptsBuilder, RemoveCommandBuilder, TokenMetadata,
+};
+use subxt::Config;
+
+#[derive(Debug, clap::Args)]
+#[clap(name = "remove", about = "Remove a contract on Polkadot")]
+pub struct PolkadotRemoveCommand {
+    #[clap(long, value_parser = parse_code_hash, help = "Specifies the code hash to remove.")]
+    code_hash: Option<<DefaultConfig as Config>::Hash>,
+    #[clap(flatten)]
+    extrinsic_cli_opts: CLIExtrinsicOpts,
+}
+
+impl PolkadotRemoveCommand {
+    /// Returns whether to export the call output in JSON format.
+    pub fn output_json(&self) -> bool {
+        self.extrinsic_cli_opts.output_json
+    }
+
+    pub async fn handle(&self) -> Result<(), ErrorVariant> {
+        check_target_match("polkadot").unwrap();
+        let cli_options = ExtrinsicOptsBuilder::default()
+            .file(Some(self.extrinsic_cli_opts.file.clone()))
+            .url(self.extrinsic_cli_opts.url().clone())
+            .suri(self.extrinsic_cli_opts.suri.clone())
+            .storage_deposit_limit(self.extrinsic_cli_opts.storage_deposit_limit.clone())
+            .done();
+        let remove_exec = RemoveCommandBuilder::default()
+            .code_hash(self.code_hash)
+            .extrinsic_opts(cli_options)
+            .done()
+            .await?;
+        let remove_result = remove_exec.remove_code().await?;
+        let display_events = remove_result.display_events;
+        let output = if self.output_json() {
+            display_events.to_json()?
+        } else {
+            let token_metadata = TokenMetadata::query(remove_exec.client()).await?;
+            display_events.display_events(Verbosity::Default, &token_metadata)?
+        };
+        println!("{output}");
+        if let Some(code_removed) = remove_result.code_removed {
+            let remove_result = code_removed.code_hash;
+
+            if self.output_json() {
+                println!("{}", &remove_result);
+            } else {
+                name_value_println!("Code hash", format!("{remove_result:?}"));
+            }
+            Ok(())
+        } else {
+            let error_code_hash = hex::encode(remove_exec.final_code_hash());
+            Err(anyhow::anyhow!("Error removing the code: {}", error_code_hash).into())
+        }
+    }
+}

--- a/src/bin/cli/polkadot/upload.rs
+++ b/src/bin/cli/polkadot/upload.rs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use contract_extrinsics::ErrorVariant;
+use serde_json::json;
+use std::fmt::Debug;
+
+use super::CLIExtrinsicOpts;
+use crate::cli::check_target_match;
+use anyhow::Result;
+use contract_build::{name_value_println, Verbosity};
+use contract_extrinsics::{ExtrinsicOptsBuilder, TokenMetadata, UploadCommandBuilder};
+
+#[derive(Debug, clap::Args)]
+#[clap(name = "upload", about = "Upload a contract on Polkadot")]
+pub struct PolkadotUploadCommand {
+    #[clap(flatten)]
+    extrinsic_cli_opts: CLIExtrinsicOpts,
+}
+
+impl PolkadotUploadCommand {
+    /// Returns whether to export the call output in JSON format.
+    pub fn output_json(&self) -> bool {
+        self.extrinsic_cli_opts.output_json
+    }
+
+    pub async fn handle(&self) -> Result<(), ErrorVariant> {
+        check_target_match("polkadot").unwrap();
+        let cli_options = ExtrinsicOptsBuilder::default()
+            .file(Some(self.extrinsic_cli_opts.file.clone()))
+            .url(self.extrinsic_cli_opts.url().clone())
+            .suri(self.extrinsic_cli_opts.suri.clone())
+            .storage_deposit_limit(self.extrinsic_cli_opts.storage_deposit_limit.clone())
+            .done();
+        let exec = UploadCommandBuilder::default()
+            .extrinsic_opts(cli_options)
+            .done()
+            .await?;
+
+        let code_hash = exec.code().code_hash();
+
+        if !self.extrinsic_cli_opts.execute {
+            match exec.upload_code_rpc().await? {
+                Ok(result) => {
+                    if self.output_json() {
+                        let json_object = json!({
+                            "result": "Success",
+                            "code_hash": result.code_hash,
+                            "deposit": result.deposit
+                        })
+                        .to_string();
+                        println!("{}", json_object);
+                    } else {
+                        name_value_println!("Result", "Success");
+                        name_value_println!("Code hash", format!("{:?}", result.code_hash));
+                        name_value_println!("Deposit", format!("{:?}", result.deposit));
+                        println!("Execution of your upload call has NOT been completed.\n
+                        To submit the transaction and execute the call on chain, please include -x/--execute flag.");
+                    }
+                }
+                Err(err) => {
+                    let metadata = exec.client().metadata();
+                    let err = ErrorVariant::from_dispatch_error(&err, &metadata)?;
+                    return Err(err);
+                }
+            }
+        } else {
+            let result = exec.upload_code().await?;
+            let events = result.display_events;
+            let output = if self.output_json() {
+                events.to_json()?
+            } else {
+                let token_metadata = TokenMetadata::query(exec.client()).await?;
+                events.display_events(Verbosity::Default, &token_metadata)?
+            };
+            println!("{output}");
+            if let Some(code_stored) = result.code_stored {
+                if self.output_json() {
+                    let json_object = json!({
+                        "code_hash": code_stored.code_hash,
+                    })
+                    .to_string();
+                    println!("{}", json_object);
+                } else {
+                    name_value_println!("Code hash", format!("{:?}", code_stored.code_hash));
+                }
+            } else {
+                let code_hash = hex::encode(code_hash);
+                return Err(anyhow::anyhow!(
+                    "This contract has already been uploaded. Code hash: 0x{code_hash}"
+                )
+                .into());
+            }
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Description:
This pull request implements `Polkadot` node interactions into `Solang`'s CLI, allowing users to:
- `upload`
- `instantiate`
- `call`
- `remove`  

### Key features include:
- Network Name Parameter: Allows users to specify the Polkadot network by name.

Example: `solang polkadot upload --suri //Alice --network rococo -x --output-json flipper.contract`

### Checklist
- [x] Tested the new commands using a shell script `integration/polkadot/cli_test.sh`.
- [x] Added documentation for the newly implemented commands.