### PR TITLE
Move to github provided runners for arm macos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,8 +84,7 @@ jobs:
 
   mac-arm:
     name: Mac Arm
-    runs-on: [self-hosted, macOS, ARM64, MacStadium]
-    if: ${{ github.repository_owner == 'hyperledger' }}
+    runs-on: macos-13-xlarge
     steps:
     - name: Checkout sources
       uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,8 +133,7 @@ jobs:
 
   mac-arm:
     name: Mac Arm
-    runs-on: [self-hosted, macOS, ARM64, MacStadium]
-    if: ${{ github.repository_owner == 'hyperledger' }}
+    runs-on: macos-13-xlarge
     steps:
     - name: Checkout sources
       uses: actions/checkout@v3


### PR DESCRIPTION
This means we no longer rely on the Hyperledger provided one.

See https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/