### PR TITLE
Refactor library_using_for.sol for clarity and naming conventions

### DIFF
--- a/docs/examples/library_using_for.sol
+++ b/docs/examples/library_using_for.sol
@@ -1,19 +1,19 @@
-contract test {
-    using lib for int32[100];
-
-    int32[100] bar;
-
-    function foo() public {
-        bar.set(10, 571);
+library Library {
+    function set(
+        int32[100] storage data,
+        uint256 index,
+        int32 value
+    ) internal  {
+        data[index] = value;
     }
 }
 
-library lib {
-    function set(
-        int32[100] storage a,
-        uint256 index,
-        int32 val
-    ) internal {
-        a[index] = val;
+contract TestContract {
+    using Library for int32[100];
+
+    int32[100] public dataArray;
+
+    function setElement(uint256 index, int32 value) public {
+        dataArray.set(index, value);
     }
 }


### PR DESCRIPTION
This commit refactors the library_using_for.sol code for better readability and adherence to naming conventions.

This pull request focuses on enhancing the [library_using_for.sol](https://github.com/hyperledger/solang/blob/main/docs/examples/library_using_for.sol). The changes improve the contract's readability and adherence to naming conventions.