### PR TITLE
It is better to use the repository field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solang"
 version = "0.3.3"
 authors = ["Sean Young <sean@mess.org>", "Lucas Steuernagel <lucas.tnagel@gmail.com>", "Cyrill Leutwiler <bigcyrill@hotmail.com>"]
-homepage = "https://github.com/hyperledger/solang"
+repository = "https://github.com/hyperledger/solang"
 documentation = "https://solang.readthedocs.io/"
 license = "Apache-2.0"
 build = "build.rs"

--- a/solang-parser/Cargo.toml
+++ b/solang-parser/Cargo.toml
@@ -2,7 +2,7 @@
 name = "solang-parser"
 version = "0.3.3"
 authors = ["Sean Young <sean@mess.org>", "Lucas Steuernagel <lucas.tnagel@gmail.com>", "Cyrill Leutwiler <bigcyrill@hotmail.com>"]
-homepage = "https://github.com/hyperledger/solang"
+repository = "https://github.com/hyperledger/solang"
 documentation = "https://solang.readthedocs.io/"
 license = "Apache-2.0"
 build = "build.rs"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.