### PR TITLE
LLD: Clean up context after linking each contract

### DIFF
--- a/src/linker/linker.cpp
+++ b/src/linker/linker.cpp
@@ -6,7 +6,8 @@
 #include "llvm/Support/CrashRecoveryContext.h"
 
 // The LLD entry points are not safe to re-enter without destroying their state.
-static bool DestroyCTX() {
+static bool DestroyCTX()
+{
 	llvm::CrashRecoveryContext crc;
 
  	return crc.RunSafely([&]() { lld::CommonLinkerContext::destroy(); });

--- a/src/linker/linker.cpp
+++ b/src/linker/linker.cpp
@@ -2,17 +2,26 @@
 
 // Call the LLD linker
 #include "lld/Common/Driver.h"
+#include "lld/Common/CommonLinkerContext.h"
+#include "llvm/Support/CrashRecoveryContext.h"
+
+// The LLD entry points are not safe to re-enter without destroying their state.
+static bool DestroyCTX() {
+	llvm::CrashRecoveryContext crc;
+
+ 	return crc.RunSafely([&]() { lld::CommonLinkerContext::destroy(); });
+}
 
 extern "C" bool LLDWasmLink(const char *argv[], size_t length)
 {
 	llvm::ArrayRef<const char *> args(argv, length);
 
-	return lld::wasm::link(args, llvm::outs(), llvm::errs(), false, false);
+	return lld::wasm::link(args, llvm::outs(), llvm::errs(), false, false) && DestroyCTX();
 }
 
 extern "C" bool LLDELFLink(const char *argv[], size_t length)
 {
 	llvm::ArrayRef<const char *> args(argv, length);
 
-	return lld::elf::link(args, llvm::outs(), llvm::errs(), false, false);
+	return lld::elf::link(args, llvm::outs(), llvm::errs(), false, false) && DestroyCTX();
 }


### PR DESCRIPTION
The LLD entry points are not safe to re-enter without destroying their state. Coincidentally this worked so far but will break apart for example when compiling multiple contracts in `RelocMode::PIC`.