### PR TITLE
v0.3.3: Atlantis

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   linux-x86-64:
     name: Linux x86-64
     runs-on: solang-ubuntu-latest
-    container: ghcr.io/hyperledger/solang-llvm:ci-5
+    container: ghcr.io/hyperledger/solang-llvm:ci-6
     steps:
     - name: Checkout sources
       uses: actions/checkout@v3.1.0
@@ -33,7 +33,7 @@ jobs:
     name: Linux arm64
     runs-on: linux-arm64
     if: ${{ github.repository_owner == 'hyperledger' }}
-    container: ghcr.io/hyperledger/solang-llvm:ci-5
+    container: ghcr.io/hyperledger/solang-llvm:ci-6
     steps:
     - name: Checkout sources
       uses: actions/checkout@v3.1.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
   linux-x86-64:
     name: Linux x86-64
     runs-on: solang-ubuntu-latest
-    container: ghcr.io/hyperledger/solang-llvm:ci-5
+    container: ghcr.io/hyperledger/solang-llvm:ci-6
     env:
       RUSTFLAGS: -C instrument-coverage -C llvm-args=--instrprof-atomic-counter-update-all --cfg=coverage --cfg=trybuild_no_target
       CARGO_INCREMENTAL: 0
@@ -109,7 +109,7 @@ jobs:
     name: Linux Arm
     runs-on: linux-arm64
     if: ${{ github.repository_owner == 'hyperledger' }}
-    container: ghcr.io/hyperledger/solang-llvm:ci-5
+    container: ghcr.io/hyperledger/solang-llvm:ci-6
     steps:
     - name: Checkout sources
       uses: actions/checkout@v3
@@ -252,7 +252,7 @@ jobs:
   anchor:
     name: Anchor Integration test
     runs-on: solang-ubuntu-latest
-    container: ghcr.io/hyperledger/solang-llvm:ci-5
+    container: ghcr.io/hyperledger/solang-llvm:ci-6
     needs: linux-x86-64
     steps:
     - name: Checkout sources
@@ -304,7 +304,7 @@ jobs:
   solana:
     name: Solana Integration test
     runs-on: solang-ubuntu-latest
-    container: ghcr.io/hyperledger/solang-llvm:ci-5
+    container: ghcr.io/hyperledger/solang-llvm:ci-6
     needs: linux-x86-64
     steps:
     - name: Checkout sources
@@ -475,7 +475,7 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     name: Coverage report
-    container: ghcr.io/hyperledger/solang-llvm:ci-5
+    container: ghcr.io/hyperledger/solang-llvm:ci-6
     needs: [linux-x86-64, solana, anchor, polkadot, polkadot-subxt, vscode]
     env:
       RUSTFLAGS: -C instrument-coverage -C llvm-args=--instrprof-atomic-counter-update-all --cfg=coverage --cfg=trybuild_no_target

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ will be documented here.
 
 This release improves the Solana developer experience, since now required
 accounts can be specified using annotations. For Polkadot, compatibility with
-Ethereum Solidity has been increased further, it is now possible to write 
+Ethereum Solidity has been increased further, it is now possible to write
 [EIP-1967](https://eips.ethereum.org/EIPS/eip-1967) compatible proxy contracts.
 There are many fixes all over the code base.
 
@@ -24,18 +24,19 @@ There are many fixes all over the code base.
 - The language server can now format Solidity source code using the `forge-fmt` crate. [chioni16](https://github.com/chioni16)
 - The langauge server can now do go references, go to implementation, and go to type
   definition. [chioni16](https://github.com/chioni16)
-- **Polkadot** `Panic` errors can now be caught in try-catch statements [xermicus](https://github.com/xermicus) 
-- **Polkadot** custom errors are now supported [xermicus](https://github.com/xermicus) 
-- **Polkadot** now supporting the `address.code` builtin [xermicus](https://github.com/xermicus) 
+- **Polkadot** `Panic` errors can now be caught in try-catch statements [xermicus](https://github.com/xermicus)
+- **Polkadot** custom errors are now supported [xermicus](https://github.com/xermicus)
+- **Polkadot** now supporting the `address.code` builtin [xermicus](https://github.com/xermicus)
 
 ### Fixed
 - **Solana** the data field of AccountInfo can now be modified. [LucasSte](https://github.com/LucasSte)
 - The vscode extension now uses the solang binary in the path, if available. [seanyoung](https://github.com/seanyoung)
 - Fixed a bug in the ABI encoding of dynamic arrays. [xermicus](https://github.com/xermicus)
-- Fixed a bug where loading from a storage struct member was not considered a storage read. 
+- Fixed a bug where loading from a storage struct member was not considered a storage read.
   [xermicus](https://github.com/xermicus) [seanyoung](https://github.com/seanyoung)
-- Fixed a compiler crash caused by chained assignments like `return a = b`.  [xermicus](https://github.com/xermicus) 
-- Variables declared in the return parameters no longer ignore the `storage` location. [xermicus](https://github.com/xermicus) 
+- Fixed a compiler crash caused by chained assignments like `return a = b`.  [xermicus](https://github.com/xermicus)
+- Variables declared in the return parameters no longer ignore the `storage` location. [xermicus](https://github.com/xermicus)
+
 ### Changed
 - **BREAKING:** **Solana** the contract Solidity type can no longer be used. This type
   used to represent a single address, but this does not make sense as there are many

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 All notable changes to [Solang](https://github.com/hyperledger/solang/)
 will be documented here.
 
+## v0.3.3 Atlantis
+
+This release improves the Solana developer experience, since now required
+accounts can be specified using annotations. There are many fixes all over
+the code base.
+
+### Added
+- **Solana** the required accounts for instructions can now be specified using function annotations. [LucasSte](https://github.com/LucasSte)
+  ```
+  contract Foo {
+      @account(oneAccount)
+      @signer(mySigner)
+      @mutableAccount(otherAccount)
+      @mutableSigner(otherSigner)
+      function bar() external returns (uint64) {}
+  }
+  ```
+- The language server can now format Solidity source code using the `forge-fmt` crate. [chioni16](https://github.com/chioni16)
+- The langauge server can now do go references, go to implementation, and go to type
+  definition. [chioni16](https://github.com/chioni16)
+
+### Fixed
+- **Solana** the data field of AccountInfo can now be modified. [LucasSte](https://github.com/LucasSte)
+- The vscode extension now uses the solang binary in the path, if available. [seanyoung](https://github.com/seanyoung)
+
+### Changed
+- **breaking** **Solana** the contract Solidity type can no longer be used. This type
+  used to represent a single address, but this does not make sense as there are many
+  accounts associated with a contract call. [LucasSte](https://github.com/LucasSte)
+
 ## v0.3.2 Brasília
 
 The language server is much improved, and many fixes all over.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ the code base.
 - The vscode extension now uses the solang binary in the path, if available. [seanyoung](https://github.com/seanyoung)
 
 ### Changed
-- **breaking** **Solana** the contract Solidity type can no longer be used. This type
+- **BREAKING:** **Solana** the contract Solidity type can no longer be used. This type
   used to represent a single address, but this does not make sense as there are many
   accounts associated with a contract call. [LucasSte](https://github.com/LucasSte)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ will be documented here.
 ## v0.3.3 Atlantis
 
 This release improves the Solana developer experience, since now required
-accounts can be specified using annotations. There are many fixes all over
-the code base.
+accounts can be specified using annotations. For Polkadot, compatibility with
+Ethereum Solidity has been increased further, it is now possible to write 
+[EIP-1967](https://eips.ethereum.org/EIPS/eip-1967) compatible proxy contracts.
+There are many fixes all over the code base.
 
 ### Added
 - **Solana** the required accounts for instructions can now be specified using function annotations. [LucasSte](https://github.com/LucasSte)
@@ -22,11 +24,18 @@ the code base.
 - The language server can now format Solidity source code using the `forge-fmt` crate. [chioni16](https://github.com/chioni16)
 - The langauge server can now do go references, go to implementation, and go to type
   definition. [chioni16](https://github.com/chioni16)
+- **Polkadot** `Panic` errors can now be caught in try-catch statements [xermicus](https://github.com/xermicus) 
+- **Polkadot** custom errors are now supported [xermicus](https://github.com/xermicus) 
+- **Polkadot** now supporting the `address.code` builtin [xermicus](https://github.com/xermicus) 
 
 ### Fixed
 - **Solana** the data field of AccountInfo can now be modified. [LucasSte](https://github.com/LucasSte)
 - The vscode extension now uses the solang binary in the path, if available. [seanyoung](https://github.com/seanyoung)
-
+- Fixed a bug in the ABI encoding of dynamic arrays. [xermicus](https://github.com/xermicus)
+- Fixed a bug where loading from a storage struct member was not considered a storage read. 
+  [xermicus](https://github.com/xermicus) [seanyoung](https://github.com/seanyoung)
+- Fixed a compiler crash caused by chained assignments like `return a = b`.  [xermicus](https://github.com/xermicus) 
+- Variables declared in the return parameters no longer ignore the `storage` location. [xermicus](https://github.com/xermicus) 
 ### Changed
 - **BREAKING:** **Solana** the contract Solidity type can no longer be used. This type
   used to represent a single address, but this does not make sense as there are many

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ itertools = "0.11"
 num-rational = "0.4"
 indexmap = "2.0"
 once_cell = "1.18"
-solang-parser = { path = "solang-parser", version = "0.3.2" }
+solang-parser = { path = "solang-parser", version = "0.3.3" }
 codespan-reporting = "0.11"
 phf = { version = "0.11", features = ["macros"] }
 rust-lapper = "1.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/hyperledger/solang-llvm:ci-5 as builder
+FROM ghcr.io/hyperledger/solang-llvm:ci-6 as builder
 
 COPY . src
 WORKDIR /src/stdlib/

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -171,7 +171,7 @@ you may need to consult. `Ninja <https://ninja-build.org>`_ is necessary for bui
 
 .. code-block:: bash
 
-	git clone --depth 1 --branch solana-rustc/15.0-2022-08-09 https://github.com/solana-labs/llvm-project
+	git clone --depth 1 --branch solana-rustc/15.0-2022-12-07 https://github.com/solana-labs/llvm-project
 	cd llvm-project
 
 Now run cmake to create the makefiles. Replace the *installdir* argument to ``CMAKE_INSTALL_PREFIX`` with a directory where you would like to have LLVM installed, and then run the build:

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -28,11 +28,11 @@ Option 2: Download binaries
 
 There are binaries available on github releases:
 
-- `Linux x86-64 <https://github.com/hyperledger/solang/releases/download/v0.3.2/solang-linux-x86-64>`_
-- `Linux arm64 <https://github.com/hyperledger/solang/releases/download/v0.3.2/solang-linux-arm64>`_
-- `Windows x64 <https://github.com/hyperledger/solang/releases/download/v0.3.2/solang.exe>`_
-- `MacOS intel <https://github.com/hyperledger/solang/releases/download/v0.3.2/solang-mac-intel>`_
-- `MacOS arm <https://github.com/hyperledger/solang/releases/download/v0.3.2/solang-mac-arm>`_
+- `Linux x86-64 <https://github.com/hyperledger/solang/releases/download/v0.3.3/solang-linux-x86-64>`_
+- `Linux arm64 <https://github.com/hyperledger/solang/releases/download/v0.3.3/solang-linux-arm64>`_
+- `Windows x64 <https://github.com/hyperledger/solang/releases/download/v0.3.3/solang.exe>`_
+- `MacOS intel <https://github.com/hyperledger/solang/releases/download/v0.3.3/solang-mac-intel>`_
+- `MacOS arm <https://github.com/hyperledger/solang/releases/download/v0.3.3/solang-mac-arm>`_
 
 Download the file and save it somewhere in your ``$PATH``, for example the bin directory in your home directory. If the
 path you use is not already in ``$PATH``, then you need to add it yourself.
@@ -56,7 +56,7 @@ Option 3: Use ghcr.io/hyperledger/solang containers
 
 New images are automatically made available on
 `solang containers <https://github.com/hyperledger/solang/pkgs/container/solang>`_.
-There is a release `v0.3.2` tag and a `latest` tag:
+There is a release `v0.3.3` tag and a `latest` tag:
 
 .. code-block:: bash
 
@@ -126,8 +126,8 @@ Linux
 ~~~~~
 
 A pre-built version of LLVM, specifically configured for Solang, is available at
-`<https://github.com/hyperledger/solang-llvm/releases/download/llvm15-1/llvm15.0-linux-x86-64.tar.xz>`_ for x86 processors
-and at `<https://github.com/hyperledger/solang-llvm/releases/download/llvm15-1/llvm15.0-linux-arm64.tar.xz>`_ for ARM.
+`<https://github.com/hyperledger/solang-llvm/releases/download/llvm15-2/llvm15.0-linux-x86-64.tar.xz>`_ for x86 processors
+and at `<https://github.com/hyperledger/solang-llvm/releases/download/llvm15-2/llvm15.0-linux-arm64.tar.xz>`_ for ARM.
 After downloading, untar the file in a terminal and add it to your path.
 
 .. code-block:: bash
@@ -139,7 +139,7 @@ Windows
 ~~~~~~~
 
 A pre-built version of LLVM, specifically configured for Solang, is available at
-`<https://github.com/hyperledger/solang-llvm/releases/download/llvm15-1/llvm15.0-win.zip>`_.
+`<https://github.com/hyperledger/solang-llvm/releases/download/llvm15-2/llvm15.0-win.zip>`_.
 
 After unzipping the file, add the bin directory to your path.
 
@@ -151,8 +151,8 @@ Mac
 ~~~
 
 A pre-built version of LLVM for intel macs, is available at
-`<https://github.com/hyperledger/solang-llvm/releases/download/llvm15-1/llvm15.0-mac-intel.tar.xz>`_ and for arm macs there is
-`<https://github.com/hyperledger/solang-llvm/releases/download/llvm15-1/llvm15.0-mac-arm.tar.xz>`_. After downloading,
+`<https://github.com/hyperledger/solang-llvm/releases/download/llvm15-2/llvm15.0-mac-intel.tar.xz>`_ and for arm macs there is
+`<https://github.com/hyperledger/solang-llvm/releases/download/llvm15-2/llvm15.0-mac-arm.tar.xz>`_. After downloading,
 untar the file in a terminal and add it to your path like so:
 
 .. code-block:: bash

--- a/solang-parser/Cargo.toml
+++ b/solang-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solang-parser"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Sean Young <sean@mess.org>", "Lucas Steuernagel <lucas.tnagel@gmail.com>", "Cyrill Leutwiler <bigcyrill@hotmail.com>"]
 homepage = "https://github.com/hyperledger/solang"
 documentation = "https://solang.readthedocs.io/"

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -4,8 +4,12 @@
 	"description": "Use the solang compiler for syntax highlighting, compiler warnings and errors, and hovers",
 	"publisher": "solang",
 	"icon": "hl_solang.png",
-	"author": "Shivam Balikondwar <shivambalikondwar@icloud.com>",
-	"version": "0.3.2",
+	"contributors": [
+		"Shivam Balikondwar <shivambalikondwar@icloud.com>",
+		"Govardhan G D <chioni1620@gmail.com>",
+		"Sean Young <sean@mess.org>"
+	],
+	"version": "0.3.3",
 	"repository": "github.com/hyperledger/solang",
 	"engines": {
 		"vscode": "^1.43.0"


### PR DESCRIPTION
This release improves the Solana developer experience, since now required
accounts can be specified using annotations. For Polkadot, compatibility with
Ethereum Solidity has been increased further, it is now possible to write
[EIP-1967](https://eips.ethereum.org/EIPS/eip-1967) compatible proxy contracts.
There are many fixes all over the code base.

### Added
- **Solana** the required accounts for instructions can now be specified using function annotations. [LucasSte](https://github.com/LucasSte)
  ```
  contract Foo {
      @account(oneAccount)
      @signer(mySigner)
      @mutableAccount(otherAccount)
      @mutableSigner(otherSigner)
      function bar() external returns (uint64) {}
  }
  ```
- The language server can now format Solidity source code using the `forge-fmt` crate. [chioni16](https://github.com/chioni16)
- The langauge server can now do go references, go to implementation, and go to type
  definition. [chioni16](https://github.com/chioni16)
- **Polkadot** `Panic` errors can now be caught in try-catch statements [xermicus](https://github.com/xermicus)
- **Polkadot** custom errors are now supported [xermicus](https://github.com/xermicus)
- **Polkadot** now supporting the `address.code` builtin [xermicus](https://github.com/xermicus)

### Fixed
- **Solana** the data field of AccountInfo can now be modified. [LucasSte](https://github.com/LucasSte)
- The vscode extension now uses the solang binary in the path, if available. [seanyoung](https://github.com/seanyoung)
- Fixed a bug in the ABI encoding of dynamic arrays. [xermicus](https://github.com/xermicus)
- Fixed a bug where loading from a storage struct member was not considered a storage read.
  [xermicus](https://github.com/xermicus) [seanyoung](https://github.com/seanyoung)
- Fixed a compiler crash caused by chained assignments like `return a = b`.  [xermicus](https://github.com/xermicus)
- Variables declared in the return parameters no longer ignore the `storage` location. [xermicus](https://github.com/xermicus)

### Changed
- **BREAKING:** **Solana** the contract Solidity type can no longer be used. This type
  used to represent a single address, but this does not make sense as there are many
  accounts associated with a contract call. [LucasSte](https://github.com/LucasSte)
