### PR TITLE
Add Soroban target foundations.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,9 +73,11 @@ jobs:
     - name: Run cargo clippy
       run: cargo clippy --workspace --tests --bins -- -D warnings
     - name: Run cargo clippy without wasm_opt feature
-      run: cargo clippy --workspace --no-default-features --features language_server,llvm --bins -- -D warnings
+      run: cargo clippy --workspace --no-default-features --features language_server,llvm,soroban --bins -- -D warnings
     - name: Run cargo clippy without llvm feature
       run: cargo clippy --workspace --no-default-features --lib -- -D warnings
+    - name: Run cargo clippy with only soroban feature
+      run: cargo clippy --workspace --no-default-features --features soroban,llvm --lib -- -D warnings
     - name: Run cargo doc
       run: cargo doc --workspace --bins
     - name: Run cargo fmt
@@ -181,7 +183,7 @@ jobs:
     - name: Run tests
       run: cargo test --verbose --workspace
     - name: Run tests without wasm_opt
-      run: cargo test --verbose --workspace --no-default-features --features language_server,llvm
+      run: cargo test --verbose --workspace --no-default-features --features language_server,llvm,soroban
     - uses: actions/upload-artifact@v3.1.0
       with:
         name: solang-mac-arm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
         cargo build
     - name: Run tests
       if: always()
-      run: cargo llvm-cov --all-features --workspace --no-report
+      run: cargo llvm-cov --all-features --workspace --no-report --jobs 2
     - name: Upload binary
       uses: actions/upload-artifact@v3.1.0
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ will be documented here.
 ## Unreleased
 
 ### Added
+- **Soroban** Work on adding support for [Stellar's Soroban](https://soroban.stellar.org/docs) contracts platforms started, by adding a skeleton that supports the Soroban runtime. [Salaheldin Soliman](https://github.com/salaheldinsoliman)
+
 - The `string.concat()` and `bytes.concat()` builtin functions are supported. [seanyoung](https://github.com/seanyoung)
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ forge-fmt = { version = "0.2.0", optional = true }
 # We don't use ethers-core directly, but need the correct version for the
 # build to work.
 ethers-core = { version = "2.0.10", optional = true }
+soroban-sdk = { version = "20.0.0-rc2", features = ["testutils"] }
 
 [dev-dependencies]
 num-derive = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ forge-fmt = { version = "0.2.0", optional = true }
 # We don't use ethers-core directly, but need the correct version for the
 # build to work.
 ethers-core = { version = "2.0.10", optional = true }
-soroban-sdk = { version = "20.0.0-rc2", features = ["testutils"] }
+soroban-sdk = { version = "20.0.0-rc2", features = ["testutils"], optional = true }
 
 [dev-dependencies]
 num-derive = "0.4"
@@ -100,7 +100,8 @@ no-default-features = true
 lto = true
 
 [features]
-default = ["llvm", "wasm_opt", "language_server"]
+soroban = ["soroban-sdk"]
+default = ["llvm", "wasm_opt", "language_server", "soroban"]
 llvm = ["inkwell", "libc"]
 wasm_opt = ["llvm", "wasm-opt", "contract-build"]
 language_server = ["tower-lsp", "forge-fmt", "ethers-core", "tokio", "rust-lapper"]

--- a/src/bin/cli/mod.rs
+++ b/src/bin/cli/mod.rs
@@ -277,7 +277,7 @@ pub struct TargetArg {
 
 #[derive(Args, Deserialize, Debug, PartialEq)]
 pub struct CompileTargetArg {
-    #[arg(name = "TARGET", long = "target", value_parser = ["solana", "polkadot", "evm"], help = "Target to build for [possible values: solana, polkadot]", num_args = 1, hide_possible_values = true)]
+    #[arg(name = "TARGET", long = "target", value_parser = ["solana", "polkadot", "evm", "soroban"], help = "Target to build for [possible values: solana, polkadot]", num_args = 1, hide_possible_values = true)]
     pub name: Option<String>,
 
     #[arg(name = "ADDRESS_LENGTH", help = "Address length on the Polkadot Parachain", long = "address-length", num_args = 1, value_parser = value_parser!(u64).range(4..1024))]
@@ -463,6 +463,7 @@ pub(crate) fn target_arg<T: TargetArgTrait>(target_arg: &T) -> Target {
             value_length: target_arg.get_value_length().unwrap_or(16) as usize,
         },
         "evm" => solang::Target::EVM,
+        "soroban" => solang::Target::Soroban,
         _ => unreachable!(),
     };
 

--- a/src/bin/solang.rs
+++ b/src/bin/solang.rs
@@ -405,7 +405,7 @@ fn contract_results(
 
     let context = inkwell::context::Context::create();
 
-    let binary = resolved_contract.binary(ns, &context, opt);
+    let binary = resolved_contract.binary(ns, &context, opt, contract_no);
 
     if save_intermediates(&binary, compiler_output) {
         return;

--- a/src/codegen/dispatch/mod.rs
+++ b/src/codegen/dispatch/mod.rs
@@ -17,5 +17,6 @@ pub(super) fn function_dispatch(
         Target::Polkadot { .. } | Target::EVM => {
             polkadot::function_dispatch(contract_no, all_cfg, ns, opt)
         }
+        Target::Soroban => vec![],
     }
 }

--- a/src/codegen/events/mod.rs
+++ b/src/codegen/events/mod.rs
@@ -50,5 +50,7 @@ pub(super) fn new_event_emitter<'a>(
             ns,
             event_no,
         }),
+
+        Target::Soroban => todo!(),
     }
 }

--- a/src/codegen/expression.rs
+++ b/src/codegen/expression.rs
@@ -3651,7 +3651,7 @@ fn array_literal_to_memory_array(
 fn code(loc: &Loc, contract_no: usize, ns: &Namespace, opt: &Options) -> Expression {
     let contract = &ns.contracts[contract_no];
 
-    let code = contract.emit(ns, opt);
+    let code = contract.emit(ns, opt, contract_no);
 
     let size = Expression::NumberLiteral {
         loc: *loc,

--- a/src/emit/binary.rs
+++ b/src/emit/binary.rs
@@ -39,6 +39,7 @@ use inkwell::OptimizationLevel;
 use once_cell::sync::OnceCell;
 use solang_parser::pt;
 
+#[cfg(feature = "soroban")]
 use super::soroban;
 
 static LLVM_INIT: OnceCell<()> = OnceCell::new();
@@ -170,7 +171,7 @@ impl<'a> Binary<'a> {
         contract: &'a Contract,
         ns: &'a Namespace,
         opt: &'a Options,
-        contract_no: usize,
+        _contract_no: usize,
     ) -> Self {
         let std_lib = load_stdlib(context, &ns.target);
         match ns.target {
@@ -178,10 +179,11 @@ impl<'a> Binary<'a> {
                 polkadot::PolkadotTarget::build(context, &std_lib, contract, ns, opt)
             }
             Target::Solana => solana::SolanaTarget::build(context, &std_lib, contract, ns, opt),
-            Target::EVM => unimplemented!(),
+            #[cfg(feature = "soroban")]
             Target::Soroban => {
-                soroban::SorobanTarget::build(context, &std_lib, contract, ns, opt, contract_no)
+                soroban::SorobanTarget::build(context, &std_lib, contract, ns, opt, _contract_no)
             }
+            _ => unimplemented!("target not implemented"),
         }
     }
 

--- a/src/emit/mod.rs
+++ b/src/emit/mod.rs
@@ -23,6 +23,8 @@ mod loop_builder;
 mod math;
 pub mod polkadot;
 pub mod solana;
+
+#[cfg(feature = "soroban")]
 pub mod soroban;
 mod storage;
 mod strings;

--- a/src/emit/polkadot/target.rs
+++ b/src/emit/polkadot/target.rs
@@ -815,7 +815,7 @@ impl<'a> TargetRuntime<'a> for PolkadotTarget {
 
         let created_contract = &ns.contracts[contract_no];
 
-        let code = created_contract.emit(ns, binary.options);
+        let code = created_contract.emit(ns, binary.options, contract_no);
 
         let (scratch_buf, scratch_len) = scratch_buf!();
 

--- a/src/emit/soroban/mod.rs
+++ b/src/emit/soroban/mod.rs
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pub(super) mod target;
+use crate::codegen::cfg::ControlFlowGraph;
+use crate::emit::cfg::emit_cfg;
+use crate::{
+    codegen::{cfg::ASTFunction, Options},
+    emit::Binary,
+    sema::ast,
+};
+use inkwell::{
+    context::Context,
+    module::{Linkage, Module},
+};
+use soroban_sdk::xdr::{
+    DepthLimitedWrite, ScEnvMetaEntry, ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0,
+    ScSpecTypeDef, StringM, WriteXdr,
+};
+
+const SOROBAN_ENV_INTERFACE_VERSION: u64 = 85899345977;
+
+pub struct SorobanTarget;
+
+impl SorobanTarget {
+    pub fn build<'a>(
+        context: &'a Context,
+        std_lib: &Module<'a>,
+        contract: &'a ast::Contract,
+        ns: &'a ast::Namespace,
+        opt: &'a Options,
+        contract_no: usize,
+    ) -> Binary<'a> {
+        let filename = ns.files[contract.loc.file_no()].file_name();
+        let mut binary = Binary::new(
+            context,
+            ns.target,
+            &contract.id.name,
+            &filename,
+            opt,
+            std_lib,
+            None,
+        );
+
+        Self::emit_public_functions(contract, &mut binary, ns, context, contract_no);
+        Self::emit_env_meta_entries(context, &mut binary);
+
+        binary
+    }
+
+    fn emit_public_functions<'a>(
+        contract: &'a ast::Contract,
+        binary: &mut Binary<'a>,
+        ns: &'a ast::Namespace,
+        context: &'a Context,
+        contract_no: usize,
+    ) {
+        let mut defines = Vec::new();
+
+        for (cfg_no, cfg) in contract.cfg.iter().enumerate() {
+            println!("cfg name {}", cfg.name);
+            let ftype = binary.function_type(
+                &cfg.params.iter().map(|p| p.ty.clone()).collect::<Vec<_>>(),
+                &cfg.returns.iter().map(|p| p.ty.clone()).collect::<Vec<_>>(),
+                ns,
+            );
+
+            // For each function, determine the name and the linkage
+            // Soroban has no dispatcher, so all externally addressable functions are exported and should be named the same as the original function name in the source code.
+            // If there are duplicate function names, then the function name in the source is mangled to include the signature.
+            let default_constructor = ns.default_constructor(contract_no);
+            let name = {
+                if cfg.public {
+                    let f = match &cfg.function_no {
+                        ASTFunction::SolidityFunction(no) | ASTFunction::YulFunction(no) => {
+                            &ns.functions[*no]
+                        }
+                        _ => &default_constructor,
+                    };
+
+                    if f.mangled_name_contracts.contains(&contract_no) {
+                        &f.mangled_name
+                    } else {
+                        &f.id.name
+                    }
+                } else {
+                    &cfg.name
+                }
+            };
+
+            Self::emit_function_spec_entry(context, cfg, name.clone(), binary);
+
+            let linkage = if cfg.public {
+                Linkage::External
+            } else {
+                Linkage::Internal
+            };
+
+            let func_decl = if let Some(func) = binary.module.get_function(name) {
+                // must not have a body yet
+                assert_eq!(func.get_first_basic_block(), None);
+
+                func
+            } else {
+                binary.module.add_function(name, ftype, Some(linkage))
+            };
+
+            binary.functions.insert(cfg_no, func_decl);
+
+            defines.push((func_decl, cfg));
+        }
+
+        for (func_decl, cfg) in defines {
+            emit_cfg(&mut SorobanTarget, binary, contract, cfg, func_decl, ns);
+        }
+    }
+
+    fn emit_env_meta_entries<'a>(context: &'a Context, binary: &mut Binary<'a>) {
+        let mut meta = DepthLimitedWrite::new(Vec::new(), 10);
+        ScEnvMetaEntry::ScEnvMetaKindInterfaceVersion(SOROBAN_ENV_INTERFACE_VERSION)
+            .write_xdr(&mut meta)
+            .expect("writing env meta interface version to xdr");
+        Self::add_custom_section(context, &binary.module, "contractenvmetav0", meta.inner);
+    }
+
+    fn emit_function_spec_entry<'a>(
+        context: &'a Context,
+        cfg: &'a ControlFlowGraph,
+        name: String,
+        binary: &mut Binary<'a>,
+    ) {
+        if cfg.public && !cfg.is_placeholder() {
+            // TODO: Emit custom type spec entries.
+            let mut spec = DepthLimitedWrite::new(Vec::new(), 10);
+            ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
+                name: name
+                    .try_into()
+                    .unwrap_or_else(|_| panic!("function name {:?} exceeds limit", cfg.name)),
+                inputs: cfg
+                    .params
+                    .iter()
+                    .enumerate()
+                    .map(|(i, p)| ScSpecFunctionInputV0 {
+                        name: p
+                            .id
+                            .as_ref()
+                            .map(|id| id.to_string())
+                            .unwrap_or_else(|| i.to_string())
+                            .try_into()
+                            .expect("function input name exceeds limit"),
+                        type_: ScSpecTypeDef::U32, // TODO: Map type.
+                        doc: StringM::default(),   // TODO: Add doc.
+                    })
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .expect("function input count exceeds limit"),
+                outputs: cfg
+                    .returns
+                    .iter()
+                    .map(|_| ScSpecTypeDef::U32) // TODO: Map type.
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .expect("function output count exceeds limit"),
+                doc: StringM::default(), // TODO: Add doc.
+            })
+            .write_xdr(&mut spec)
+            .unwrap_or_else(|_| panic!("writing spec to xdr for function {}", cfg.name));
+
+            Self::add_custom_section(context, &binary.module, "contractspecv0", spec.inner);
+        }
+    }
+
+    fn add_custom_section<'a>(
+        context: &'a Context,
+        module: &Module<'a>,
+        name: &'a str,
+        value: Vec<u8>,
+    ) {
+        let value_str = unsafe {
+            // TODO: Figure out the right way to generate the LLVM metadata for
+            // a slice of bytes.
+            String::from_utf8_unchecked(value)
+        };
+
+        module
+            .add_global_metadata(
+                "wasm.custom_sections",
+                &context.metadata_node(&[
+                    context.metadata_string(name).into(),
+                    context.metadata_string(&value_str).into(),
+                ]),
+            )
+            .expect("adding spec as metadata");
+    }
+}

--- a/src/emit/soroban/mod.rs
+++ b/src/emit/soroban/mod.rs
@@ -41,13 +41,15 @@ impl SorobanTarget {
             None,
         );
 
-        Self::emit_public_functions(contract, &mut binary, ns, context, contract_no);
+        Self::emit_functions_with_spec(contract, &mut binary, ns, context, contract_no);
         Self::emit_env_meta_entries(context, &mut binary);
 
         binary
     }
 
-    fn emit_public_functions<'a>(
+    // In Soroban, the public functions specifications is embeded in the contract binary.
+    // for each function, emit both the function spec entry and the function body.
+    fn emit_functions_with_spec<'a>(
         contract: &'a ast::Contract,
         binary: &mut Binary<'a>,
         ns: &'a ast::Namespace,
@@ -57,7 +59,6 @@ impl SorobanTarget {
         let mut defines = Vec::new();
 
         for (cfg_no, cfg) in contract.cfg.iter().enumerate() {
-            println!("cfg name {}", cfg.name);
             let ftype = binary.function_type(
                 &cfg.params.iter().map(|p| p.ty.clone()).collect::<Vec<_>>(),
                 &cfg.returns.iter().map(|p| p.ty.clone()).collect::<Vec<_>>(),

--- a/src/emit/soroban/target.rs
+++ b/src/emit/soroban/target.rs
@@ -1,80 +1,33 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::codegen::cfg::HashTy;
 use crate::codegen::Expression;
-use crate::sema::ast::{CallTy, Function, Namespace, Type};
-use std::collections::HashMap;
-use std::fmt;
-use std::str;
-
-use crate::Target;
-use inkwell::targets::TargetTriple;
+use crate::emit::binary::Binary;
+use crate::emit::soroban::SorobanTarget;
+use crate::emit::ContractArgs;
+use crate::emit::{TargetRuntime, Variable};
+use crate::sema::ast;
+use crate::sema::ast::CallTy;
+use crate::sema::ast::{Function, Namespace, Type};
 use inkwell::types::{BasicTypeEnum, IntType};
 use inkwell::values::{
     ArrayValue, BasicMetadataValueEnum, BasicValueEnum, FunctionValue, IntValue, PointerValue,
 };
 use solang_parser::pt::Loc;
+use std::collections::HashMap;
 
-pub mod binary;
-mod cfg;
-mod expression;
-mod functions;
-mod instructions;
-mod loop_builder;
-mod math;
-pub mod polkadot;
-pub mod solana;
-pub mod soroban;
-mod storage;
-mod strings;
-
-use crate::codegen::{cfg::HashTy, Options};
-use crate::emit::binary::Binary;
-use crate::sema::ast;
-
-#[derive(Clone)]
-pub struct Variable<'a> {
-    value: BasicValueEnum<'a>,
-}
-
-pub struct ContractArgs<'b> {
-    program_id: Option<PointerValue<'b>>,
-    value: Option<IntValue<'b>>,
-    gas: Option<IntValue<'b>>,
-    salt: Option<IntValue<'b>>,
-    seeds: Option<(PointerValue<'b>, IntValue<'b>)>,
-    accounts: Option<(PointerValue<'b>, IntValue<'b>)>,
-    flags: Option<IntValue<'b>>,
-}
-
-#[derive(Clone, Copy)]
-pub enum BinaryOp {
-    Add,
-    Subtract,
-    Multiply,
-}
-
-impl fmt::Display for BinaryOp {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                Self::Add => "add",
-                Self::Subtract => "sub",
-                Self::Multiply => "mul",
-            }
-        )
-    }
-}
-
-pub trait TargetRuntime<'a> {
+// TODO: Implement TargetRuntime for SorobanTarget.
+#[allow(unused_variables)]
+impl<'a> TargetRuntime<'a> for SorobanTarget {
     fn get_storage_int(
         &self,
         bin: &Binary<'a>,
         function: FunctionValue,
         slot: PointerValue<'a>,
         ty: IntType<'a>,
-    ) -> IntValue<'a>;
+    ) -> IntValue<'a> {
+        unimplemented!()
+    }
 
     fn storage_load(
         &self,
@@ -83,7 +36,9 @@ pub trait TargetRuntime<'a> {
         slot: &mut IntValue<'a>,
         function: FunctionValue<'a>,
         ns: &ast::Namespace,
-    ) -> BasicValueEnum<'a>;
+    ) -> BasicValueEnum<'a> {
+        unimplemented!()
+    }
 
     /// Recursively store a type to storage
     fn storage_store(
@@ -95,7 +50,9 @@ pub trait TargetRuntime<'a> {
         dest: BasicValueEnum<'a>,
         function: FunctionValue<'a>,
         ns: &ast::Namespace,
-    );
+    ) {
+        unimplemented!()
+    }
 
     /// Recursively clear storage. The default implementation is for slot-based storage
     fn storage_delete(
@@ -105,7 +62,9 @@ pub trait TargetRuntime<'a> {
         slot: &mut IntValue<'a>,
         function: FunctionValue<'a>,
         ns: &Namespace,
-    );
+    ) {
+        unimplemented!()
+    }
 
     // Bytes and string have special storage layout
     fn set_storage_string(
@@ -114,14 +73,18 @@ pub trait TargetRuntime<'a> {
         function: FunctionValue<'a>,
         slot: PointerValue<'a>,
         dest: BasicValueEnum<'a>,
-    );
+    ) {
+        unimplemented!()
+    }
 
     fn get_storage_string(
         &self,
         bin: &Binary<'a>,
         function: FunctionValue,
         slot: PointerValue<'a>,
-    ) -> PointerValue<'a>;
+    ) -> PointerValue<'a> {
+        unimplemented!()
+    }
 
     fn set_storage_extfunc(
         &self,
@@ -130,7 +93,9 @@ pub trait TargetRuntime<'a> {
         slot: PointerValue,
         dest: PointerValue,
         dest_ty: BasicTypeEnum,
-    );
+    ) {
+        unimplemented!()
+    }
 
     fn get_storage_extfunc(
         &self,
@@ -138,7 +103,9 @@ pub trait TargetRuntime<'a> {
         function: FunctionValue,
         slot: PointerValue<'a>,
         ns: &Namespace,
-    ) -> PointerValue<'a>;
+    ) -> PointerValue<'a> {
+        unimplemented!()
+    }
 
     fn get_storage_bytes_subscript(
         &self,
@@ -148,7 +115,9 @@ pub trait TargetRuntime<'a> {
         index: IntValue<'a>,
         loc: Loc,
         ns: &Namespace,
-    ) -> IntValue<'a>;
+    ) -> IntValue<'a> {
+        unimplemented!()
+    }
 
     fn set_storage_bytes_subscript(
         &self,
@@ -159,7 +128,9 @@ pub trait TargetRuntime<'a> {
         value: IntValue<'a>,
         ns: &Namespace,
         loc: Loc,
-    );
+    ) {
+        unimplemented!()
+    }
 
     fn storage_subscript(
         &self,
@@ -169,7 +140,9 @@ pub trait TargetRuntime<'a> {
         slot: IntValue<'a>,
         index: BasicValueEnum<'a>,
         ns: &Namespace,
-    ) -> IntValue<'a>;
+    ) -> IntValue<'a> {
+        unimplemented!()
+    }
 
     fn storage_push(
         &self,
@@ -179,7 +152,9 @@ pub trait TargetRuntime<'a> {
         slot: IntValue<'a>,
         val: Option<BasicValueEnum<'a>>,
         ns: &Namespace,
-    ) -> BasicValueEnum<'a>;
+    ) -> BasicValueEnum<'a> {
+        unimplemented!()
+    }
 
     fn storage_pop(
         &self,
@@ -190,7 +165,9 @@ pub trait TargetRuntime<'a> {
         load: bool,
         ns: &Namespace,
         loc: Loc,
-    ) -> Option<BasicValueEnum<'a>>;
+    ) -> Option<BasicValueEnum<'a>> {
+        unimplemented!()
+    }
 
     fn storage_array_length(
         &self,
@@ -199,7 +176,9 @@ pub trait TargetRuntime<'a> {
         _slot: IntValue<'a>,
         _elem_ty: &Type,
         _ns: &Namespace,
-    ) -> IntValue<'a>;
+    ) -> IntValue<'a> {
+        unimplemented!()
+    }
 
     /// keccak256 hash
     fn keccak256_hash(
@@ -209,19 +188,29 @@ pub trait TargetRuntime<'a> {
         length: IntValue,
         dest: PointerValue,
         ns: &Namespace,
-    );
+    ) {
+        unimplemented!()
+    }
 
     /// Prints a string
-    fn print(&self, bin: &Binary, string: PointerValue, length: IntValue);
+    fn print(&self, bin: &Binary, string: PointerValue, length: IntValue) {
+        unimplemented!()
+    }
 
     /// Return success without any result
-    fn return_empty_abi(&self, bin: &Binary);
+    fn return_empty_abi(&self, bin: &Binary) {
+        unimplemented!()
+    }
 
     /// Return failure code
-    fn return_code<'b>(&self, bin: &'b Binary, ret: IntValue<'b>);
+    fn return_code<'b>(&self, bin: &'b Binary, ret: IntValue<'b>) {
+        unimplemented!()
+    }
 
     /// Return failure without any result
-    fn assert_failure(&self, bin: &Binary, data: PointerValue, length: IntValue);
+    fn assert_failure(&self, bin: &Binary, data: PointerValue, length: IntValue) {
+        unimplemented!()
+    }
 
     fn builtin_function(
         &self,
@@ -231,7 +220,9 @@ pub trait TargetRuntime<'a> {
         args: &[BasicMetadataValueEnum<'a>],
         first_arg_type: BasicTypeEnum,
         ns: &Namespace,
-    ) -> Option<BasicValueEnum<'a>>;
+    ) -> Option<BasicValueEnum<'a>> {
+        unimplemented!()
+    }
 
     /// Calls constructor
     fn create_contract<'b>(
@@ -246,7 +237,9 @@ pub trait TargetRuntime<'a> {
         contract_args: ContractArgs<'b>,
         ns: &Namespace,
         loc: Loc,
-    );
+    ) {
+        unimplemented!()
+    }
 
     /// call external function
     fn external_call<'b>(
@@ -261,7 +254,9 @@ pub trait TargetRuntime<'a> {
         ty: CallTy,
         ns: &Namespace,
         loc: Loc,
-    );
+    ) {
+        unimplemented!()
+    }
 
     /// send value to address
     fn value_transfer<'b>(
@@ -273,7 +268,9 @@ pub trait TargetRuntime<'a> {
         _value: IntValue<'b>,
         _ns: &Namespace,
         loc: Loc,
-    );
+    ) {
+        unimplemented!()
+    }
 
     /// builtin expressions
     fn builtin<'b>(
@@ -283,16 +280,24 @@ pub trait TargetRuntime<'a> {
         vartab: &HashMap<usize, Variable<'b>>,
         function: FunctionValue<'b>,
         ns: &Namespace,
-    ) -> BasicValueEnum<'b>;
+    ) -> BasicValueEnum<'b> {
+        unimplemented!()
+    }
 
     /// Return the return data from an external call (either revert error or return values)
-    fn return_data<'b>(&self, bin: &Binary<'b>, function: FunctionValue<'b>) -> PointerValue<'b>;
+    fn return_data<'b>(&self, bin: &Binary<'b>, function: FunctionValue<'b>) -> PointerValue<'b> {
+        unimplemented!()
+    }
 
     /// Return the value we received
-    fn value_transferred<'b>(&self, binary: &Binary<'b>, ns: &Namespace) -> IntValue<'b>;
+    fn value_transferred<'b>(&self, binary: &Binary<'b>, ns: &Namespace) -> IntValue<'b> {
+        unimplemented!()
+    }
 
     /// Terminate execution, destroy bin and send remaining funds to addr
-    fn selfdestruct<'b>(&self, binary: &Binary<'b>, addr: ArrayValue<'b>, ns: &Namespace);
+    fn selfdestruct<'b>(&self, binary: &Binary<'b>, addr: ArrayValue<'b>, ns: &Namespace) {
+        unimplemented!()
+    }
 
     /// Crypto Hash
     fn hash<'b>(
@@ -303,7 +308,9 @@ pub trait TargetRuntime<'a> {
         string: PointerValue<'b>,
         length: IntValue<'b>,
         ns: &Namespace,
-    ) -> IntValue<'b>;
+    ) -> IntValue<'b> {
+        unimplemented!()
+    }
 
     /// Emit event
     fn emit_event<'b>(
@@ -312,7 +319,9 @@ pub trait TargetRuntime<'a> {
         function: FunctionValue<'b>,
         data: BasicValueEnum<'b>,
         topics: &[BasicValueEnum<'b>],
-    );
+    ) {
+        unimplemented!()
+    }
 
     /// Return ABI encoded data
     fn return_abi_data<'b>(
@@ -320,70 +329,7 @@ pub trait TargetRuntime<'a> {
         binary: &Binary<'b>,
         data: PointerValue<'b>,
         data_len: BasicValueEnum<'b>,
-    );
-}
-
-#[derive(PartialEq, Eq)]
-pub enum Generate {
-    Object,
-    Assembly,
-    Linked,
-}
-
-impl Target {
-    /// LLVM Target name
-    fn llvm_target_name(&self) -> &'static str {
-        if *self == Target::Solana {
-            "sbf"
-        } else {
-            "wasm32"
-        }
-    }
-
-    /// LLVM Target triple
-    fn llvm_target_triple(&self) -> TargetTriple {
-        TargetTriple::create(if *self == Target::Solana {
-            "sbf-unknown-unknown"
-        } else {
-            "wasm32-unknown-unknown-wasm"
-        })
-    }
-
-    /// LLVM Target triple
-    fn llvm_features(&self) -> &'static str {
-        if *self == Target::Solana {
-            "+solana"
-        } else {
-            ""
-        }
-    }
-}
-
-impl ast::Contract {
-    /// Generate the binary. This can be used to generate llvm text, object file
-    /// or final linked binary.
-    pub fn binary<'a>(
-        &'a self,
-        ns: &'a ast::Namespace,
-        context: &'a inkwell::context::Context,
-        opt: &'a Options,
-        contract_no: usize,
-    ) -> binary::Binary {
-        binary::Binary::build(context, self, ns, opt, contract_no)
-    }
-
-    /// Generate the final program code for the contract
-    pub fn emit(&self, ns: &ast::Namespace, opt: &Options, contract_no: usize) -> Vec<u8> {
-        if ns.target == Target::EVM {
-            return vec![];
-        }
-
-        self.code
-            .get_or_init(move || {
-                let context = inkwell::context::Context::create();
-                let binary = self.binary(ns, &context, opt, contract_no);
-                binary.code(Generate::Linked).expect("llvm build")
-            })
-            .to_vec()
+    ) {
+        unimplemented!()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub enum Target {
     },
     /// Ethereum EVM, see <https://ethereum.org/en/developers/docs/evm/>
     EVM,
+    Soroban,
 }
 
 impl fmt::Display for Target {
@@ -39,6 +40,7 @@ impl fmt::Display for Target {
             Target::Solana => write!(f, "Solana"),
             Target::Polkadot { .. } => write!(f, "Polkadot"),
             Target::EVM => write!(f, "EVM"),
+            Target::Soroban => write!(f, "Soroban"),
         }
     }
 }
@@ -51,6 +53,7 @@ impl PartialEq for Target {
             Target::Solana => matches!(other, Target::Solana),
             Target::Polkadot { .. } => matches!(other, Target::Polkadot { .. }),
             Target::EVM => matches!(other, Target::EVM),
+            Target::Soroban => matches!(other, Target::Soroban),
         }
     }
 }
@@ -144,7 +147,7 @@ pub fn compile(
         let contract = &ns.contracts[contract_no];
 
         if contract.instantiable {
-            let code = contract.emit(&ns, opts);
+            let code = contract.emit(&ns, opts, contract_no);
 
             let (abistr, _) = abi::generate_abi(contract_no, &ns, &code, false, &authors, version);
 

--- a/src/linker/mod.rs
+++ b/src/linker/mod.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod bpf;
-mod wasm;
-
+mod polkadot_wasm;
+mod soroban_wasm;
 use crate::Target;
 use once_cell::sync::Lazy;
 use std::ffi::CString;
@@ -16,10 +16,14 @@ pub fn link(input: &[u8], name: &str, target: Target) -> Vec<u8> {
     // We should fix this one day
     let _lock = LINKER_MUTEX.lock().unwrap();
 
-    if target == Target::Solana {
-        bpf::link(input, name)
-    } else {
-        wasm::link(input, name)
+    match target {
+        Target::Solana => bpf::link(input, name),
+        Target::Soroban => soroban_wasm::link(input, name),
+        Target::Polkadot {
+            address_length: _,
+            value_length: _,
+        } => polkadot_wasm::link(input, name),
+        _ => panic!("linker not implemented for target {:?}", target),
     }
 }
 

--- a/src/linker/polkadot_wasm.rs
+++ b/src/linker/polkadot_wasm.rs
@@ -31,7 +31,6 @@ pub fn link(input: &[u8], name: &str) -> Vec<u8> {
         CString::new("--gc-sections").unwrap(),
         CString::new("--global-base=0").unwrap(),
     ];
-
     command_line.push(CString::new("--export").unwrap());
     command_line.push(CString::new("deploy").unwrap());
     command_line.push(CString::new("--export").unwrap());
@@ -40,7 +39,6 @@ pub fn link(input: &[u8], name: &str) -> Vec<u8> {
     command_line.push(CString::new("--import-memory").unwrap());
     command_line.push(CString::new("--initial-memory=1048576").unwrap());
     command_line.push(CString::new("--max-memory=1048576").unwrap());
-
     command_line.push(
         CString::new(
             object_filename

--- a/src/linker/soroban_wasm.rs
+++ b/src/linker/soroban_wasm.rs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::ffi::CString;
+use std::fs::File;
+use std::io::Read;
+use std::io::Write;
+use tempfile::tempdir;
+
+pub fn link(input: &[u8], name: &str) -> Vec<u8> {
+    let dir = tempdir().expect("failed to create temp directory for linking");
+
+    let object_filename = dir.path().join(format!("{name}.o"));
+    let res_filename = dir.path().join(format!("{name}.wasm"));
+
+    let mut objectfile =
+        File::create(object_filename.clone()).expect("failed to create object file");
+
+    objectfile
+        .write_all(input)
+        .expect("failed to write object file to temp file");
+
+    let mut command_line = vec![
+        CString::new("-O3").unwrap(),
+        CString::new("--no-entry").unwrap(),
+        CString::new("--allow-undefined").unwrap(),
+        CString::new("--gc-sections").unwrap(),
+        CString::new("--global-base=0").unwrap(),
+    ];
+    command_line.push(CString::new("--export-dynamic").unwrap());
+
+    command_line.push(
+        CString::new(
+            object_filename
+                .to_str()
+                .expect("temp path should be unicode"),
+        )
+        .unwrap(),
+    );
+    command_line.push(CString::new("-o").unwrap());
+    command_line
+        .push(CString::new(res_filename.to_str().expect("temp path should be unicode")).unwrap());
+
+    assert!(!super::wasm_linker(&command_line), "linker failed");
+
+    let mut output = Vec::new();
+    // read the whole file
+    let mut outputfile = File::open(res_filename).expect("output file should exist");
+
+    outputfile
+        .read_to_end(&mut output)
+        .expect("failed to read output file");
+
+    output
+}

--- a/src/sema/builtin.rs
+++ b/src/sema/builtin.rs
@@ -1707,6 +1707,9 @@ impl Namespace {
         ));
     }
 
+    pub fn add_soroban_builtins(&mut self) {
+        // TODO: add soroban builtins
+    }
     pub fn add_polkadot_builtins(&mut self) {
         let loc = pt::Loc::Builtin;
         let identifier = |name: &str| Identifier {

--- a/src/sema/namespace.rs
+++ b/src/sema/namespace.rs
@@ -41,6 +41,7 @@ impl Namespace {
                 value_length,
             } => (address_length, value_length),
             Target::Solana => (32, 8),
+            Target::Soroban => (32, 8),
         };
 
         let mut ns = Namespace {
@@ -70,6 +71,7 @@ impl Namespace {
         match target {
             Target::Solana => ns.add_solana_builtins(),
             Target::Polkadot { .. } => ns.add_polkadot_builtins(),
+            Target::Soroban => ns.add_soroban_builtins(),
             _ => {}
         }
 

--- a/src/sema/yul/builtin.rs
+++ b/src/sema/yul/builtin.rs
@@ -20,6 +20,7 @@ impl YulBuiltinPrototype {
             Target::EVM => self.availability[0],
             Target::Polkadot { .. } => self.availability[1],
             Target::Solana => self.availability[2],
+            Target::Soroban => unimplemented!(),
         }
     }
 }

--- a/tests/contract.rs
+++ b/tests/contract.rs
@@ -99,9 +99,12 @@ fn parse_file(path: PathBuf, target: Target) -> io::Result<()> {
             if contract.instantiable {
                 let code = match ns.target {
                     Target::Solana | Target::Polkadot { .. } => {
-                        contract.emit(&ns, &Default::default())
+                        contract.emit(&ns, &Default::default(), contract_no)
                     }
                     Target::EVM => b"beep".to_vec(),
+                    Target::Soroban => {
+                        todo!()
+                    }
                 };
 
                 let _ = generate_abi(contract_no, &ns, &code, false, &["unknown".into()], "0.1.0");

--- a/tests/soroban.rs
+++ b/tests/soroban.rs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod soroban_testcases;
+
+use solang::codegen::Options;
+use solang::file_resolver::FileResolver;
+use solang::{compile, Target};
+use soroban_sdk::{vec, Address, Env, Symbol, Val};
+use std::ffi::OsStr;
+
+// TODO: register accounts, related balances, events, etc.
+pub struct SorobanEnv {
+    env: Env,
+    contracts: Vec<Address>,
+}
+
+pub fn build_solidity(src: &str) -> SorobanEnv {
+    let tmp_file = OsStr::new("test.sol");
+    let mut cache = FileResolver::default();
+    cache.set_file_contents(tmp_file.to_str().unwrap(), src.to_string());
+    let opt = inkwell::OptimizationLevel::Default;
+    let target = Target::Soroban;
+    let (wasm, ns) = compile(
+        tmp_file,
+        &mut cache,
+        target,
+        &Options {
+            opt_level: opt.into(),
+            log_api_return_codes: false,
+            log_runtime_errors: false,
+            log_prints: true,
+            #[cfg(feature = "wasm_opt")]
+            wasm_opt: Some(contract_build::OptimizationPasses::Z),
+            ..Default::default()
+        },
+        std::vec!["unknown".to_string()],
+        "0.0.1",
+    );
+    ns.print_diagnostics_in_plain(&cache, false);
+    assert!(!wasm.is_empty());
+    let wasm_blob = wasm[0].0.clone();
+    SorobanEnv::new_with_contract(wasm_blob)
+}
+
+impl SorobanEnv {
+    pub fn new() -> Self {
+        Self {
+            env: Env::default(),
+            contracts: Vec::new(),
+        }
+    }
+
+    pub fn new_with_contract(contract_wasm: Vec<u8>) -> Self {
+        let mut env = Self::new();
+        env.register_contract(contract_wasm);
+        env
+    }
+
+    pub fn register_contract(&mut self, contract_wasm: Vec<u8>) -> Address {
+        let addr = self
+            .env
+            .register_contract_wasm(None, contract_wasm.as_slice());
+        self.contracts.push(addr.clone());
+        addr
+    }
+
+    pub fn invoke_contract(&self, addr: &Address, function_name: &str, args: Vec<Val>) -> Val {
+        let func = Symbol::new(&self.env, function_name);
+        let mut args_soroban = vec![&self.env];
+        for arg in args {
+            args_soroban.push_back(arg)
+        }
+        println!("args_soroban: {:?}", args_soroban);
+        self.env.invoke_contract(addr, &func, args_soroban)
+    }
+}
+
+impl Default for SorobanEnv {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/tests/soroban.rs
+++ b/tests/soroban.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "soroban")]
 pub mod soroban_testcases;
 
 use solang::codegen::Options;

--- a/tests/soroban_testcases/math.rs
+++ b/tests/soroban_testcases/math.rs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::build_solidity;
+use soroban_sdk::Val;
+
+#[test]
+fn math() {
+    let env = build_solidity(
+        r#"contract math {
+        function max(uint64 a, uint64 b) public returns (uint64) {
+            if (a > b) {
+                return a;
+            } else {
+                return b;
+            }
+        }
+    }"#,
+    );
+
+    let addr = env.contracts.last().unwrap();
+    let res = env.invoke_contract(
+        addr,
+        "max",
+        vec![*Val::from_u32(4).as_val(), *Val::from_u32(5).as_val()],
+    );
+    assert!(Val::from_u32(5).as_val().shallow_eq(&res))
+}
+
+#[test]
+fn math_same_name() {
+    let src = build_solidity(
+        r#"contract math {
+        function max(uint64 a, uint64 b) public returns (uint64) {
+            if (a > b) {
+                return a;
+            } else {
+                return b;
+            }
+        }
+    
+        function max(uint64 a, uint64 b, uint64 c) public returns (uint64) {
+            if (a > b) {
+                if (a > c) {
+                    return a;
+                } else {
+                    return c;
+                }
+            } else {
+                if (b > c) {
+                    return b;
+                } else {
+                    return c;
+                }
+            }
+        }
+    }
+    "#,
+    );
+
+    let addr = src.contracts.last().unwrap();
+    let res = src.invoke_contract(
+        addr,
+        "max__uint64_uint64",
+        vec![*Val::from_u32(4).as_val(), *Val::from_u32(5).as_val()],
+    );
+    assert!(Val::from_u32(5).as_val().shallow_eq(&res));
+
+    let res = src.invoke_contract(
+        addr,
+        "max__uint64_uint64_uint64",
+        vec![
+            *Val::from_u32(4).as_val(),
+            *Val::from_u32(5).as_val(),
+            *Val::from_u32(6).as_val(),
+        ],
+    );
+    assert!(Val::from_u32(6).as_val().shallow_eq(&res));
+}

--- a/tests/soroban_testcases/math.rs
+++ b/tests/soroban_testcases/math.rs
@@ -60,14 +60,14 @@ fn math_same_name() {
     let addr = src.contracts.last().unwrap();
     let res = src.invoke_contract(
         addr,
-        "max__uint64_uint64",
+        "max_uint64_uint64",
         vec![*Val::from_u32(4).as_val(), *Val::from_u32(5).as_val()],
     );
     assert!(Val::from_u32(5).as_val().shallow_eq(&res));
 
     let res = src.invoke_contract(
         addr,
-        "max__uint64_uint64_uint64",
+        "max_uint64_uint64_uint64",
         vec![
             *Val::from_u32(4).as_val(),
             *Val::from_u32(5).as_val(),

--- a/tests/soroban_testcases/mod.rs
+++ b/tests/soroban_testcases/mod.rs
@@ -1,0 +1,2 @@
+// SPDX-License-Identifier: Apache-2.0
+mod math;


### PR DESCRIPTION
This PR is a follow up to this  PR: #1138 and #1129 , both of which discuss adding Soroban as a target for Solang.
The PR addresses three main points:
1- Soroban contracts have no dispatcher (a single point of entry). Therefore, externally callable functions in the contract should preserve their original name (if possible).
2- Soroban functions do not have their outputs as pointers in the inputs. Instead, they return the value at the end of execution.
3-Linking Soroban WASM contracts is pretty much similar to Polkadot's WASM, but with the following minor differences:
a- public functions are exported.
b- host functions (of course)

The next steps for this PR would be: (to be followed in another PRs)
1- Implement host function invocations. (The VM interface)
2- Implement XDR encoding and decoding.
3- Add Integration tests, and complete the mock VM implementation in soroban_tests.