### PR TITLE
Add a feature flag for the language server

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
     - name: Run cargo clippy
       run: cargo clippy --workspace --tests --bins -- -D warnings
     - name: Run cargo clippy without wasm_opt feature
-      run: cargo clippy --workspace --no-default-features --features language-server,llvm --bins -- -D warnings
+      run: cargo clippy --workspace --no-default-features --features language_server,llvm --bins -- -D warnings
     - name: Run cargo clippy without llvm feature
       run: cargo clippy --workspace --no-default-features --lib -- -D warnings
     - name: Run cargo doc
@@ -181,7 +181,7 @@ jobs:
     - name: Run tests
       run: cargo test --verbose --workspace
     - name: Run tests without wasm_opt
-      run: cargo test --verbose --workspace --no-default-features --features language-server,llvm
+      run: cargo test --verbose --workspace --no-default-features --features language_server,llvm
     - uses: actions/upload-artifact@v3.1.0
       with:
         name: solang-mac-arm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
     - name: Run cargo clippy
       run: cargo clippy --workspace --tests --bins -- -D warnings
     - name: Run cargo clippy without wasm_opt feature
-      run: cargo clippy --workspace --no-default-features --features llvm --bins -- -D warnings
+      run: cargo clippy --workspace --no-default-features --features language-server,llvm --bins -- -D warnings
     - name: Run cargo clippy without llvm feature
       run: cargo clippy --workspace --no-default-features --lib -- -D warnings
     - name: Run cargo doc
@@ -181,7 +181,7 @@ jobs:
     - name: Run tests
       run: cargo test --verbose --workspace
     - name: Run tests without wasm_opt
-      run: cargo test --verbose --workspace --no-default-features --features llvm
+      run: cargo test --verbose --workspace --no-default-features --features language-server,llvm
     - uses: actions/upload-artifact@v3.1.0
       with:
         name: solang-mac-arm

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,8 @@ primitive-types = { version = "0.12", features = ["codec"] }
 normalize-path = "0.2.1"
 bitflags = "2.3.3"
 forge-fmt = { version = "0.2.0", optional = true }
+# We don't use ethers-core directly, but need the correct version for the
+# build to work.
 ethers-core = { version = "2.0.10", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ contract-metadata = "3.2"
 semver = { version = "1.0", features = ["serde"] }
 tempfile = "3.8"
 libc = { version = "0.2", optional = true }
-tower-lsp = "0.20"
-tokio = { version = "1.27", features = ["rt", "io-std", "macros"] }
+tower-lsp = { version = "0.20", optional = true }
+tokio = { version = "1.27", features = ["rt", "io-std", "macros"], optional = true }
 base58 = "0.2.0"
 sha2 = "0.10"
 ripemd = "0.1"
@@ -49,7 +49,7 @@ once_cell = "1.18"
 solang-parser = { path = "solang-parser", version = "0.3.3" }
 codespan-reporting = "0.11"
 phf = { version = "0.11", features = ["macros"] }
-rust-lapper = "1.1"
+rust-lapper = { version = "1.1", optional = true }
 anchor-syn = { version = "0.29.0", features = ["idl-build"] }
 convert_case = "0.6"
 parse-display = "0.8"
@@ -66,7 +66,8 @@ contract-build = { version = "3.0.1", optional = true }
 primitive-types = { version = "0.12", features = ["codec"] }
 normalize-path = "0.2.1"
 bitflags = "2.3.3"
-forge-fmt = "0.2.0"
+forge-fmt = { version = "0.2.0", optional = true }
+ethers-core = { version = "2.0.10", optional = true }
 
 [dev-dependencies]
 num-derive = "0.4"
@@ -95,9 +96,10 @@ no-default-features = true
 lto = true
 
 [features]
-default = ["llvm", "wasm_opt"]
+default = ["llvm", "wasm_opt", "language_server"]
 llvm = ["inkwell", "libc"]
 wasm_opt = ["llvm", "wasm-opt", "contract-build"]
+language_server = ["tower-lsp", "forge-fmt", "ethers-core", "tokio", "rust-lapper"]
 
 [workspace]
 members = ["solang-parser", "tests/wasm_host_attr"]

--- a/src/bin/cli/mod.rs
+++ b/src/bin/cli/mod.rs
@@ -37,6 +37,7 @@ pub enum Commands {
     #[command(about = "Print shell completion for various shells to STDOUT")]
     ShellComplete(ShellComplete),
 
+    #[cfg(feature = "language_server")]
     #[command(about = "Start LSP language server on stdin/stdout")]
     LanguageServer(LanguageServerCommand),
 

--- a/src/bin/solang.rs
+++ b/src/bin/solang.rs
@@ -30,6 +30,7 @@ use crate::cli::{
 mod cli;
 mod doc;
 mod idl;
+#[cfg(feature = "language_server")]
 mod languageserver;
 
 fn main() {
@@ -58,6 +59,7 @@ fn main() {
             compile(&config)
         }
         Commands::ShellComplete(shell_args) => shell_complete(Cli::command(), shell_args),
+        #[cfg(feature = "language_server")]
         Commands::LanguageServer(server_args) => languageserver::start_server(&server_args),
         Commands::Idl(idl_args) => idl::idl(&idl_args),
         Commands::New(new_arg) => new_command(new_arg),


### PR DESCRIPTION
The language server alone pulls over 200 dependencies, or close to half of our total dependencies. Currently, `cargo build` causes to compile 552 crates. With this feature flag, a `cargo build --no-default-features --features llvm,wasm_opt` compiles only 296 crates.

And there are some chunky ones in the language server too. With the LS I get the following timings:

|Rank| Unit | Total | Codegen | Features
|-- | -- | -- | -- | --
|1. | wasm-opt-sys v0.112.0 build script (run) | 50.1s |   |  
|2. | **ethers-solc v2.0.10** | 16.0s | 7.1s (45%) | async, futures-util, sha2, svm, svm-builds, svm-solc
|3. | solang v0.3.3 bin "solang" | 15.8s |   | contract-build, default, ethers-core, forge-fmt, inkwell,  language_server, libc, llvm, rust-lapper, tokio, tower-lsp, wasm-opt,  wasm_opt
|4. | solang-parser v0.3.3 build script (run) | 13.8s |   | default
|5. | solang-parser v0.3.2 build script (run) | 13.4s |   | default
|6. | **lsp-types v0.94.1** | 9.9s | 1.1s (11%) | default
|7. | **ethers-core v2.0.10** | 8.1s | 3.5s (43%) |  
|8. | lalrpop v0.20.0 | 7.9s | 3.1s (39%) |  
|9. | **tokio v1.34.0** | 7.1s | 3.6s (51%) | bytes, default, fs, io-std, io-util, libc, macros, mio, net,  num_cpus, process, rt, rt-multi-thread, signal-hook-registry, socket2,  sync, time, tokio-macros
|10. | solang v0.3.3 | 6.5s | 2.4s (38%) | contract-build, default, ethers-core, forge-fmt, inkwell,  language_server, libc, llvm, rust-lapper, tokio, tower-lsp, wasm-opt,  wasm_opt
|11. | syn v1.0.109 | 6.2s | 2.6s (41%) | clone-impls, default, derive, extra-traits, fold, full, parsing, printing, proc-macro, quote, visit, visit-mut
|12. | **foundry-config v0.2.0** | 6.2s | 4.1s (66%) | 


Main offender is still `wasm-opt` by far, but we already have a flag for this.



