### PR TITLE
Fix subxt integration test off-by-one test case

### DIFF
--- a/integration/subxt-tests/src/cases/events.rs
+++ b/integration/subxt-tests/src/cases/events.rs
@@ -25,7 +25,7 @@ async fn case() -> anyhow::Result<()> {
         })
         .await?;
 
-    assert_eq!(rs.len(), 4);
+    assert_eq!(rs.len(), 5);
 
     // TODO: currently event decoding is different than ink, as we can see in contract-transcode.
     let e1 = &rs[0];


### PR DESCRIPTION
Followup from #1637 which changed the integration test. Locally I forgot to rebuild the contracts in the subxt dir  so it passed and then blamed on the CI just being flaky :sweat_smile: 