### PR TITLE
Fix common lsp panics

### DIFF
--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -3,6 +3,9 @@
 - Update the version in `Cargo.toml`, `solang-parser/Cargo.toml`, the binary
   links in `docs/installing.rst`, and `CHANGELOG.md`. Remember to match the
   solang-parser version in the top level `Cargo.toml`.
+- Ensure the `CHANGELOG.md` and `vscode/CHANGELOG.md` are up to date.
+- If the vscode extension is going to be updated, fix the version in
+  `docs/extension.rst`.
 - Copy the contents of the CHANGELOG for this release into commit message,
   using `git commit -s --cleanup=whitespace` so the that the lines beginning
   with `#` are not removed.

--- a/docs/extension.rst
+++ b/docs/extension.rst
@@ -75,8 +75,8 @@ Once you have node and npm installed, you can build the extension like so:
     npm install -g vsce
     vsce package
 
-You should now have an extension file called solang-0.3.0.vsix which can be
-installed using ``code --install-extension solang-0.3.0.vsix``.
+You should now have an extension file called ``solang-0.3.3.vsix`` which can be
+installed using ``code --install-extension solang-0.3.3.vsix``.
 
 Alternatively, the extension is run from vscode itself.
 

--- a/src/abi/anchor.rs
+++ b/src/abi/anchor.rs
@@ -49,7 +49,7 @@ pub fn generate_anchor_idl(contract_no: usize, ns: &Namespace, contract_version:
 
     Idl {
         version: Version::parse(contract_version).unwrap().to_string(),
-        name: ns.contracts[contract_no].name.clone(),
+        name: ns.contracts[contract_no].id.name.clone(),
         docs,
         constants: vec![],
         instructions,
@@ -261,7 +261,8 @@ impl TypeManager<'_> {
         // If the existing type was declared outside a contract or if it is from the current contract,
         // we should change the name of the type we are adding now.
         if other_contract.is_none()
-            || other_contract.as_ref().unwrap() == &self.namespace.contracts[self.contract_no].name
+            || other_contract.as_ref().unwrap()
+                == &self.namespace.contracts[self.contract_no].id.name
         {
             let new_name = if let Some(this_name) = contract {
                 format!("{this_name}_{type_name}")

--- a/src/abi/mod.rs
+++ b/src/abi/mod.rs
@@ -21,7 +21,7 @@ pub fn generate_abi(
             if verbose {
                 eprintln!(
                     "info: Generating ink! metadata for contract {}",
-                    ns.contracts[contract_no].name
+                    ns.contracts[contract_no].id
                 );
             }
 
@@ -33,7 +33,7 @@ pub fn generate_abi(
             if verbose {
                 eprintln!(
                     "info: Generating Anchor metadata for contract {}",
-                    ns.contracts[contract_no].name
+                    ns.contracts[contract_no].id
                 );
             }
 
@@ -45,7 +45,7 @@ pub fn generate_abi(
             if verbose {
                 eprintln!(
                     "info: Generating Ethereum ABI for contract {}",
-                    ns.contracts[contract_no].name
+                    ns.contracts[contract_no].id
                 );
             }
 

--- a/src/abi/polkadot.rs
+++ b/src/abi/polkadot.rs
@@ -309,7 +309,7 @@ pub fn gen_project(contract_no: usize, ns: &ast::Namespace) -> InkProject {
             }
         })
         .collect();
-    let contract_name = ns.contracts[contract_no].name.clone();
+    let contract_name = ns.contracts[contract_no].id.name.clone();
     let storage = Layout::Struct(StructLayout::new(contract_name, fields));
 
     let constructor_spec = |f: &Function| -> ConstructorSpec<PortableForm> {
@@ -384,7 +384,7 @@ pub fn gen_project(contract_no: usize, ns: &ast::Namespace) -> InkProject {
 
                 let t = TypeDefTuple::new_portable(fields);
 
-                let path = path!(&ns.contracts[contract_no].name, &f.name, "return_type");
+                let path = path!(&ns.contracts[contract_no].id.name, &f.name, "return_type");
 
                 let ty = registry.register_type(Type::new(
                     path,
@@ -562,7 +562,7 @@ pub fn metadata(
     );
 
     let mut builder = Contract::builder();
-    builder.name(&ns.contracts[contract_no].name);
+    builder.name(&ns.contracts[contract_no].id.name);
     let mut description = tags(contract_no, "title", ns);
     description.extend(tags(contract_no, "notice", ns));
     if !description.is_empty() {

--- a/src/bin/doc/mod.rs
+++ b/src/bin/doc/mod.rs
@@ -186,7 +186,7 @@ pub fn generate_docs(outdir: &OsString, files: &[ast::Namespace], verbose: bool)
                 name: &event_decl.name,
                 contract: event_decl
                     .contract
-                    .map(|contract_no| file.contracts[contract_no].name.as_str()),
+                    .map(|contract_no| file.contracts[contract_no].id.name.as_str()),
                 title: get_tag("title", &event_decl.tags),
                 notice: get_tag("notice", &event_decl.tags),
                 author: get_tag("author", &event_decl.tags),
@@ -356,7 +356,7 @@ pub fn generate_docs(outdir: &OsString, files: &[ast::Namespace], verbose: bool)
                 for var in base
                     .variables
                     .iter()
-                    .map(|var| map_var(file, Some(&base.name), var))
+                    .map(|var| map_var(file, Some(&base.id.name), var))
                 {
                     base_variables.push(var);
                 }
@@ -365,7 +365,7 @@ pub fn generate_docs(outdir: &OsString, files: &[ast::Namespace], verbose: bool)
                     let f = &file.functions[*function_no];
 
                     if f.has_body {
-                        Some(map_func(file, Some(&base.name), f))
+                        Some(map_func(file, Some(&base.id.name), f))
                     } else {
                         None
                     }
@@ -376,7 +376,7 @@ pub fn generate_docs(outdir: &OsString, files: &[ast::Namespace], verbose: bool)
 
             top.contracts.push(Contract {
                 loc: contract.loc,
-                name: &contract.name,
+                name: &contract.id.name,
                 ty: format!("{}", contract.ty),
                 title: get_tag("title", &contract.tags),
                 notice: get_tag("notice", &contract.tags),

--- a/src/bin/languageserver/mod.rs
+++ b/src/bin/languageserver/mod.rs
@@ -906,7 +906,7 @@ impl<'a> Builder<'a> {
             }
             ast::Expression::ConstantVariable { loc, ty, contract_no, var_no } => {
                 let (contract, name) = if let Some(contract_no) = contract_no {
-                    let contract = format!("{}.", self.ns.contracts[*contract_no].name);
+                    let contract = format!("{}.", self.ns.contracts[*contract_no].id);
                     let name = &self.ns.contracts[*contract_no].variables[*var_no].name;
                     (contract, name)
                 } else {
@@ -945,7 +945,7 @@ impl<'a> Builder<'a> {
             ast::Expression::StorageVariable { loc, ty, contract_no, var_no } => {
                 let contract = &self.ns.contracts[*contract_no];
                 let name = &contract.variables[*var_no].name;
-                let val = format!("{} {}.{}", ty.to_string(self.ns), contract.name, name);
+                let val = format!("{} {}.{}", ty.to_string(self.ns), contract.id, name);
                 self.hovers.push((
                     loc.file_no(),
                     HoverEntry {
@@ -1083,7 +1083,7 @@ impl<'a> Builder<'a> {
                         msg
                     }).join(", ");
 
-                let contract = fnc.contract_no.map(|contract_no| format!("{}.", self.ns.contracts[contract_no].name)).unwrap_or_default();
+                let contract = fnc.contract_no.map(|contract_no| format!("{}.", self.ns.contracts[contract_no].id)).unwrap_or_default();
 
                 let val = format!("{} {}{}({}) returns ({})\n", fnc.ty, contract, fnc.name, params, rets);
 
@@ -1141,7 +1141,7 @@ impl<'a> Builder<'a> {
                         msg
                     }).join(", ");
 
-                let contract = fnc.contract_no.map(|contract_no| format!("{}.", self.ns.contracts[contract_no].name)).unwrap_or_default();
+                let contract = fnc.contract_no.map(|contract_no| format!("{}.", self.ns.contracts[contract_no].id)).unwrap_or_default();
 
                 let val = format!("{} {}{}({}) returns ({})\n", fnc.ty, contract, fnc.name, params, rets);
 
@@ -1563,7 +1563,7 @@ impl<'a> Builder<'a> {
                         stop: base.loc.exclusive_end(),
                         val: make_code_block(format!(
                             "contract {}",
-                            self.ns.contracts[base.contract_no].name
+                            self.ns.contracts[base.contract_no].id
                         )),
                     },
                 ));
@@ -1590,8 +1590,8 @@ impl<'a> Builder<'a> {
             self.hovers.push((
                 file_no,
                 HoverEntry {
-                    start: contract.loc.start(),
-                    stop: contract.loc.start() + contract.name.len(),
+                    start: contract.id.loc.start(),
+                    stop: contract.id.loc.exclusive_end(),
                     val: render(&contract.tags[..]),
                 },
             ));
@@ -1602,7 +1602,7 @@ impl<'a> Builder<'a> {
             };
 
             self.definitions
-                .insert(cdi.clone(), loc_to_range(&contract.loc, file));
+                .insert(cdi.clone(), loc_to_range(&contract.id.loc, file));
 
             let impls = contract
                 .functions

--- a/src/bin/languageserver/mod.rs
+++ b/src/bin/languageserver/mod.rs
@@ -1720,7 +1720,9 @@ impl<'a> Builder<'a> {
             .collect::<HashMap<PathBuf, usize>>();
 
         for val in self.types.values_mut() {
-            val.def_path = defs_to_files[&val.def_type].clone();
+            if let Some(path) = defs_to_files.get(&val.def_type) {
+                val.def_path = path.clone();
+            }
         }
 
         for (di, range) in &self.definitions {

--- a/src/bin/solang.rs
+++ b/src/bin/solang.rs
@@ -230,7 +230,7 @@ fn compile(compile_args: &Compile) {
             !namespaces
                 .iter()
                 .flat_map(|ns| ns.contracts.iter())
-                .any(|contract| **name == contract.name)
+                .any(|contract| **name == contract.id.name)
         })
         .collect();
 
@@ -370,15 +370,15 @@ fn contract_results(
 
     let loc = ns.loc_to_string(PathDisplay::FullPath, &resolved_contract.loc);
 
-    if let Some(other_loc) = seen_contracts.get(&resolved_contract.name) {
+    if let Some(other_loc) = seen_contracts.get(&resolved_contract.id.name) {
         eprintln!(
             "error: contract {} defined at {other_loc} and {}",
-            resolved_contract.name, loc
+            resolved_contract.id, loc
         );
         exit(1);
     }
 
-    seen_contracts.insert(resolved_contract.name.to_string(), loc);
+    seen_contracts.insert(resolved_contract.id.to_string(), loc);
 
     if let Some("cfg") = compiler_output.emit.as_deref() {
         println!("{}", resolved_contract.print_cfg(ns));
@@ -389,13 +389,13 @@ fn contract_results(
         if ns.target == solang::Target::Solana {
             eprintln!(
                 "info: contract {} uses at least {} bytes account data",
-                resolved_contract.name, resolved_contract.fixed_layout_size,
+                resolved_contract.id, resolved_contract.fixed_layout_size,
             );
         }
 
         eprintln!(
             "info: Generating LLVM IR for contract {} with target {}",
-            resolved_contract.name, ns.target
+            resolved_contract.id, ns.target
         );
     }
 
@@ -413,7 +413,7 @@ fn contract_results(
     if let Some(level) = opt.wasm_opt.filter(|_| ns.target.is_polkadot() && verbose) {
         eprintln!(
             "info: wasm-opt level '{}' for contract {}",
-            level, resolved_contract.name
+            level, resolved_contract.id
         );
     }
 

--- a/src/codegen/cfg.rs
+++ b/src/codegen/cfg.rs
@@ -1283,7 +1283,7 @@ impl ControlFlowGraph {
                 } else {
                     String::new()
                 },
-                ns.contracts[*contract_no].name,
+                ns.contracts[*contract_no].id,
                 self.expr_to_string(contract, ns, encoded_args),
                 if let ExternalCallAccounts::Present(accounts) = accounts {
                     self.expr_to_string(contract, ns, accounts)
@@ -1615,9 +1615,9 @@ fn function_cfg(
     let contract_name = match func.contract_no {
         Some(base_contract_no) => format!(
             "{}::{}",
-            ns.contracts[contract_no].name, ns.contracts[base_contract_no].name
+            ns.contracts[contract_no].id, ns.contracts[base_contract_no].id
         ),
-        None => ns.contracts[contract_no].name.to_string(),
+        None => ns.contracts[contract_no].id.to_string(),
     };
 
     let name = match func.ty {
@@ -1889,8 +1889,8 @@ fn generate_modifier_dispatch(
     let modifier = &ns.functions[modifier_no];
     let name = format!(
         "{}::{}::{}::modifier{}::{}",
-        &ns.contracts[contract_no].name,
-        &ns.contracts[func.contract_no.unwrap()].name,
+        &ns.contracts[contract_no].id,
+        &ns.contracts[func.contract_no.unwrap()].id,
         func.llvm_symbol(ns),
         chain_no,
         modifier.llvm_symbol(ns)
@@ -2032,7 +2032,7 @@ fn generate_modifier_dispatch(
 impl Contract {
     /// Print the entire contract; storage initializers, constructors and functions and their CFGs
     pub fn print_cfg(&self, ns: &Namespace) -> String {
-        let mut out = format!("#\n# Contract: {}\n#\n\n", self.name);
+        let mut out = format!("#\n# Contract: {}\n#\n\n", self.id);
 
         for cfg in &self.cfg {
             if !cfg.is_placeholder() {

--- a/src/codegen/events/polkadot.rs
+++ b/src/codegen/events/polkadot.rs
@@ -46,7 +46,7 @@ impl EventEmitter for PolkadotEventEmitter<'_> {
         let loc = pt::Loc::Builtin;
         let event = &self.ns.events[self.event_no];
         // For freestanding events the name of the emitting contract is used
-        let contract_name = &self.ns.contracts[event.contract.unwrap_or(contract_no)].name;
+        let contract_name = &self.ns.contracts[event.contract.unwrap_or(contract_no)].id;
         let hash_len = Box::new(Expression::NumberLiteral {
             loc,
             ty: Type::Uint(32),

--- a/src/codegen/solana_accounts/account_collection.rs
+++ b/src/codegen/solana_accounts/account_collection.rs
@@ -339,7 +339,7 @@ fn check_instruction(instr: &Instr, data: &mut RecurseData) {
                 // If it is not a literal, we assume users are fetching it from a declared account
                 // (@account(my_id) => tx.accounts.my_id.key)
                 if matches!(address, Expression::NumberLiteral { .. }) {
-                    data.add_program_id(&data.contracts[*contract_no].name);
+                    data.add_program_id(&data.contracts[*contract_no].id.name);
                 }
 
                 address.recurse(data, check_expression);
@@ -355,7 +355,7 @@ fn check_instruction(instr: &Instr, data: &mut RecurseData) {
                 transfer_accounts(loc, *contract_no, *constructor_no, data);
             } else {
                 data.add_account(
-                    format!("{}_dataAccount", data.contracts[*contract_no].name),
+                    format!("{}_dataAccount", data.contracts[*contract_no].id),
                     &SolanaAccount {
                         loc: *loc,
                         is_signer: false,
@@ -421,7 +421,7 @@ fn check_instruction(instr: &Instr, data: &mut RecurseData) {
 
             if let Some((contract_no, function_no)) = contract_function_no {
                 if should_add_program_id {
-                    data.add_program_id(&data.contracts[*contract_no].name);
+                    data.add_program_id(&data.contracts[*contract_no].id.name);
                 }
                 if accounts.is_absent() {
                     transfer_accounts(loc, *contract_no, *function_no, data);
@@ -506,7 +506,7 @@ fn transfer_accounts(
 
     for (name, mut account) in accounts_to_add {
         if name == BuiltinAccounts::DataAccount {
-            let idl_name = format!("{}_dataAccount", data.contracts[contract_no].name);
+            let idl_name = format!("{}_dataAccount", data.contracts[contract_no].id);
             if let Some(acc) = data.functions[data.ast_no]
                 .solana_accounts
                 .borrow()
@@ -517,7 +517,7 @@ fn transfer_accounts(
                         Diagnostic::error_with_note(
                             *loc,
                             format!("contract '{}' is called more than once in this function, so automatic account collection cannot happen. \
-                                         Please, provide the necessary accounts using the {{accounts:..}} call argument", data.contracts[contract_no].name),
+                                         Please, provide the necessary accounts using the {{accounts:..}} call argument", data.contracts[contract_no].id),
                             acc.loc,
                             "other call".to_string(),
                         )

--- a/src/codegen/solana_accounts/account_management.rs
+++ b/src/codegen/solana_accounts/account_management.rs
@@ -125,7 +125,7 @@ fn process_instruction(
             let constructor_func = &functions[*func_no];
             for (name, account) in constructor_func.solana_accounts.borrow().iter() {
                 let name_to_index = if name == BuiltinAccounts::DataAccount {
-                    format!("{}_dataAccount", contracts[*contract_no].name)
+                    format!("{}_dataAccount", contracts[*contract_no].id)
                 } else {
                     name.clone()
                 };
@@ -160,7 +160,7 @@ fn process_instruction(
             accounts,
             ..
         } => {
-            let name_to_index = format!("{}_dataAccount", contracts[*contract_no].name);
+            let name_to_index = format!("{}_dataAccount", contracts[*contract_no].id);
             let account_index = functions[ast_no]
                 .solana_accounts
                 .borrow()

--- a/src/codegen/yul/mod.rs
+++ b/src/codegen/yul/mod.rs
@@ -62,7 +62,7 @@ fn yul_function_cfg(
 
     let func_name = format!(
         "{}::yul_function_{}::{}",
-        ns.contracts[contract_no].name, function_no, yul_func.name
+        ns.contracts[contract_no].id, function_no, yul_func.name
     );
     let mut cfg = ControlFlowGraph::new(func_name, ASTFunction::YulFunction(function_no));
 

--- a/src/codegen/yul/tests/expression.rs
+++ b/src/codegen/yul/tests/expression.rs
@@ -13,7 +13,7 @@ use crate::sema::yul::ast::YulSuffix;
 use crate::{sema, Target};
 use num_bigint::{BigInt, Sign};
 use once_cell::unsync::OnceCell;
-use solang_parser::pt::{ContractTy, Loc, StorageLocation, Visibility};
+use solang_parser::pt::{self, ContractTy, Loc, StorageLocation, Visibility};
 
 #[test]
 fn bool_literal() {
@@ -139,7 +139,10 @@ fn contract_constant_variable() {
         tags: vec![],
         loc,
         ty: ContractTy::Contract(loc),
-        name: "".to_string(),
+        id: pt::Identifier {
+            name: "".to_string(),
+            loc: pt::Loc::Codegen,
+        },
         bases: vec![],
         using: vec![],
         layout: vec![],
@@ -274,7 +277,10 @@ fn slot_suffix() {
         tags: vec![],
         loc: Loc::Builtin,
         ty: ContractTy::Contract(loc),
-        name: "".to_string(),
+        id: pt::Identifier {
+            name: "".to_string(),
+            loc: pt::Loc::Builtin,
+        },
         bases: vec![],
         using: vec![],
         layout: vec![layout],

--- a/src/emit/polkadot/mod.rs
+++ b/src/emit/polkadot/mod.rs
@@ -34,7 +34,7 @@ impl PolkadotTarget {
         let mut binary = Binary::new(
             context,
             ns.target,
-            &contract.name,
+            &contract.id.name,
             filename.as_str(),
             opt,
             std_lib,

--- a/src/emit/polkadot/target.rs
+++ b/src/emit/polkadot/target.rs
@@ -851,7 +851,7 @@ impl<'a> TargetRuntime<'a> for PolkadotTarget {
 
         // code hash
         let codehash = binary.emit_global_string(
-            &format!("binary_{}_codehash", created_contract.name),
+            &format!("binary_{}_codehash", created_contract.id),
             blake2_rfc::blake2b::blake2b(32, &[], &code).as_bytes(),
             true,
         );

--- a/src/emit/solana/mod.rs
+++ b/src/emit/solana/mod.rs
@@ -37,7 +37,7 @@ impl SolanaTarget {
         let mut binary = Binary::new(
             context,
             Target::Solana,
-            &contract.name,
+            &contract.id.name,
             filename.as_str(),
             opt,
             std_lib,

--- a/src/sema/ast.rs
+++ b/src/sema/ast.rs
@@ -530,18 +530,6 @@ impl Function {
     pub fn is_private(&self) -> bool {
         matches!(self.visibility, pt::Visibility::Private(_))
     }
-
-    /// Print the function type, contract name, and name
-    pub fn print_name(&self, ns: &Namespace) -> String {
-        if let Some(contract_no) = &self.contract_no {
-            format!(
-                "{} {}.{}",
-                self.ty, ns.contracts[*contract_no].id, self.name
-            )
-        } else {
-            format!("{} {}", self.ty, self.name)
-        }
-    }
 }
 
 impl From<&pt::Type> for Type {

--- a/src/sema/ast.rs
+++ b/src/sema/ast.rs
@@ -181,7 +181,7 @@ pub struct EventDecl {
 impl EventDecl {
     pub fn symbol_name(&self, ns: &Namespace) -> String {
         match &self.contract {
-            Some(c) => format!("{}.{}", ns.contracts[*c].name, self.name),
+            Some(c) => format!("{}.{}", ns.contracts[*c].id, self.name),
             None => self.name.to_string(),
         }
     }
@@ -200,7 +200,7 @@ pub struct ErrorDecl {
 impl ErrorDecl {
     pub fn symbol_name(&self, ns: &Namespace) -> String {
         match &self.contract {
-            Some(c) => format!("{}.{}", ns.contracts[*c].name, self.name),
+            Some(c) => format!("{}.{}", ns.contracts[*c].id, self.name),
             None => self.name.to_string(),
         }
     }
@@ -536,7 +536,7 @@ impl Function {
         if let Some(contract_no) = &self.contract_no {
             format!(
                 "{} {}.{}",
-                self.ty, ns.contracts[*contract_no].name, self.name
+                self.ty, ns.contracts[*contract_no].id, self.name
             )
         } else {
             format!("{} {}", self.ty, self.name)
@@ -749,7 +749,7 @@ pub struct Contract {
     pub tags: Vec<Tag>,
     pub loc: pt::Loc,
     pub ty: pt::ContractTy,
-    pub name: String,
+    pub id: pt::Identifier,
     pub bases: Vec<Base>,
     pub using: Vec<Using>,
     pub layout: Vec<Layout>,

--- a/src/sema/contracts.rs
+++ b/src/sema/contracts.rs
@@ -632,11 +632,11 @@ fn check_inheritance(contract_no: usize, ns: &mut ast::Namespace) {
                     diagnostics.push(ast::Diagnostic::error_with_note(
                         loc,
                         format!(
-                            "contract '{}' missing override for '{}' function",
+                            "contract '{}' missing override for {} function",
                             ns.contracts[contract_no].id, func.ty
                         ),
                         func.loc,
-                        format!("declaration of '{}' function", func.ty),
+                        format!("declaration of {} function", func.ty),
                     ));
                 }
                 _ => diagnostics.push(ast::Diagnostic::error_with_note(

--- a/src/sema/contracts.rs
+++ b/src/sema/contracts.rs
@@ -24,11 +24,16 @@ use tiny_keccak::{Hasher, Keccak};
 
 impl ast::Contract {
     /// Create a new contract, abstract contract, interface or library
-    pub fn new(name: &str, ty: pt::ContractTy, tags: Vec<ast::Tag>, loc: pt::Loc) -> Self {
+    pub fn new(
+        name: &pt::Identifier,
+        ty: pt::ContractTy,
+        tags: Vec<ast::Tag>,
+        loc: pt::Loc,
+    ) -> Self {
         let instantiable = matches!(ty, pt::ContractTy::Contract(_));
 
         ast::Contract {
-            name: name.to_owned(),
+            id: name.clone(),
             loc,
             ty,
             bases: Vec::new(),
@@ -56,7 +61,7 @@ impl ast::Contract {
     pub fn selector(&self) -> u32 {
         let mut hasher = Keccak::v256();
         let mut hash = [0u8; 32];
-        hasher.update(self.name.as_bytes());
+        hasher.update(self.id.name.as_bytes());
         hasher.finalize(&mut hash);
 
         u32::from_le_bytes(hash[0..4].try_into().unwrap())
@@ -119,7 +124,7 @@ pub fn resolve_base_contracts(
                     base.loc,
                     format!(
                         "library '{}' cannot have a base contract",
-                        ns.contracts[contract.contract_no].name
+                        ns.contracts[contract.contract_no].id
                     ),
                 ));
                 continue;
@@ -140,7 +145,7 @@ pub fn resolve_base_contracts(
                         name.loc,
                         format!(
                             "contract '{}' duplicate base '{}'",
-                            ns.contracts[contract.contract_no].name, name
+                            ns.contracts[contract.contract_no].id, name
                         ),
                     ));
                 } else if is_base(contract.contract_no, no, ns) {
@@ -148,7 +153,7 @@ pub fn resolve_base_contracts(
                         name.loc,
                         format!(
                             "base '{}' from contract '{}' is cyclic",
-                            name, ns.contracts[contract.contract_no].name
+                            name, ns.contracts[contract.contract_no].id
                         ),
                     ));
                 } else if ns.contracts[contract.contract_no].is_interface()
@@ -158,7 +163,7 @@ pub fn resolve_base_contracts(
                         name.loc,
                         format!(
                             "interface '{}' cannot have {} '{}' as a base",
-                            ns.contracts[contract.contract_no].name, ns.contracts[no].ty, name
+                            ns.contracts[contract.contract_no].id, ns.contracts[no].ty, name
                         ),
                     ));
                 } else if ns.contracts[no].is_library() {
@@ -168,7 +173,7 @@ pub fn resolve_base_contracts(
                         name.loc,
                         format!(
                             "library '{}' cannot be used as base contract for {} '{}'",
-                            name, contract.ty, contract.name,
+                            name, contract.ty, contract.id,
                         ),
                     ));
                 } else {
@@ -365,7 +370,7 @@ fn check_inheritance(contract_no: usize, ns: &mut ast::Namespace) {
 
                 let source_override = entry
                     .iter()
-                    .map(|(contract_no, _)| -> &str { &ns.contracts[*contract_no].name })
+                    .map(|(contract_no, _)| -> &str { &ns.contracts[*contract_no].id.name })
                     .collect::<Vec<&str>>()
                     .join(",");
 
@@ -387,7 +392,7 @@ fn check_inheritance(contract_no: usize, ns: &mut ast::Namespace) {
                         // List of contract which should have been specified
                         let missing: Vec<String> = override_needed
                             .difference(&override_specified)
-                            .map(|contract_no| ns.contracts[*contract_no].name.to_owned())
+                            .map(|contract_no| ns.contracts[*contract_no].id.name.to_owned())
                             .collect();
 
                         if !missing.is_empty() && override_needed.len() >= 2 {
@@ -405,7 +410,7 @@ fn check_inheritance(contract_no: usize, ns: &mut ast::Namespace) {
                         // List of contract which should not have been specified
                         let extra: Vec<String> = override_specified
                             .difference(&override_needed)
-                            .map(|contract_no| ns.contracts[*contract_no].name.to_owned())
+                            .map(|contract_no| ns.contracts[*contract_no].id.name.to_owned())
                             .collect();
 
                         if !extra.is_empty() {
@@ -576,7 +581,7 @@ fn check_inheritance(contract_no: usize, ns: &mut ast::Namespace) {
                                 *loc,
                                 format!(
                                     "function '{}' override list does not contain '{}'",
-                                    cur.name, ns.contracts[prev_contract_no].name
+                                    cur.name, ns.contracts[prev_contract_no].id
                                 ),
                                 func_prev.loc,
                                 format!("previous definition of function '{}'", func_prev.name),
@@ -628,7 +633,7 @@ fn check_inheritance(contract_no: usize, ns: &mut ast::Namespace) {
                         loc,
                         format!(
                             "contract '{}' missing override for '{}' function",
-                            ns.contracts[contract_no].name, func.ty
+                            ns.contracts[contract_no].id, func.ty
                         ),
                         func.loc,
                         format!("declaration of '{}' function", func.ty),
@@ -638,7 +643,7 @@ fn check_inheritance(contract_no: usize, ns: &mut ast::Namespace) {
                     loc,
                     format!(
                         "contract '{}' missing override for function '{}'",
-                        ns.contracts[contract_no].name, func.name
+                        ns.contracts[contract_no].id, func.name
                     ),
                     func.loc,
                     format!("declaration of function '{}'", func.name),
@@ -729,7 +734,7 @@ fn polkadot_requires_public_functions(contract_no: usize, ns: &mut ast::Namespac
             }
         })
     {
-        let message = format!("contracts without public storage or functions are not allowed on Polkadot. Consider declaring this contract abstract: 'abstract contract {}'", contract.name);
+        let message = format!("contracts without public storage or functions are not allowed on Polkadot. Consider declaring this contract abstract: 'abstract contract {}'", contract.id);
         contract.instantiable = false;
 
         ns.diagnostics
@@ -1108,12 +1113,12 @@ pub fn collect_base_args<'a>(
                     *loc,
                     format!(
                         "duplicate argument for base contract '{}'",
-                        ns.contracts[*base_no].name
+                        ns.contracts[*base_no].id
                     ),
                     *prev_args.loc,
                     format!(
                         "previous argument for base contract '{}'",
-                        ns.contracts[*base_no].name
+                        ns.contracts[*base_no].id
                     ),
                 ));
             } else {
@@ -1139,12 +1144,12 @@ pub fn collect_base_args<'a>(
                     base.loc,
                     format!(
                         "duplicate argument for base contract '{}'",
-                        ns.contracts[base.contract_no].name
+                        ns.contracts[base.contract_no].id
                     ),
                     *prev_args.loc,
                     format!(
                         "previous argument for base contract '{}'",
-                        ns.contracts[base.contract_no].name
+                        ns.contracts[base.contract_no].id
                     ),
                 ));
             } else {
@@ -1218,7 +1223,7 @@ fn check_base_args(contract_no: usize, ns: &mut ast::Namespace) {
                         contract.loc,
                         format!(
                             "missing arguments to base contract '{}' constructor",
-                            ns.contracts[*base_no].name
+                            ns.contracts[*base_no].id
                         ),
                     ));
                 }
@@ -1235,7 +1240,7 @@ fn check_base_args(contract_no: usize, ns: &mut ast::Namespace) {
                     contract.loc,
                     format!(
                         "missing arguments to base contract '{}' constructor",
-                        ns.contracts[*base_no].name
+                        ns.contracts[*base_no].id
                     ),
                 ));
             }

--- a/src/sema/dotgraphviz.rs
+++ b/src/sema/dotgraphviz.rs
@@ -134,7 +134,7 @@ impl Dot {
         ];
 
         if let Some(contract) = func.contract_no {
-            labels.insert(1, format!("contract: {}", ns.contracts[contract].name));
+            labels.insert(1, format!("contract: {}", ns.contracts[contract].id));
         }
 
         if func.ty == pt::FunctionTy::Constructor || func.ty == pt::FunctionTy::Function {
@@ -153,7 +153,7 @@ impl Dot {
                 labels.push(String::from("override"));
             } else {
                 for is_override in is_overrides {
-                    labels.push(format!("override {}", ns.contracts[*is_override].name));
+                    labels.push(format!("override {}", ns.contracts[*is_override].id));
                 }
             }
         }
@@ -244,8 +244,8 @@ impl Dot {
         for (base_no, (_, _, args)) in &func.bases {
             let node = self.add_node(
                 Node::new(
-                    &ns.contracts[*base_no].name,
-                    vec![ns.contracts[*base_no].name.to_string()],
+                    &ns.contracts[*base_no].id.name,
+                    vec![ns.contracts[*base_no].id.to_string()],
                 ),
                 Some(func_node),
                 Some(String::from("base")),
@@ -302,7 +302,7 @@ impl Dot {
                     format!(
                         "code {}literal contract {}",
                         if *runtime { "runtime " } else { "" },
-                        ns.contracts[*contract_no].name,
+                        ns.contracts[*contract_no].id,
                     ),
                     ns.loc_to_string(PathDisplay::FullPath, loc),
                 ];
@@ -1211,10 +1211,7 @@ impl Dot {
                 let func = &ns.functions[*function_no];
 
                 if let Some(contract_no) = func.contract_no {
-                    labels.insert(
-                        1,
-                        format!("{}.{}", ns.contracts[contract_no].name, func.name),
-                    )
+                    labels.insert(1, format!("{}.{}", ns.contracts[contract_no].id, func.name))
                 } else {
                     labels.insert(1, format!("free function {}", func.name))
                 }
@@ -1243,7 +1240,7 @@ impl Dot {
                 let f = &ns.functions[*function_no];
 
                 if let Some(contract_no) = f.contract_no {
-                    labels.insert(1, format!("{}.{}", ns.contracts[contract_no].name, f.name))
+                    labels.insert(1, format!("{}.{}", ns.contracts[contract_no].id, f.name))
                 }
 
                 let node = self.add_node(
@@ -1333,7 +1330,7 @@ impl Dot {
                 ..
             } => {
                 let labels = vec![
-                    format!("constructor contract {}", ns.contracts[*contract_no].name),
+                    format!("constructor contract {}", ns.contracts[*contract_no].id),
                     ns.loc_to_string(PathDisplay::FullPath, loc),
                 ];
 
@@ -1386,7 +1383,7 @@ impl Dot {
             }
             Expression::InterfaceId { loc, contract_no } => {
                 let labels = vec![
-                    format!("interfaceid contract {}", ns.contracts[*contract_no].name),
+                    format!("interfaceid contract {}", ns.contracts[*contract_no].id),
                     ns.loc_to_string(PathDisplay::FullPath, loc),
                 ];
 
@@ -2077,7 +2074,7 @@ impl Dot {
                 1,
                 format!(
                     "{}.{}",
-                    ns.contracts[*contract].name, ns.contracts[*contract].variables[var_no].name
+                    ns.contracts[*contract].id, ns.contracts[*contract].variables[var_no].name
                 ),
             );
         } else {
@@ -2105,7 +2102,7 @@ impl Dot {
             String::from("storage variable"),
             format!(
                 "{}.{}",
-                ns.contracts[contract].name, ns.contracts[contract].variables[var_no].name
+                ns.contracts[contract].id, ns.contracts[contract].variables[var_no].name
             ),
             ty.to_string(ns),
             ns.loc_to_string(PathDisplay::FullPath, loc),
@@ -2591,7 +2588,7 @@ impl Namespace {
                 Node::new(
                     "contract",
                     vec![
-                        format!("contract {}", c.name),
+                        format!("contract {}", c.id),
                         self.loc_to_string(PathDisplay::FullPath, &c.loc),
                     ],
                 ),
@@ -2606,7 +2603,7 @@ impl Namespace {
                     Node::new(
                         "base",
                         vec![
-                            format!("base {}", self.contracts[base.contract_no].name),
+                            format!("base {}", self.contracts[base.contract_no].id),
                             self.loc_to_string(PathDisplay::FullPath, &base.loc),
                         ],
                     ),
@@ -2672,7 +2669,7 @@ impl Namespace {
                     UsingList::Library(library_no) => {
                         let library = &self.contracts[*library_no];
 
-                        vec![format!("library {}", library.name)]
+                        vec![format!("library {}", library.id)]
                     }
                 };
 

--- a/src/sema/expression/constructor.rs
+++ b/src/sema/expression/constructor.rs
@@ -33,7 +33,7 @@ fn constructor(
                 *loc,
                 format!(
                     "new cannot construct current contract '{}'",
-                    ns.contracts[no].name
+                    ns.contracts[no].id
                 ),
             ));
             return Err(());
@@ -53,7 +53,7 @@ fn constructor(
             *loc,
             format!(
                 "cannot construct '{}' of type '{}'",
-                ns.contracts[no].name, ns.contracts[no].ty
+                ns.contracts[no].id, ns.contracts[no].ty
             ),
         ));
 
@@ -66,7 +66,7 @@ fn constructor(
             *loc,
             format!(
                 "circular reference creating contract '{}'",
-                ns.contracts[no].name
+                ns.contracts[no].id
             ),
         ));
         return Err(());
@@ -246,7 +246,7 @@ pub fn constructor_named_args(
                 *loc,
                 format!(
                     "new cannot construct current contract '{}'",
-                    ns.contracts[no].name
+                    ns.contracts[no].id
                 ),
             ));
             return Err(());
@@ -266,7 +266,7 @@ pub fn constructor_named_args(
             *loc,
             format!(
                 "cannot construct '{}' of type '{}'",
-                ns.contracts[no].name, ns.contracts[no].ty
+                ns.contracts[no].id, ns.contracts[no].ty
             ),
         ));
 
@@ -279,7 +279,7 @@ pub fn constructor_named_args(
             *loc,
             format!(
                 "circular reference creating contract '{}'",
-                ns.contracts[no].name
+                ns.contracts[no].id
             ),
         ));
         return Err(());
@@ -615,8 +615,7 @@ pub(super) fn solana_constructor_check(
             *loc,
             format!(
                 "cannot construct '{}' of type '{}'",
-                ns.contracts[constructor_contract_no].name,
-                ns.contracts[constructor_contract_no].ty
+                ns.contracts[constructor_contract_no].id, ns.contracts[constructor_contract_no].ty
             ),
         ));
     }
@@ -627,7 +626,7 @@ pub(super) fn solana_constructor_check(
                 *loc,
                 format!(
                     "circular reference creating contract '{}'",
-                    ns.contracts[constructor_contract_no].name
+                    ns.contracts[constructor_contract_no].id
                 ),
             ));
         }

--- a/src/sema/expression/function_call.rs
+++ b/src/sema/expression/function_call.rs
@@ -2692,7 +2692,7 @@ fn contract_call_named_args(
                 *loc,
                 format!(
                     "contract '{}' does not have function '{}'",
-                    ns.contracts[external_contract_no].name, func_name.name
+                    ns.contracts[external_contract_no].id, func_name.name
                 ),
             ));
         }
@@ -2936,7 +2936,7 @@ fn preprocess_contract_call<T>(
                 *loc,
                 format!(
                     "'{}' constructor takes no argument",
-                    ns.contracts[external_contract_no].name
+                    ns.contracts[external_contract_no].id
                 ),
             ));
             return PreProcessedCall::Error;

--- a/src/sema/expression/member_access.rs
+++ b/src/sema/expression/member_access.rs
@@ -114,7 +114,7 @@ pub(super) fn member_access(
                             e.loc(),
                             format!(
                                 "contract '{}' does not have a member called '{}'",
-                                ns.contracts[call_contract_no].name, id.name,
+                                ns.contracts[call_contract_no].id, id.name,
                             ),
                         ));
                         Err(())
@@ -125,7 +125,7 @@ pub(super) fn member_access(
                             e.loc(),
                             format!(
                                 "function '{}' of contract '{}' is overloaded",
-                                id.name, ns.contracts[call_contract_no].name,
+                                id.name, ns.contracts[call_contract_no].id,
                             ),
                         ));
                         Err(())
@@ -428,7 +428,7 @@ pub(super) fn member_access(
                         format!(
                             "{} '{}' has no public function '{}'",
                             ns.contracts[ref_contract_no].ty,
-                            ns.contracts[ref_contract_no].name,
+                            ns.contracts[ref_contract_no].id,
                             id.name
                         ),
                     ));
@@ -442,7 +442,7 @@ pub(super) fn member_access(
                             "function '{}' of {} '{}' is overloaded",
                             id.name,
                             ns.contracts[ref_contract_no].ty,
-                            ns.contracts[ref_contract_no].name
+                            ns.contracts[ref_contract_no].id
                         ),
                     ));
                     Err(())
@@ -534,7 +534,7 @@ fn contract_constant(
                         *loc,
                         format!(
                             "need instance of contract '{}' to get variable value '{}'",
-                            ns.contracts[contract_no].name,
+                            ns.contracts[contract_no].id,
                             ns.contracts[contract_no].variables[var_no].name,
                         ),
                     ));
@@ -688,7 +688,7 @@ fn type_name_expr(
         (Type::Contract(n), "name") => Ok(Expression::BytesLiteral {
             loc: *loc,
             ty: Type::String,
-            value: ns.contracts[*n].name.as_bytes().to_vec(),
+            value: ns.contracts[*n].id.name.as_bytes().to_vec(),
         }),
         (Type::Contract(n), "interfaceId") => {
             let contract = &ns.contracts[*n];
@@ -698,7 +698,7 @@ fn type_name_expr(
                     *loc,
                     format!(
                         "type(…).interfaceId is permitted on interface, not {} {}",
-                        contract.ty, contract.name
+                        contract.ty, contract.id
                     ),
                 ));
                 Err(())
@@ -723,7 +723,7 @@ fn type_name_expr(
                     *loc,
                     format!(
                         "{} '{}' has no declared program_id",
-                        contract.ty, contract.name
+                        contract.ty, contract.id
                     ),
                 ));
                 Err(())
@@ -750,7 +750,7 @@ fn type_name_expr(
                     *loc,
                     format!(
                         "containing our own contract code for '{}' would generate infinite size contract",
-                        ns.contracts[*no].name
+                        ns.contracts[*no].id
                     ),
                 ));
                 return Err(());
@@ -761,7 +761,7 @@ fn type_name_expr(
                     *loc,
                     format!(
                         "circular reference creating contract code for '{}'",
-                        ns.contracts[*no].name
+                        ns.contracts[*no].id
                     ),
                 ));
                 return Err(());

--- a/src/sema/file.rs
+++ b/src/sema/file.rs
@@ -82,11 +82,13 @@ impl File {
     }
 
     /// Convert line + char to offset
-    pub fn get_offset(&self, line_no: usize, column_no: usize) -> usize {
+    pub fn get_offset(&self, line_no: usize, column_no: usize) -> Option<usize> {
         if line_no == 0 {
-            column_no
+            Some(column_no)
         } else {
-            self.line_starts[line_no - 1] + column_no
+            self.line_starts
+                .get(line_no - 1)
+                .map(|offset| offset + column_no)
         }
     }
 

--- a/src/sema/functions.rs
+++ b/src/sema/functions.rs
@@ -37,7 +37,7 @@ pub fn contract_function(
         pt::FunctionTy::Function => {
             // Function name cannot be the same as the contract name
             if let Some(n) = &func.name {
-                if n.name == ns.contracts[contract_no].name {
+                if n.name == ns.contracts[contract_no].id.name {
                     ns.diagnostics.push(Diagnostic::error(
                         func.loc,
                         "function cannot have same name as the contract".to_string(),
@@ -206,7 +206,7 @@ pub fn contract_function(
                                 name.loc,
                                 format!(
                                     "override '{}' is not a base contract of '{}'",
-                                    name, ns.contracts[contract_no].name
+                                    name, ns.contracts[contract_no].id
                                 ),
                             ));
                         } else {
@@ -1112,7 +1112,10 @@ fn signatures() {
     let mut ns = Namespace::new(Target::EVM);
 
     ns.contracts.push(ast::Contract::new(
-        "bar",
+        &pt::Identifier {
+            name: "bar".to_string(),
+            loc: pt::Loc::Implicit,
+        },
         pt::ContractTy::Contract(pt::Loc::Implicit),
         Vec::new(),
         pt::Loc::Implicit,

--- a/src/sema/statements.rs
+++ b/src/sema/statements.rs
@@ -106,7 +106,7 @@ pub fn resolve_function_body(
                                 *loc,
                                 format!(
                                     "contract '{}' is not a base contract of '{}'",
-                                    base.name, ns.contracts[contract_no].name,
+                                    base.name, ns.contracts[contract_no].id,
                                 ),
                             ));
                             all_ok = false;
@@ -173,7 +173,7 @@ pub fn resolve_function_body(
                         def.loc,
                         format!(
                             "missing arguments to contract '{}' constructor",
-                            ns.contracts[base.contract_no].name
+                            ns.contracts[base.contract_no].id
                         ),
                     ));
                 }

--- a/src/sema/tags.rs
+++ b/src/sema/tags.rs
@@ -167,7 +167,7 @@ pub fn resolve_tags(
                     .as_ref()
                     .unwrap()
                     .iter()
-                    .any(|contract_no| c.value == ns.contracts[*contract_no].name)
+                    .any(|contract_no| c.value == ns.contracts[*contract_no].id.name)
                 {
                     res.push(Tag {
                         loc,

--- a/src/sema/types.rs
+++ b/src/sema/types.rs
@@ -263,7 +263,7 @@ fn type_decl(
         loc: def.loc,
         name: def.name.name.to_string(),
         ty,
-        contract: contract_no.map(|no| ns.contracts[no].name.to_string()),
+        contract: contract_no.map(|no| ns.contracts[no].id.to_string()),
     });
 }
 
@@ -449,7 +449,7 @@ fn resolve_contract<'a>(
     );
 
     ns.contracts
-        .push(Contract::new(&name.name, def.ty.clone(), doc, def.loc));
+        .push(Contract::new(name, def.ty.clone(), doc, def.loc));
 
     contract_annotations(contract_no, &def.annotations, ns);
 
@@ -627,7 +627,7 @@ fn contract_annotations(
                 note.loc,
                 format!(
                     "unknown annotation '{}' on contract {}",
-                    note.id.name, ns.contracts[contract_no].name,
+                    note.id.name, ns.contracts[contract_no].id,
                 ),
             ));
             continue;
@@ -1076,7 +1076,7 @@ fn enum_decl(
         name: enum_.name.as_ref().unwrap().name.to_string(),
         loc: enum_.loc,
         contract: match contract_no {
-            Some(c) => Some(ns.contracts[c].name.to_owned()),
+            Some(c) => Some(ns.contracts[c].id.name.to_owned()),
             None => None,
         },
         ty: Type::Uint(8),
@@ -1289,7 +1289,7 @@ impl Type {
 
                 s
             }
-            Type::Contract(n) => format!("contract {}", ns.contracts[*n].name),
+            Type::Contract(n) => format!("contract {}", ns.contracts[*n].id),
             Type::UserType(n) => format!("usertype {}", ns.user_types[*n]),
             Type::Ref(r) => r.to_string(ns),
             Type::StorageRef(_, ty) => {
@@ -2104,7 +2104,7 @@ impl Type {
                     value.to_llvm_string(ns)
                 )
             }
-            Type::Contract(i) => ns.contracts[*i].name.to_owned(),
+            Type::Contract(i) => ns.contracts[*i].id.name.to_owned(),
             Type::InternalFunction { .. } => "function".to_owned(),
             Type::ExternalFunction { .. } => "function".to_owned(),
             Type::Ref(r) => r.to_llvm_string(ns),

--- a/src/sema/variables.rs
+++ b/src/sema/variables.rs
@@ -190,7 +190,7 @@ pub fn variable_decl<'a>(
                                     name.loc,
                                     format!(
                                         "override '{}' is not a base contract of '{}'",
-                                        name, ns.contracts[contract_no].name
+                                        name, ns.contracts[contract_no].id
                                     ),
                                 ));
                             } else {

--- a/src/sema/yul/tests/expression.rs
+++ b/src/sema/yul/tests/expression.rs
@@ -336,7 +336,15 @@ fn resolve_variable_contract() {
     let mut function_table = FunctionsTable::new(0);
     let mut ns = Namespace::new(Target::EVM);
     let loc = Loc::File(0, 2, 3);
-    let mut contract = ast::Contract::new("test", ContractTy::Contract(loc), vec![], loc);
+    let mut contract = ast::Contract::new(
+        &pt::Identifier {
+            name: "test".to_string(),
+            loc: pt::Loc::Codegen,
+        },
+        ContractTy::Contract(loc),
+        vec![],
+        loc,
+    );
     contract.variables.push(Variable {
         tags: vec![],
         name: "var1".to_string(),
@@ -785,7 +793,15 @@ fn test_member_access() {
     let mut ns = Namespace::new(Target::EVM);
     let loc = Loc::File(0, 2, 3);
 
-    let mut contract = ast::Contract::new("test", ContractTy::Contract(loc), vec![], loc);
+    let mut contract = ast::Contract::new(
+        &pt::Identifier {
+            name: "test".into(),
+            loc: pt::Loc::Builtin,
+        },
+        ContractTy::Contract(loc),
+        vec![],
+        loc,
+    );
     contract.variables.push(Variable {
         tags: vec![],
         name: "var1".to_string(),
@@ -880,7 +896,15 @@ fn test_check_types() {
     let context = ExprContext::default();
 
     let mut ns = Namespace::new(Target::EVM);
-    let mut contract = ast::Contract::new("test", ContractTy::Contract(loc), vec![], loc);
+    let mut contract = ast::Contract::new(
+        &pt::Identifier {
+            name: "test".into(),
+            loc: pt::Loc::Builtin,
+        },
+        ContractTy::Contract(loc),
+        vec![],
+        loc,
+    );
     contract.variables.push(Variable {
         tags: vec![],
         name: "var1".to_string(),

--- a/tests/contract_testcases/evm/virtual_receive.sol
+++ b/tests/contract_testcases/evm/virtual_receive.sol
@@ -1,0 +1,12 @@
+abstract contract b {
+	receive() external payable virtual;
+	fallback() external virtual;
+}
+
+contract c is b {
+}
+// ---- Expect: diagnostics ----
+// error: 6:1-7:2: contract 'c' missing override for fallback function
+// 	note 3:2-29: declaration of fallback function
+// error: 6:1-7:2: contract 'c' missing override for receive function
+// 	note 2:2-36: declaration of receive function

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the "solang" extension will be documented in this file.
 
-## Unreleased
+## [0.3.3]
 
 - The same version of solang should be used by the language server as on the command line,
   so first look in the $PATH for solang before downloading the solang binary. As a result, the

--- a/vscode/src/test/suite/extension.test.ts
+++ b/vscode/src/test/suite/extension.test.ts
@@ -427,6 +427,14 @@ async function testrefs(docUri: vscode.Uri) {
   assert.strictEqual(loc15.range.end.line, 38);
   assert.strictEqual(loc15.range.end.character, 17);
   assert.strictEqual(loc15.uri.path, docUri.path);
+
+  const pos2 = new vscode.Position(28, 12);
+  const actualref2 = (await vscode.commands.executeCommand(
+    'vscode.executeReferenceProvider',
+    docUri,
+    pos2,
+  )) as vscode.Location[];
+  assert.strictEqual(actualref2.length, 0);
 }
 
 async function testrename(docUri: vscode.Uri) {
@@ -495,10 +503,10 @@ async function testformat(docUri: vscode.Uri) {
 
   try {
     const workedits = new vscode.WorkspaceEdit();
-    workedits.set(docUri, textedits); 
-    const done = await vscode.workspace.applyEdit(workedits); 
+    workedits.set(docUri, textedits);
+    const done = await vscode.workspace.applyEdit(workedits);
     assert(done);
-  
+
     const actualtext = doc.getText();
     const expectedtext = "contract deck {\n    enum suit {\n        club,\n        diamonds,\n        hearts,\n        spades\n    }\n    enum value {\n        two,\n        three,\n        four,\n        five,\n        six,\n        seven,\n        eight,\n        nine,\n        ten,\n        jack,\n        queen,\n        king,\n        ace\n    }\n\n    struct card {\n        value v;\n        suit s;\n    }\n\n    function score(card c) public returns (uint32 score) {\n        if (c.s == suit.hearts) {\n            if (c.v == value.ace) {\n                score = 14;\n            }\n            if (c.v == value.king) {\n                score = 13;\n            }\n            if (c.v == value.queen) {\n                score = 12;\n            }\n            if (c.v == value.jack) {\n                score = 11;\n            }\n        }\n        // all others score 0\n    }\n}\n";
     assert.strictEqual(actualtext, expectedtext);
@@ -551,6 +559,18 @@ async function testhover(docUri: vscode.Uri) {
   const contentarr3 = actualhover3[0].contents as vscode.MarkdownString[];
 
   assert.strictEqual(contentarr3[0].value, 'Abort execution if argument evaulates to false\n\n```solidity\n[built-in] void require (bool)\n```');
+
+  const pos4 = new vscode.Position(53, 13);
+
+  const actualhover4 = (await vscode.commands.executeCommand(
+    'vscode.executeHoverProvider',
+    docUri,
+    pos4
+  )) as vscode.Hover[];
+
+  const contentarr4 = actualhover4[0].contents as vscode.MarkdownString[];
+
+  assert.strictEqual(contentarr4[0].value, '');
 }
 
 async function testdiagnos(docUri: vscode.Uri, expecteddiag: vscode.Diagnostic[]) {

--- a/vscode/src/test/suite/extension.test.ts
+++ b/vscode/src/test/suite/extension.test.ts
@@ -428,13 +428,19 @@ async function testrefs(docUri: vscode.Uri) {
   assert.strictEqual(loc15.range.end.character, 17);
   assert.strictEqual(loc15.uri.path, docUri.path);
 
-  const pos2 = new vscode.Position(28, 12);
+  const pos2 = new vscode.Position(21, 6);
   const actualref2 = (await vscode.commands.executeCommand(
     'vscode.executeReferenceProvider',
     docUri,
     pos2,
   )) as vscode.Location[];
-  assert.strictEqual(actualref2.length, 0);
+  assert.strictEqual(actualref2.length, 1);
+  const loc20 = actualref2[0];
+  assert.strictEqual(loc20.range.start.line, 0);
+  assert.strictEqual(loc20.range.start.character, 0);
+  assert.strictEqual(loc20.range.end.line, 44);
+  assert.strictEqual(loc20.range.end.character, 1);
+  assert.strictEqual(loc20.uri.path, docUri.path);
 }
 
 async function testrename(docUri: vscode.Uri) {
@@ -560,7 +566,7 @@ async function testhover(docUri: vscode.Uri) {
 
   assert.strictEqual(contentarr3[0].value, 'Abort execution if argument evaulates to false\n\n```solidity\n[built-in] void require (bool)\n```');
 
-  const pos4 = new vscode.Position(53, 13);
+  const pos4 = new vscode.Position(32, 13);
 
   const actualhover4 = (await vscode.commands.executeCommand(
     'vscode.executeHoverProvider',
@@ -568,9 +574,7 @@ async function testhover(docUri: vscode.Uri) {
     pos4
   )) as vscode.Hover[];
 
-  const contentarr4 = actualhover4[0].contents as vscode.MarkdownString[];
-
-  assert.strictEqual(contentarr4[0].value, '');
+  assert.strictEqual(actualhover4.length, 0);
 }
 
 async function testdiagnos(docUri: vscode.Uri, expecteddiag: vscode.Diagnostic[]) {

--- a/vscode/src/test/suite/extension.test.ts
+++ b/vscode/src/test/suite/extension.test.ts
@@ -434,13 +434,7 @@ async function testrefs(docUri: vscode.Uri) {
     docUri,
     pos2,
   )) as vscode.Location[];
-  assert.strictEqual(actualref2.length, 1);
-  const loc20 = actualref2[0];
-  assert.strictEqual(loc20.range.start.line, 0);
-  assert.strictEqual(loc20.range.start.character, 0);
-  assert.strictEqual(loc20.range.end.line, 44);
-  assert.strictEqual(loc20.range.end.character, 1);
-  assert.strictEqual(loc20.uri.path, docUri.path);
+  assert.strictEqual(actualref2.length, 0);
 }
 
 async function testrename(docUri: vscode.Uri) {


### PR DESCRIPTION
These lsp crashes are concurrency issues, so writing tests from them is hard.

If we could hand-craft lsp json-rpc messages then this would be easier, but we only test the extension by controlling vscode.

