### PR TITLE
Set v0.3.3 version number correctly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solang"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Sean Young <sean@mess.org>", "Lucas Steuernagel <lucas.tnagel@gmail.com>", "Cyrill Leutwiler <bigcyrill@hotmail.com>"]
 homepage = "https://github.com/hyperledger/solang"
 documentation = "https://solang.readthedocs.io/"


### PR DESCRIPTION
The [v0.3.3 PR](https://github.com/hyperledger/solang/pull/1573) did not update the version of the solang crate :roll_eyes: 

This is a bit embarrassing!