### PR TITLE
Add print functionality to Soroban contracts

### DIFF
--- a/integration/soroban/.gitignore
+++ b/integration/soroban/.gitignore
@@ -6,3 +6,5 @@
 !package.json
 node_modules
 package-lock.json
+*.txt
+*.toml

--- a/integration/soroban/runtime_error.sol
+++ b/integration/soroban/runtime_error.sol
@@ -1,0 +1,9 @@
+contract Error {
+    uint64  count = 1;
+
+    /// @notice Calling this function twice will cause an overflow
+    function decrement() public returns (uint64){
+        count -= 1;
+        return count;
+    }
+}

--- a/integration/soroban/test_helpers.js
+++ b/integration/soroban/test_helpers.js
@@ -1,53 +1,64 @@
 import * as StellarSdk from '@stellar/stellar-sdk';
 
-
-
 export async function call_contract_function(method, server, keypair, contract) {
+    let res = null;
 
-    let res;
-    let builtTransaction = new StellarSdk.TransactionBuilder(await server.getAccount(keypair.publicKey()), {
-      fee: StellarSdk.BASE_FEE,
-      networkPassphrase: StellarSdk.Networks.TESTNET,
-    }).addOperation(contract.call(method)).setTimeout(30).build();
-  
-    let preparedTransaction = await server.prepareTransaction(builtTransaction);
-  
-    // Sign the transaction with the source account's keypair.
-    preparedTransaction.sign(keypair);
-  
     try {
-      let sendResponse = await server.sendTransaction(preparedTransaction);
-      if (sendResponse.status === "PENDING") {
-        let getResponse = await server.getTransaction(sendResponse.hash);
-        // Poll `getTransaction` until the status is not "NOT_FOUND"
-        while (getResponse.status === "NOT_FOUND") {
-          console.log("Waiting for transaction confirmation...");
-          // See if the transaction is complete
-          getResponse = await server.getTransaction(sendResponse.hash);
-          // Wait one second
-          await new Promise((resolve) => setTimeout(resolve, 1000));
-        }
-  
-        if (getResponse.status === "SUCCESS") {
-          // Make sure the transaction's resultMetaXDR is not empty
-          if (!getResponse.resultMetaXdr) {
-            throw "Empty resultMetaXDR in getTransaction response";
-          }
-          // Find the return value from the contract and return it
-          let transactionMeta = getResponse.resultMetaXdr;
-          let returnValue = transactionMeta.v3().sorobanMeta().returnValue();
-          console.log(`Transaction result: ${returnValue.value()}`);
-          res = returnValue.value();
+        let builtTransaction = new StellarSdk.TransactionBuilder(await server.getAccount(keypair.publicKey()), {
+            fee: StellarSdk.BASE_FEE,
+            networkPassphrase: StellarSdk.Networks.TESTNET,
+        }).addOperation(contract.call(method)).setTimeout(30).build();
+
+        let preparedTransaction = await server.prepareTransaction(builtTransaction);
+
+        // Sign the transaction with the source account's keypair.
+        preparedTransaction.sign(keypair);
+
+        let sendResponse = await server.sendTransaction(preparedTransaction);
+
+        if (sendResponse.status === "PENDING") {
+            let getResponse = await server.getTransaction(sendResponse.hash);
+            // Poll `getTransaction` until the status is not "NOT_FOUND"
+            while (getResponse.status === "NOT_FOUND") {
+                console.log("Waiting for transaction confirmation...");
+                // Wait one second
+                await new Promise((resolve) => setTimeout(resolve, 1000));
+                // See if the transaction is complete
+                getResponse = await server.getTransaction(sendResponse.hash);
+            }
+
+            if (getResponse.status === "SUCCESS") {
+                // Ensure the transaction's resultMetaXDR is not empty
+                if (!getResponse.resultMetaXdr) {
+                    throw "Empty resultMetaXDR in getTransaction response";
+                }
+                // Extract and return the return value from the contract
+                let transactionMeta = getResponse.resultMetaXdr;
+                let returnValue = transactionMeta.v3().sorobanMeta().returnValue();
+                console.log(`Transaction result: ${returnValue.value()}`);
+                res = returnValue.value();
+            } else {
+                throw `Transaction failed: ${getResponse.resultXdr}`;
+            }
+        } else if (sendResponse.status === "FAILED") {
+            // Handle expected failure and return the error message
+            if (sendResponse.errorResultXdr) {
+                const errorXdr = StellarSdk.xdr.TransactionResult.fromXDR(sendResponse.errorResultXdr, 'base64');
+                const errorRes = errorXdr.result().results()[0].tr().invokeHostFunctionResult().code().value;
+                console.log(`Transaction error: ${errorRes}`);
+                res = errorRes;
+            } else {
+                throw "Transaction failed but no errorResultXdr found";
+            }
         } else {
-          throw `Transaction failed: ${getResponse.resultXdr}`;
+            throw sendResponse.errorResultXdr;
         }
-      } else {
-        throw sendResponse.errorResultXdr;
-      }
     } catch (err) {
-      // Catch and report any errors we've thrown
-      console.log("Sending transaction failed");
-      console.log(err);
+        // Return the error as a string instead of failing the test
+        console.log("Transaction processing failed");
+        console.log(err);
+        res = err.toString();
     }
+
     return res;
 }

--- a/src/codegen/dispatch/soroban.rs
+++ b/src/codegen/dispatch/soroban.rs
@@ -102,35 +102,47 @@ pub fn function_dispatch(
 
         wrapper_cfg.add(&mut vartab, placeholder);
 
-        // set the msb 8 bits of the return value to 6, the return value is 64 bits.
-        // FIXME: this assumes that the solidity function always returns one value.
-        let shifted = Expression::ShiftLeft {
-            loc: pt::Loc::Codegen,
-            ty: Type::Uint(64),
-            left: value[0].clone().into(),
-            right: Expression::NumberLiteral {
+        // TODO: support multiple returns
+        if value.len() == 1 {
+            // set the msb 8 bits of the return value to 6, the return value is 64 bits.
+            // FIXME: this assumes that the solidity function always returns one value.
+            let shifted = Expression::ShiftLeft {
                 loc: pt::Loc::Codegen,
                 ty: Type::Uint(64),
-                value: BigInt::from(8_u64),
-            }
-            .into(),
-        };
+                left: value[0].clone().into(),
+                right: Expression::NumberLiteral {
+                    loc: pt::Loc::Codegen,
+                    ty: Type::Uint(64),
+                    value: BigInt::from(8_u64),
+                }
+                .into(),
+            };
 
-        let tag = Expression::NumberLiteral {
-            loc: pt::Loc::Codegen,
-            ty: Type::Uint(64),
-            value: BigInt::from(6_u64),
-        };
+            let tag = Expression::NumberLiteral {
+                loc: pt::Loc::Codegen,
+                ty: Type::Uint(64),
+                value: BigInt::from(6_u64),
+            };
 
-        let added = Expression::Add {
-            loc: pt::Loc::Codegen,
-            ty: Type::Uint(64),
-            overflowing: false,
-            left: shifted.into(),
-            right: tag.into(),
-        };
+            let added = Expression::Add {
+                loc: pt::Loc::Codegen,
+                ty: Type::Uint(64),
+                overflowing: false,
+                left: shifted.into(),
+                right: tag.into(),
+            };
 
-        wrapper_cfg.add(&mut vartab, Instr::Return { value: vec![added] });
+            wrapper_cfg.add(&mut vartab, Instr::Return { value: vec![added] });
+        } else {
+            // Return 2 as numberliteral. 2 is the soroban Void type encoded.
+            let two = Expression::NumberLiteral {
+                loc: pt::Loc::Codegen,
+                ty: Type::Uint(64),
+                value: BigInt::from(2_u64),
+            };
+
+            wrapper_cfg.add(&mut vartab, Instr::Return { value: vec![two] });
+        }
 
         vartab.finalize(ns, &mut wrapper_cfg);
         cfg.public = false;

--- a/src/codegen/expression.rs
+++ b/src/codegen/expression.rs
@@ -939,7 +939,23 @@ pub fn expression(
                     expr
                 };
 
-                cfg.add(vartab, Instr::Print { expr: to_print });
+                let res = if let Expression::AllocDynamicBytes {
+                    loc,
+                    ty,
+                    size: _,
+                    initializer: Some(initializer),
+                } = &to_print
+                {
+                    Expression::BytesLiteral {
+                        loc: *loc,
+                        ty: ty.clone(),
+                        value: initializer.to_vec(),
+                    }
+                } else {
+                    to_print
+                };
+
+                cfg.add(vartab, Instr::Print { expr: res });
             }
 
             Expression::Poison

--- a/src/emit/soroban/mod.rs
+++ b/src/emit/soroban/mod.rs
@@ -22,6 +22,7 @@ use std::sync;
 const SOROBAN_ENV_INTERFACE_VERSION: u64 = 90194313216;
 pub const PUT_CONTRACT_DATA: &str = "l._";
 pub const GET_CONTRACT_DATA: &str = "l.1";
+pub const LOG_FROM_LINEAR_MEMORY: &str = "x._";
 
 pub struct SorobanTarget;
 
@@ -231,12 +232,23 @@ impl SorobanTarget {
             .i64_type()
             .fn_type(&[ty.into(), ty.into()], false);
 
+        let log_function_ty = binary
+            .context
+            .i64_type()
+            .fn_type(&[ty.into(), ty.into(), ty.into(), ty.into()], false);
+
         binary
             .module
             .add_function(PUT_CONTRACT_DATA, function_ty_1, Some(Linkage::External));
         binary
             .module
             .add_function(GET_CONTRACT_DATA, function_ty, Some(Linkage::External));
+
+        binary.module.add_function(
+            LOG_FROM_LINEAR_MEMORY,
+            log_function_ty,
+            Some(Linkage::External),
+        );
     }
 
     fn emit_initializer(binary: &mut Binary, _ns: &ast::Namespace) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,12 +95,11 @@ impl Target {
 
     /// Size of a pointer in bits
     pub fn ptr_size(&self) -> u16 {
-        if *self == Target::Solana {
+        match *self {
             // Solana is BPF, which is 64 bit
-            64
-        } else {
+            Target::Solana => 64,
             // All others are WebAssembly in 32 bit mode
-            32
+            _ => 32,
         }
     }
 

--- a/src/linker/soroban_wasm.rs
+++ b/src/linker/soroban_wasm.rs
@@ -11,8 +11,7 @@ use wasm_encoder::{
 };
 use wasmparser::{Global, Import, Parser, Payload::*, SectionLimited, TypeRef};
 
-use crate::emit::soroban::GET_CONTRACT_DATA;
-use crate::emit::soroban::PUT_CONTRACT_DATA;
+use crate::emit::soroban::{GET_CONTRACT_DATA, LOG_FROM_LINEAR_MEMORY, PUT_CONTRACT_DATA};
 
 pub fn link(input: &[u8], name: &str) -> Vec<u8> {
     let dir = tempdir().expect("failed to create temp directory for linking");
@@ -82,7 +81,7 @@ fn generate_module(input: &[u8]) -> Vec<u8> {
     module.finish()
 }
 
-/// Resolve all pallet contracts runtime imports
+/// Resolve all soroban contracts runtime imports
 fn generate_import_section(section: SectionLimited<Import>, module: &mut Module) {
     let mut imports = ImportSection::new();
     for import in section.into_iter().map(|import| import.unwrap()) {
@@ -98,6 +97,7 @@ fn generate_import_section(section: SectionLimited<Import>, module: &mut Module)
         };
         let module_name = match import.name {
             GET_CONTRACT_DATA | PUT_CONTRACT_DATA => "l",
+            LOG_FROM_LINEAR_MEMORY => "x",
             _ => panic!("got func {:?}", import),
         };
         // parse the import name to all string after the the first dot

--- a/src/sema/namespace.rs
+++ b/src/sema/namespace.rs
@@ -41,7 +41,7 @@ impl Namespace {
                 value_length,
             } => (address_length, value_length),
             Target::Solana => (32, 8),
-            Target::Soroban => (32, 8),
+            Target::Soroban => (32, 64),
         };
 
         let mut ns = Namespace {

--- a/tests/soroban_testcases/mod.rs
+++ b/tests/soroban_testcases/mod.rs
@@ -1,3 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
 mod math;
+mod print;
 mod storage;

--- a/tests/soroban_testcases/print.rs
+++ b/tests/soroban_testcases/print.rs
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::build_solidity;
+use soroban_sdk::testutils::Logs;
+
+#[test]
+fn log_runtime_error() {
+    let src = build_solidity(
+        r#"contract counter {
+            uint64 public count = 1;
+        
+            function decrement() public returns (uint64){
+                count -= 1;
+                return count;
+            }
+        }"#,
+    );
+
+    let addr = src.contracts.last().unwrap();
+
+    let _res = src.invoke_contract(addr, "init", vec![]);
+
+    src.invoke_contract(addr, "decrement", vec![]);
+
+    let logs = src.invoke_contract_expect_error(addr, "decrement", vec![]);
+
+    assert!(logs[0].contains("runtime_error: math overflow in test.sol:5:17-27"));
+}
+
+#[test]
+fn print() {
+    let src = build_solidity(
+        r#"contract Printer {
+
+            function print() public {
+                print("Hello, World!");
+            }
+        }"#,
+    );
+
+    let addr = src.contracts.last().unwrap();
+
+    let _res = src.invoke_contract(addr, "init", vec![]);
+
+    src.invoke_contract(addr, "print", vec![]);
+
+    let logs = src.env.logs().all();
+
+    assert!(logs[0].contains("Hello, World!"));
+}
+
+#[test]
+fn print_then_runtime_error() {
+    let src = build_solidity(
+        r#"contract counter {
+            uint64 public count = 1;
+        
+            function decrement() public returns (uint64){
+                print("Second call will FAIL!");
+                count -= 1;
+                return count;
+            }
+        }"#,
+    );
+
+    let addr = src.contracts.last().unwrap();
+
+    let _res = src.invoke_contract(addr, "init", vec![]);
+
+    src.invoke_contract(addr, "decrement", vec![]);
+
+    let logs = src.invoke_contract_expect_error(addr, "decrement", vec![]);
+
+    assert!(logs[0].contains("Second call will FAIL!"));
+    assert!(logs[1].contains("Second call will FAIL!"));
+    assert!(logs[2].contains("runtime_error: math overflow in test.sol:6:17-27"));
+}


### PR DESCRIPTION
This PR adds static string print functionality to Soroban contracts. This serves the following:

1. `print()` statements
2. Logging runtime errors.

However, the following findings might be interesting:
In both Solana and Polkadot, the VM execution capacity can grasp a call to `vector_new` in the `stdlib`: https://github.com/hyperledger/solang/blob/06798cdeac6fd62ee98f5ae7da38f3af4933dc0f/stdlib/stdlib.c#L167

However, Soroban doesn't. That's why Soroban would need Solang to implement a more efficient way of printing dynamic strings. 
@leighmcculloch
