### PR TITLE
Default flipper example should not include @program_id

### DIFF
--- a/examples/solana/flipper.sol
+++ b/examples/solana/flipper.sol
@@ -1,4 +1,3 @@
-@program_id("F1ipperKF9EfD821ZbbYjS319LXYiBmjhzkkf5a26rC")
 contract flipper {
 	bool private value;
 


### PR DESCRIPTION
Users are getting the error "incorrect program id for instruction", which is confusing.