### PR TITLE
Fix broken build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,9 @@ primitive-types = { version = "0.12", features = ["codec"] }
 normalize-path = "0.2.1"
 bitflags = "2.3.3"
 forge-fmt = "0.2.0"
+# We don't use ethers-core directly, but need the correct version for the
+# build to work.
+ethers-core = "2.0.10"
 
 [dev-dependencies]
 num-derive = "0.4"


### PR DESCRIPTION
For some reason, cargo is not pick the latest version of ethers-core. This breaks the build. Add a line to Cargo.toml fixes the problem.