### PR TITLE
Polkadot: Bugfix codegen for empty events

### DIFF
--- a/integration/polkadot/events.sol
+++ b/integration/polkadot/events.sol
@@ -10,6 +10,8 @@ contract Events {
     event ThisEventTopicShouldGetHashed(address indexed caller);
     event Event(bool indexed something);
 
+    event Empty();
+
     function emit_event() public {
         emit foo1(254, "hello there");
 
@@ -18,5 +20,7 @@ contract Events {
         emit ThisEventTopicShouldGetHashed(msg.sender);
 
         emit Event(true);
+
+        emit Empty();
     }
 }

--- a/integration/polkadot/events.spec.ts
+++ b/integration/polkadot/events.spec.ts
@@ -68,7 +68,6 @@ describe('Deploy events contract and test event data, docs and topics', () => {
         // - blake2x256 sum of its signature: 'Empty()'
 
         event_topic = await conn.query.system.eventTopics("0x2c54a2a9a9aa474af5d6e2bb2e5a35b84051acaf95b233f98f96860d36f2b81b");
-        console.log(event_topic.toHuman());
         expect(event_topic.length).toBe(1);
         expect(events[4].args.map(a => a.toJSON())).toEqual([]);
     });

--- a/integration/polkadot/events.spec.ts
+++ b/integration/polkadot/events.spec.ts
@@ -29,7 +29,7 @@ describe('Deploy events contract and test event data, docs and topics', () => {
         let res0: any = await transaction(tx, alice);
         let events: DecodedEvent[] = res0.contractEvents;
 
-        expect(events.length).toEqual(4);
+        expect(events.length).toEqual(5);
 
         expect(events[0].event.identifier).toBe("Events::foo1");
         expect(events[0].event.docs).toEqual(["Ladida tada"]);
@@ -63,5 +63,13 @@ describe('Deploy events contract and test event data, docs and topics', () => {
         expect(field_topic.length).toBe(1);
         event_topic = await conn.query.system.eventTopics("0xc2bc7a077121efada8bc6a0af16c1e886406e8c2d1716979cb1b92098d8b49bc");
         expect(event_topic.length).toBe(1);
+
+        // The 5th event yields no data and the following event topic:
+        // - blake2x256 sum of its signature: 'Empty()'
+
+        event_topic = await conn.query.system.eventTopics("0x2c54a2a9a9aa474af5d6e2bb2e5a35b84051acaf95b233f98f96860d36f2b81b");
+        console.log(event_topic.toHuman());
+        expect(event_topic.length).toBe(1);
+        expect(events[4].args.map(a => a.toJSON())).toEqual([]);
     });
 });


### PR DESCRIPTION
This is an oversight from #1632: The ABI encoder panics when trying to encoding no arguments. Previously, events always contained at least a single byte of data (empty events would have the discriminant/index of the event enum). However now, the data field for empty events is actually empty. So in codegen we check if we have to encode data first and pass a pointer to an empty buffer if not.