### PR TITLE
Match solc diagnostic levels

### DIFF
--- a/src/codegen/cfg.rs
+++ b/src/codegen/cfg.rs
@@ -1793,6 +1793,10 @@ fn function_cfg(
             None,
             opt,
         );
+
+        if !stmt.reachable() {
+            break;
+        }
     }
 
     if func.body.last().map(Statement::reachable).unwrap_or(true) {

--- a/src/codegen/statements/mod.rs
+++ b/src/codegen/statements/mod.rs
@@ -52,6 +52,10 @@ pub(crate) fn statement(
                     return_override,
                     opt,
                 );
+
+                if !stmt.reachable() {
+                    break;
+                }
             }
         }
         Statement::VariableDecl(loc, pos, _, Some(init)) => {

--- a/src/sema/namespace.rs
+++ b/src/sema/namespace.rs
@@ -1134,7 +1134,7 @@ impl Namespace {
                         .into_iter()
                         .map(|p| {
                             if let Some(name) = p.id {
-                                diagnostics.push(Diagnostic::error(
+                                diagnostics.push(Diagnostic::warning(
                                     name.loc,
                                     "function type parameters cannot be named".to_string(),
                                 ));
@@ -1148,7 +1148,7 @@ impl Namespace {
                         .into_iter()
                         .map(|p| {
                             if let Some(name) = p.id {
-                                diagnostics.push(Diagnostic::error(
+                                diagnostics.push(Diagnostic::warning(
                                     name.loc,
                                     "function type returns cannot be named".to_string(),
                                 ));

--- a/src/sema/namespace.rs
+++ b/src/sema/namespace.rs
@@ -1138,7 +1138,6 @@ impl Namespace {
                                     name.loc,
                                     "function type parameters cannot be named".to_string(),
                                 ));
-                                success = false;
                             }
                             p.ty
                         })
@@ -1152,7 +1151,6 @@ impl Namespace {
                                     name.loc,
                                     "function type returns cannot be named".to_string(),
                                 ));
-                                success = false;
                             }
                             p.ty
                         })

--- a/tests/contract_testcases/evm/memory_safe.sol
+++ b/tests/contract_testcases/evm/memory_safe.sol
@@ -9,6 +9,6 @@ library Issue1526 {
 }
 
 // ---- Expect: diagnostics ----
-// error: 5:34-39: flag 'foo' not supported
-// error: 5:41-54: flag 'memory-safe' already specified
+// warning: 5:34-39: flag 'foo' not supported
+// warning: 5:41-54: flag 'memory-safe' already specified
 // 	note 5:19-32: previous location

--- a/tests/contract_testcases/polkadot/function_types/decls_04.sol
+++ b/tests/contract_testcases/polkadot/function_types/decls_04.sol
@@ -4,4 +4,6 @@ contract test {
             }
         }
 // ---- Expect: diagnostics ----
-// error: 3:42-43: function type returns cannot be named
+// warning: 2:13-34: function can be declared 'pure'
+// warning: 3:42-43: function type returns cannot be named
+// warning: 3:45-46: local variable 'a' is unused

--- a/tests/contract_testcases/polkadot/function_types/decls_05.sol
+++ b/tests/contract_testcases/polkadot/function_types/decls_05.sol
@@ -4,4 +4,6 @@ contract test {
             }
         }
 // ---- Expect: diagnostics ----
-// error: 3:34-37: function type parameters cannot be named
+// warning: 2:13-34: function can be declared 'pure'
+// warning: 3:34-37: function type parameters cannot be named
+// warning: 3:54-55: local variable 'a' is unused

--- a/tests/contract_testcases/polkadot/functions/for_forever.sol
+++ b/tests/contract_testcases/polkadot/functions/for_forever.sol
@@ -8,4 +8,5 @@
         }
     }
 // ---- Expect: diagnostics ----
-// error: 7:13-19: unreachable statement
+// warning: 3:9-49: function can be declared 'pure'
+// warning: 7:13-19: unreachable statement

--- a/tests/contract_testcases/polkadot/loops/test_infinite_loop.sol
+++ b/tests/contract_testcases/polkadot/loops/test_infinite_loop.sol
@@ -9,4 +9,5 @@ contract test3 {
             }
         }
 // ---- Expect: diagnostics ----
-// error: 8:17-25: unreachable statement
+// warning: 5:13-63: function can be declared 'pure'
+// warning: 8:17-25: unreachable statement

--- a/tests/contract_testcases/polkadot/yul/unreachable_after_asm.sol
+++ b/tests/contract_testcases/polkadot/yul/unreachable_after_asm.sol
@@ -14,6 +14,7 @@ contract testTypes {
 } 
 
 // ---- Expect: diagnostics ----
-// error: 5:19-32: flag 'memory-safe' not supported
-// error: 5:34-39: flag 'meh' not supported
-// error: 10:9-12:10: unreachable statement
+// warning: 2:5-14: storage variable 'b' has been assigned, but never read
+// warning: 5:19-32: flag 'memory-safe' not supported
+// warning: 5:34-39: flag 'meh' not supported
+// warning: 10:9-12:10: unreachable statement

--- a/tests/contract_testcases/solana/yul/return_in_asm.sol
+++ b/tests/contract_testcases/solana/yul/return_in_asm.sol
@@ -7,5 +7,5 @@ contract Contract {
 }
 
 // ---- Expect: diagnostics ----
-// error: 3:19-32: flag 'memory-safe' not supported
+// warning: 3:19-32: flag 'memory-safe' not supported
 // error: 4:13-25: builtin 'return' is not available for target Solana. Please, open a GitHub issue at https://github.com/hyperledger/solang/issues if there is need to support this function

--- a/tests/evm.rs
+++ b/tests/evm.rs
@@ -253,7 +253,7 @@ fn ethereum_solidity_tests() {
         })
         .sum();
 
-    assert_eq!(errors, 986);
+    assert_eq!(errors, 960);
 }
 
 fn set_file_contents(source: &str, path: &Path) -> (FileResolver, Vec<String>) {


### PR DESCRIPTION
The following errors are warnings in solc

 - unreachable code should be warning
 - function types with parameter/return names should be warning
 - unknown assembly flags should be warnings