### PR TITLE
macOS 11 runners are being removed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,10 +118,7 @@ jobs:
 
   mac-intel:
     name: Mac Intel
-    # The Hyperledger self-hosted intel macs have the label macos-latest
-    # and run macos 12. We don't want to build llvm on macos 12, because
-    # then it can't be used on macos 11.
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
     - name: Checkout sources
       uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -199,7 +199,7 @@ jobs:
 
   mac-intel:
     name: Mac Intel
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
     - name: Checkout sources
       uses: actions/checkout@v3
@@ -223,7 +223,7 @@ jobs:
 
   mac-universal:
     name: Mac Universal Binary
-    runs-on: macos-11
+    runs-on: macos-12
     needs: [mac-arm, mac-intel]
     steps:
     - uses: actions/download-artifact@v3


### PR DESCRIPTION
See:

https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/

We should try and build on the oldest supported platform, so that the binaries run on as many platforms as possible.

Cc: @ryjones 