### PR TITLE
Fix type(int256).min in comparisons

### DIFF
--- a/src/sema/expression/integers.rs
+++ b/src/sema/expression/integers.rs
@@ -4,10 +4,9 @@ use crate::sema::ast::{Expression, Namespace, Type};
 use crate::sema::diagnostics::Diagnostics;
 use crate::sema::expression::ResolveTo;
 use num_bigint::{BigInt, Sign};
-use num_traits::{One, Zero};
+use num_traits::Zero;
 use solang_parser::diagnostics::Diagnostic;
 use solang_parser::pt;
-use std::ops::Add;
 
 pub(super) fn coerce(
     l: &Type,
@@ -210,7 +209,7 @@ pub fn bigint_to_expression(
     // BigInt bits() returns the bits used without the sign. Negative value is allowed to be one
     // larger than positive value, e.g int8 has inclusive range -128 to 127.
     let bits = if n.sign() == Sign::Minus {
-        n.add(BigInt::one()).bits()
+        (n + 1u32).bits()
     } else {
         n.bits()
     };

--- a/tests/contract_testcases/solana/large_negative_ints.sol
+++ b/tests/contract_testcases/solana/large_negative_ints.sol
@@ -1,0 +1,31 @@
+pragma solidity ^0.8.0;
+
+library Issue1523 {
+    function i1523_fail1(int256 x) internal pure returns (bool) {
+        return x <= type(int256).min;
+    }
+
+    function i1523_fail2(int256 x) internal pure returns (bool) {
+        return x <= type(int256).min + 1;
+    }
+
+    function i1523_fail3(int256 x) internal pure returns (bool) {
+        // Actual min value inlined
+        return x <= -57896044618658097711785492504343953926634992332820282019728792003956564819968;
+    }
+
+    function i1523_fail4(int256 x) internal pure returns (bool) {
+        // Actual min value + 1
+        return x <= -57896044618658097711785492504343953926634992332820282019728792003956564819967;
+    }
+
+    function i1523_pass1() internal pure returns (int256) {
+        return type(int256).min + 1;
+    }
+
+    function i1523_pass2() internal pure returns (int256) {
+        return type(int256).min;
+    }
+}
+
+// ---- Expect: diagnostics ----


### PR DESCRIPTION
When resolving comparisons, we don't know what the types of the operands are so we resolve with `ResolveTo::Unknown`. In this path, there is an mistake in the bounds check for negative integers.

Fixes https://github.com/hyperledger/solang/issues/1523