### PR TITLE
vscode: Use same solang for language server as for compilation on command line

### DIFF
--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the "solang" extension will be documented in this file.
 
+## Unreleased
+
+- The same version of solang should be used by the language server as for on the command line,
+  so first look in the $PATH for solang before downloading the solang binary. As a result, the
+  `forceSolangExecutable` option is no longer needed. [seanyoung](https://github.com/seanyoung)
+- Go to definition, go to type definition, go to implementation is implemented. [chioni16](https://github.com/chioni16)
+- Rename functionality is now implemented. [chioni16](https://github.com/chioni16)
+- It is not longer necessary to save a Solidity file, in order for the language server to pick
+  up changes to the file. [chioni16](https://github.com/chioni16)
+
 ## [0.3.0]
 
 - Ensure the extension still works without a connections to the internet

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the "solang" extension will be documented in this file.
 
 ## Unreleased
 
-- The same version of solang should be used by the language server as for on the command line,
+- The same version of solang should be used by the language server as on the command line,
   so first look in the $PATH for solang before downloading the solang binary. As a result, the
   `forceSolangExecutable` option is no longer needed. [seanyoung](https://github.com/seanyoung)
 - Go to definition, go to type definition, go to implementation is implemented. [chioni16](https://github.com/chioni16)

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -38,11 +38,6 @@
 					"default": false,
 					"description": "Whether to ask for permission before downloading any files from the Internet"
 				},
-				"solang.forceSolangExecutable": {
-					"type": "string",
-					"default": "",
-					"description": "Use the executable at this path and do not download or update solang. Leave this empty for automatic download."
-				},
 				"solidity.trace.server": {
 					"scope": "window",
 					"type": "string",

--- a/vscode/src/utils/getServer.ts
+++ b/vscode/src/utils/getServer.ts
@@ -22,14 +22,12 @@ export default async function getServer(context: vscode.ExtensionContext): Promi
     return undefined;
   }
 
-  const local = config.get('forceSolangExecutable');
-  if (typeof local == 'string' && local) {
-    const ourVersion = executableVersion(local);
+  const local = 'solang';
+  const localVersion = executableVersion(local);
 
-    if (ourVersion) {
-      console.log("Local Solang version: " + ourVersion);
-      return local;
-    }
+  if (localVersion) {
+    console.log("Local Solang version: " + localVersion);
+    return local;
   }
 
   const dest = path.join(context.globalStoragePath, platform);


### PR DESCRIPTION
We've had complaints that the extension gives different errors and warnings than solang on the command line. Use solang from the path and only download solang if it can not be found.

Fixes https://github.com/hyperledger/solang/issues/1444