### PR TITLE
Fix slice length

### DIFF
--- a/integration/solana/calls.spec.ts
+++ b/integration/solana/calls.spec.ts
@@ -18,16 +18,16 @@ describe('Testing calls', function () {
 
         await callee.program.methods.setX(new BN(102))
             .accounts({ dataAccount: callee.storage.publicKey })
-            .rpc({commitment: "confirmed"});
+            .rpc({commitment: "processed"});
 
         let res = await callee.program.methods.getX()
             .accounts({ dataAccount: callee.storage.publicKey })
-            .view({commitment: "confirmed"});
+            .view({commitment: "processed"});
 
         expect(res).toEqual(new BN(102));
 
         res = await caller.program.methods.whoAmI()
-            .view({commitment: "confirmed"});
+            .view({commitment: "processed"});
 
         expect(res).toStrictEqual(caller.program_key);
 
@@ -36,11 +36,11 @@ describe('Testing calls', function () {
                 callee_dataAccount: callee.storage.publicKey,
                 callee_pid: callee.program_key,
                 })
-            .rpc({commitment: "confirmed"});
+            .rpc({commitment: "processed"});
 
         res = await callee.program.methods.getX()
             .accounts({ dataAccount: callee.storage.publicKey })
-            .view({commitment: "confirmed"});
+            .view({commitment: "processed"});
 
         expect(res).toEqual(new BN(13123));
 
@@ -49,7 +49,7 @@ describe('Testing calls', function () {
                 callee_dataAccount: callee.storage.publicKey,
                 callee_pid: callee.program_key,
             })
-            .view({commitment: "confirmed"});
+            .view({commitment: "processed"});
 
         expect(res).toEqual(new BN(33123));
 
@@ -58,7 +58,7 @@ describe('Testing calls', function () {
                 callee2_pid: callee2.program_key,
                 callee_pid: callee.program_key,
             })
-            .view({commitment: "confirmed"});
+            .view({commitment: "processed"});
 
         expect(res.return0).toEqual(new BN(24));
         expect(res.return1).toBe("my name is callee");
@@ -69,7 +69,7 @@ describe('Testing calls', function () {
                 callee_pid: callee.program_key,
                 other_callee2: callee2.program_key,
             })
-            .view({commitment: "confirmed"});
+            .view({commitment: "processed"});
 
         expect(res.return0).toEqual(new BN(10));
         expect(res.return1).toBe("x:asda");

--- a/integration/solana/create_contract.sol
+++ b/integration/solana/create_contract.sol
@@ -129,6 +129,20 @@ contract Seed2 {
 
         creator.call_with_signer{seeds: seeds, accounts: metas, program_id: creator_program_id}();
     }
+
+    @account(pdaSigner)
+    @account(creatorId)
+    function pda_sign(uint8 bump) external view {
+        (address pda, bytes1 _bump) = try_find_program_address(["mint_authority"], address(this));
+        assert(bump == _bump);
+        assert(pda == tx.accounts.pdaSigner.key);
+
+        AccountMeta[1] metas = [
+            AccountMeta({pubkey: tx.accounts.pdaSigner.key, is_signer: true, is_writable: false})
+        ];
+
+        creator.call_with_signer{accounts: metas, seeds: [["mint_authority", abi.encode(_bump)]], program_id: tx.accounts.creatorId.key}();
+    }
 }
 
 @program_id("8gTkAidfM82u3DGbKcZpHwL5p47KQA16MDb4WmrHdmF6")

--- a/integration/solana/create_contract.spec.ts
+++ b/integration/solana/create_contract.spec.ts
@@ -124,6 +124,14 @@ describe('ChildContract', function () {
             .simulate();
 
         expect(res.raw.toString()).toContain('Signer found');
+
+        const [pdaSigner, bump2] = PublicKey.findProgramAddressSync([Buffer.from("mint_authority")], seed_program);
+
+        res = await seed2.methods.pdaSign(new BN(bump2))
+            .accounts({pdaSigner: pdaSigner, creatorId: program_key})
+            .simulate();
+
+        expect(res.raw.toString()).toContain('Signer found');
     });
 
     it('Create Contract with account metas vector', async function () {

--- a/src/emit/expression.rs
+++ b/src/emit/expression.rs
@@ -2228,6 +2228,9 @@ fn basic_value_to_slice<'a>(
         Type::Slice(_) | Type::DynamicBytes | Type::String => {
             let data = bin.vector_bytes(val);
             let len = bin.vector_len(val);
+            let len = bin
+                .builder
+                .build_int_z_extend(len, bin.context.i64_type(), "ext");
 
             (data, len)
         }


### PR DESCRIPTION
When converting [this example](https://github.com/solana-developers/program-examples/blob/main/tokens/pda-mint-authority/solang/solidity/pda-mint-authority.sol) to the new Solidity annotation syntax, I uncovered a small bug in slice creation, in which we were not casting the length to `uint64`, leading to an `InvalidLength` error in Solana's runtime.