### PR TITLE
Verify account space specified in annotation

### DIFF
--- a/src/bin/languageserver/mod.rs
+++ b/src/bin/languageserver/mod.rs
@@ -1409,25 +1409,27 @@ impl<'a> Builder<'a> {
                 continue;
             }
 
-            for note in &func.annotations {
-                match note {
-                    ast::ConstructorAnnotation::Bump(expr)
-                    | ast::ConstructorAnnotation::Seed(expr)
-                    | ast::ConstructorAnnotation::Space(expr) => {
-                        builder.expression(expr, &func.symtable)
-                    }
+            if let Some(bump) = &func.annotations.bump {
+                builder.expression(&bump.1, &func.symtable);
+            }
 
-                    ast::ConstructorAnnotation::Payer(loc, name) => {
-                        builder.hovers.push((
-                            loc.file_no(),
-                            HoverEntry {
-                                start: loc.start(),
-                                stop: loc.exclusive_end(),
-                                val: format!("payer account: {name}"),
-                            },
-                        ));
-                    }
-                }
+            for seed in &func.annotations.seeds {
+                builder.expression(&seed.1, &func.symtable);
+            }
+
+            if let Some(space) = &func.annotations.space {
+                builder.expression(&space.1, &func.symtable);
+            }
+
+            if let Some((loc, name)) = &func.annotations.payer {
+                builder.hovers.push((
+                    loc.file_no(),
+                    HoverEntry {
+                        start: loc.start(),
+                        stop: loc.exclusive_end(),
+                        val: format!("payer account: {name}"),
+                    },
+                ));
             }
 
             for (i, param) in func.params.iter().enumerate() {

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -42,12 +42,15 @@ use std::cmp::Ordering;
 use crate::codegen::cfg::ASTFunction;
 use crate::codegen::solana_accounts::account_management::manage_contract_accounts;
 use crate::codegen::yul::generate_yul_function_cfg;
+use crate::sema::diagnostics::Diagnostics;
+use crate::sema::eval::eval_const_number;
 use crate::sema::Recurse;
 #[cfg(feature = "wasm_opt")]
 use contract_build::OptimizationPasses;
 use num_bigint::{BigInt, Sign};
 use num_rational::BigRational;
 use num_traits::{FromPrimitive, Zero};
+use solang_parser::diagnostics::Diagnostic;
 use solang_parser::{pt, pt::CodeLocation};
 
 // The sizeof(struct account_data_header)
@@ -55,6 +58,10 @@ pub const SOLANA_FIRST_OFFSET: u64 = 16;
 
 /// Name of the storage initializer function
 pub const STORAGE_INITIALIZER: &str = "storage_initializer";
+
+/// Maximum permitted size of account data (10 MiB).
+/// https://github.com/solana-labs/solana/blob/08aba38d3507c8cb66f85074d8f1249d43e64a75/sdk/program/src/system_instruction.rs#L85
+pub const MAXIMUM_ACCOUNT_SIZE: u64 = 10 * 1024 * 1024;
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum OptimizationLevel {
@@ -326,6 +333,27 @@ fn layout(contract_no: usize, ns: &mut Namespace) {
                 });
 
                 slot += ty.storage_slots(ns);
+            }
+        }
+    }
+
+    let constructors = ns.contracts[contract_no].constructors(ns);
+    if !constructors.is_empty() {
+        if let Some((_, exp)) = &ns.functions[constructors[0]].annotations.space {
+            // This code path is only reachable on Solana
+            assert_eq!(ns.target, Target::Solana);
+            if let Ok((_, value)) = eval_const_number(exp, ns, &mut Diagnostics::default()) {
+                if slot > value {
+                    ns.diagnostics.push(Diagnostic::error(
+                        exp.loc(),
+                        format!("contract requires at least {} bytes of space", slot),
+                    ));
+                } else if value > BigInt::from(MAXIMUM_ACCOUNT_SIZE) {
+                    ns.diagnostics.push(Diagnostic::error(
+                        exp.loc(),
+                        "Solana's runtime does not permit accounts larger than 10 MB".to_string(),
+                    ));
+                }
             }
         }
     }

--- a/src/codegen/revert.rs
+++ b/src/codegen/revert.rs
@@ -405,7 +405,7 @@ pub(crate) fn error_msg_with_loc(ns: &Namespace, error: String, loc: Option<Loc>
     }
 }
 
-fn string_to_expr(string: String) -> Expression {
+pub(super) fn string_to_expr(string: String) -> Expression {
     Expression::FormatString {
         loc: Loc::Codegen,
         args: vec![(

--- a/src/sema/ast.rs
+++ b/src/sema/ast.rs
@@ -347,7 +347,7 @@ pub struct Function {
     /// For overloaded functions this is the mangled (unique) name.
     pub mangled_name: String,
     /// Solana constructors may have seeds specified using @seed tags
-    pub annotations: Vec<ConstructorAnnotation>,
+    pub annotations: ConstructorAnnotations,
     /// Which contracts should we use the mangled name in?
     pub mangled_name_contracts: HashSet<usize>,
     /// This indexmap stores the accounts this functions needs to be called on Solana
@@ -366,26 +366,17 @@ pub struct SolanaAccount {
     pub generated: bool,
 }
 
-#[derive(Debug)]
-pub enum ConstructorAnnotation {
-    Seed(Expression),
-    Payer(pt::Loc, String),
-    Space(Expression),
-    Bump(Expression),
+#[derive(Debug, Default)]
+pub struct ConstructorAnnotations {
+    // (annotation location, annotation expression)
+    pub seeds: Vec<(pt::Loc, Expression)>,
+    pub space: Option<(pt::Loc, Expression)>,
+    pub bump: Option<(pt::Loc, Expression)>,
+    // (annotation location, account name)
+    pub payer: Option<(pt::Loc, String)>,
 }
 
-impl CodeLocation for ConstructorAnnotation {
-    fn loc(&self) -> pt::Loc {
-        match self {
-            ConstructorAnnotation::Seed(expr)
-            | ConstructorAnnotation::Space(expr)
-            | ConstructorAnnotation::Bump(expr) => expr.loc(),
-            ConstructorAnnotation::Payer(loc, _) => *loc,
-        }
-    }
-}
-
-/// This trait provides a single interface for fetching paramenters, returns and the symbol table
+/// This trait provides a single interface for fetching parameters, returns and the symbol table
 /// for both yul and solidity functions
 pub trait FunctionAttributes {
     fn get_symbol_table(&self) -> &Symtable;
@@ -464,7 +455,7 @@ impl Function {
             symtable: Symtable::new(),
             emits_events: Vec::new(),
             mangled_name,
-            annotations: Vec::new(),
+            annotations: ConstructorAnnotations::default(),
             mangled_name_contracts: HashSet::new(),
             solana_accounts: IndexMap::new().into(),
         }
@@ -509,16 +500,12 @@ impl Function {
 
     /// Does this function have an @payer annotation?
     pub fn has_payer_annotation(&self) -> bool {
-        self.annotations
-            .iter()
-            .any(|note| matches!(note, ConstructorAnnotation::Payer(..)))
+        self.annotations.payer.is_some()
     }
 
     /// Does this function have an @seed annotation?
     pub fn has_seed_annotation(&self) -> bool {
-        self.annotations
-            .iter()
-            .any(|note| matches!(note, ConstructorAnnotation::Seed(..)))
+        !self.annotations.seeds.is_empty()
     }
 
     /// Does this function have the pure state

--- a/src/sema/dotgraphviz.rs
+++ b/src/sema/dotgraphviz.rs
@@ -214,33 +214,30 @@ impl Dot {
         }
 
         // Annotations
-        if !func.annotations.is_empty() {
-            let node = self.add_node(
-                Node::new("annotations", vec!["annotations".into()]),
-                Some(func_node),
-                Some(String::from("annotations")),
-            );
+        let node = self.add_node(
+            Node::new("annotations", vec!["annotations".into()]),
+            Some(func_node),
+            Some(String::from("annotations")),
+        );
 
-            for note in &func.annotations {
-                match note {
-                    ConstructorAnnotation::Seed(expr) => {
-                        self.add_expression(expr, Some(func), ns, node, "seed".into());
-                    }
-                    ConstructorAnnotation::Space(expr) => {
-                        self.add_expression(expr, Some(func), ns, node, "space".into());
-                    }
-                    ConstructorAnnotation::Bump(expr) => {
-                        self.add_expression(expr, Some(func), ns, node, "bump".into());
-                    }
-                    ConstructorAnnotation::Payer(_, name) => {
-                        self.add_node(
-                            Node::new("payer", vec![name.clone()]),
-                            Some(node),
-                            Some(String::from("payer declaration")),
-                        );
-                    }
-                };
-            }
+        for seed in &func.annotations.seeds {
+            self.add_expression(&seed.1, Some(func), ns, node, "seed".into());
+        }
+
+        if let Some(space) = &func.annotations.space {
+            self.add_expression(&space.1, Some(func), ns, node, "space".into());
+        }
+
+        if let Some(bump) = &func.annotations.bump {
+            self.add_expression(&bump.1, Some(func), ns, node, "bump".into());
+        }
+
+        if let Some((_, name)) = &func.annotations.payer {
+            self.add_node(
+                Node::new("payer", vec![name.clone()]),
+                Some(node),
+                Some(String::from("payer declaration")),
+            );
         }
 
         // bases

--- a/tests/contract_testcases/solana/annotations/bad_accounts.sol
+++ b/tests/contract_testcases/solana/annotations/bad_accounts.sol
@@ -75,7 +75,7 @@ contract OldAnnotationSyntax {
 // error: 39:12-29: 'SysvarInstruction' is a reserved account name
 // error: 47:12-18: account 'solang' already defined
 // 	note 46:5-19: previous definition
-// error: 58:11-18: '@seed' annotation on top of a constructor only accepts literals
-// error: 59:12-20: '@space' annotation on top of a constructor only accepts literals
-// error: 60:11-18: '@bump' annotation on top of a constructor only accepts literals
+// error: 58:11-18: '@seed' annotation on a constructor only accepts constant values
+// error: 59:12-20: '@space' annotation on a constructor only accepts constant values
+// error: 60:11-18: '@bump' annotation on a constructor only accepts constant values
 // error: 63:22-29: parameter annotations are only allowed in constructors

--- a/tests/contract_testcases/solana/annotations/invalid_space.sol
+++ b/tests/contract_testcases/solana/annotations/invalid_space.sol
@@ -1,0 +1,15 @@
+contract Test2 {
+    address public a;
+    address public b;
+
+    @payer(acc)
+    @space(5<<64)
+    constructor(address c, address d) {
+        a = c;
+        b = d;
+    }
+}
+
+// ---- Expect: diagnostics ----
+// error: 6:12-17: Solana's runtime does not permit accounts larger than 10 MB
+// error: codegen: value 92233720368547758208 does not fit into type uint64.

--- a/tests/contract_testcases/solana/annotations/not_enough_space.sol
+++ b/tests/contract_testcases/solana/annotations/not_enough_space.sol
@@ -1,0 +1,16 @@
+contract Test {
+    address a;
+    address b;
+
+    @payer(acc)
+    @space(5)
+    constructor(address c, address d) {
+        a = c;
+        b = d;
+    }
+}
+
+// ---- Expect: diagnostics ----
+// warning: 2:5-14: storage variable 'a' has been assigned, but never read
+// warning: 3:5-14: storage variable 'b' has been assigned, but never read
+// error: 6:12-13: contract requires at least 80 bytes of space

--- a/tests/contract_testcases/solana/annotations/not_enough_space_2.sol
+++ b/tests/contract_testcases/solana/annotations/not_enough_space_2.sol
@@ -1,0 +1,14 @@
+contract Test3 {
+    address public a;
+    address public b;
+
+    @payer(acc)
+    @space(5+8*2)
+    constructor(address c, address d) {
+        a = c;
+        b = d;
+    }
+}
+
+// ---- Expect: diagnostics ----
+// error: 6:12-17: contract requires at least 80 bytes of space


### PR DESCRIPTION
On Solana, we can specify the space necessary for a contract's data account in the constructor with an annotation. We do not verify, however, if the declared space is enough to hold all the contract variables. As a consequence, we could call the constructor without any issue using a very small space value and hit other runtime errors later.

PS: I found it unpleasant to keep iterating over the constructor annotations to find the one we were looking for, so I replaced the vector by a struct to hold the permitted annotations.